### PR TITLE
Codex/fix trash next image

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "land": "bash scripts/land-session.sh",
     "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
     "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
-    "tauri": "tauri",
+    "tauri": "bash scripts/tauri-local.sh",
     "test": "vitest run",
     "test:e2e": "bash tests/e2e/run-e2e.sh",
     "test:perf": "vitest run src/lib/view-utils.test.ts -t \"grid rendering performance budget\"",

--- a/scripts/tauri-local.sh
+++ b/scripts/tauri-local.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+default_key_path="$HOME/.tauri/cull-updater.key"
+keychain_service="cull-tauri-updater-key"
+
+if [ -z "${TAURI_SIGNING_PRIVATE_KEY:-}" ] && [ -z "${TAURI_SIGNING_PRIVATE_KEY_PATH:-}" ] && [ -f "$default_key_path" ]; then
+  export TAURI_SIGNING_PRIVATE_KEY="$(cat "$default_key_path")"
+fi
+
+if { [ -n "${TAURI_SIGNING_PRIVATE_KEY:-}" ] || [ -n "${TAURI_SIGNING_PRIVATE_KEY_PATH:-}" ]; } && [ -z "${TAURI_SIGNING_PRIVATE_KEY_PASSWORD+x}" ] && command -v security >/dev/null 2>&1; then
+  key_password="$(security find-generic-password -a "$USER" -s "$keychain_service" -w 2>/dev/null || true)"
+  if [ -n "$key_password" ]; then
+    export TAURI_SIGNING_PRIVATE_KEY_PASSWORD="$key_password"
+  fi
+fi
+
+exec tauri "$@"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -54,7 +54,7 @@
       "endpoints": [
         "https://github.com/glebis/cull/releases/latest/download/latest.json"
       ],
-      "pubkey": "RWQ/hN99EWx6S1S3ZjWWFVoH8AorsiSRIHFkv18E4aDwFm8/UHz1j4z6"
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDU0QjYwMDM3QTFCNzlEM0MKUldROG5iZWhOd0MyVklwY0ZFSC9QZmJyVDd0aXN1T1JnaHdRbVBJYTduQVh0Q2I5Y2JDZWcyVDYK"
     }
   },
   "bundle": {

--- a/src/lib/components/StatusBar.svelte
+++ b/src/lib/components/StatusBar.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
-    import { viewMode, totalCount, images, selectedCount, statusHint, gridPreset, GRID_PRESETS, activeCollection, collections, activeFolder, folders, activeSmartCollection, activeDetectedClass, imageLoadState, showDetectionBoxes, nsfwMode } from '$lib/stores';
+    import { viewMode, totalCount, images, selectedCount, statusHint, gridPreset, GRID_PRESETS, activeCollection, collections, activeFolder, folders, activeSmartCollection, activeDetectedClass, imageLoadState, showDetectionBoxes, nsfwMode, shortcutsOpen } from '$lib/stores';
     import { previewDisplayBlanked, previewDisplayFrozen, previewDisplayWebStreamStatus } from '$lib/preview-display-store';
     import { previewDisplayStatusLabel } from '$lib/preview-display';
+    import { openCommandPalette } from '$lib/command-palette';
     import { derived } from 'svelte/store';
 
     const displayCount = derived(
@@ -42,6 +43,14 @@
         [previewDisplayFrozen, previewDisplayBlanked],
         ([$frozen, $blanked]) => previewDisplayStatusLabel($frozen, $blanked)
     );
+
+    function openShortcuts() {
+        shortcutsOpen.set(true);
+    }
+
+    function openCommands() {
+        openCommandPalette('commands');
+    }
 </script>
 
 <div class="statusbar">
@@ -76,24 +85,17 @@
     </div>
     <div class="right">
         {#if $showDetectionBoxes}
-            <span class="hint active-hint">D:boxes</span>
-        {:else}
-            <span class="hint">D:boxes</span>
+            <span class="state-chip active-hint">D:boxes</span>
         {/if}
-        <span class="hint">B:nsfw:{$nsfwMode}</span>
-        <span class="hint">hjkl:nav</span>
-        <span class="hint">space:select</span>
-        <span class="hint">1-5:rate</span>
-        <span class="hint">0:clear</span>
-        <span class="hint">a:accept</span>
-        <span class="hint">x:reject</span>
-        <span class="hint">u:undecide</span>
-        <span class="hint">c:collect</span>
-        <span class="hint">b:batch</span>
-        <span class="hint">f:fullscreen</span>
-        <span class="hint">+/-:size</span>
-        <span class="hint">?:help</span>
-        <span class="hint">Cmd+P:commands</span>
+        <span class="state-chip">B:nsfw:{$nsfwMode}</span>
+        <button class="shortcut-button" type="button" onclick={openShortcuts} title="?:help" aria-label="Open keyboard shortcuts">
+            <kbd>?</kbd>
+            <span>Shortcuts</span>
+        </button>
+        <button class="shortcut-button" type="button" onclick={openCommands} title="Cmd+P:commands" aria-label="Open command palette">
+            <kbd>Cmd+P</kbd>
+            <span>Commands</span>
+        </button>
     </div>
 </div>
 
@@ -134,18 +136,48 @@
     }
     .right {
         display: flex;
-        gap: 12px;
+        align-items: center;
+        gap: 8px;
         overflow: hidden;
         flex: 0 1 auto;
         min-width: 0;
     }
-    .hint {
+    .state-chip,
+    .shortcut-button {
         color: var(--text-secondary);
         font-size: 10px;
         white-space: nowrap;
     }
+    .state-chip {
+        display: inline-flex;
+        align-items: center;
+        min-height: 18px;
+    }
+    .shortcut-button {
+        display: inline-flex;
+        align-items: center;
+        gap: 5px;
+        height: 22px;
+        padding: 0 6px;
+        border: 1px solid var(--border);
+        border-radius: var(--radius);
+        background: var(--surface);
+        font: inherit;
+        line-height: 1;
+        cursor: default;
+    }
+    .shortcut-button:hover,
+    .shortcut-button:focus-visible {
+        color: var(--text);
+        border-color: var(--blue);
+        outline: none;
+    }
+    .shortcut-button kbd {
+        color: var(--blue);
+        font: inherit;
+    }
     .active-hint {
-        color: var(--green, #9ece6a);
+        color: var(--green);
     }
     .preset {
         color: var(--text-secondary);

--- a/src/lib/image-removal.test.ts
+++ b/src/lib/image-removal.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { clampFocusIndexToList, nextFocusIndexAfterFocusedRemoval } from './image-removal';
+
+describe('nextFocusIndexAfterFocusedRemoval', () => {
+    it('keeps the removed index when there is a next image', () => {
+        expect(nextFocusIndexAfterFocusedRemoval(1, 4)).toBe(1);
+    });
+
+    it('wraps to the first image when the removed image was last', () => {
+        expect(nextFocusIndexAfterFocusedRemoval(3, 4)).toBe(0);
+    });
+
+    it('keeps focus at zero after removing the only image', () => {
+        expect(nextFocusIndexAfterFocusedRemoval(0, 1)).toBe(0);
+    });
+});
+
+describe('clampFocusIndexToList', () => {
+    it('preserves in-range focus', () => {
+        expect(clampFocusIndexToList(2, 5)).toBe(2);
+    });
+
+    it('falls back to first image when focus is outside the current list', () => {
+        expect(clampFocusIndexToList(5, 5)).toBe(0);
+    });
+});

--- a/src/lib/image-removal.ts
+++ b/src/lib/image-removal.ts
@@ -1,0 +1,16 @@
+export function nextFocusIndexAfterFocusedRemoval(
+    removedIndex: number,
+    originalLength: number,
+): number {
+    const remainingLength = Math.max(0, originalLength - 1);
+    if (remainingLength === 0) return 0;
+
+    const normalizedIndex = Math.max(0, removedIndex);
+    return normalizedIndex < remainingLength ? normalizedIndex : 0;
+}
+
+export function clampFocusIndexToList(index: number, length: number): number {
+    if (length <= 0) return 0;
+    if (index < 0) return 0;
+    return index < length ? index : 0;
+}

--- a/src/lib/keys-help-shortcut.test.ts
+++ b/src/lib/keys-help-shortcut.test.ts
@@ -95,11 +95,13 @@ describe("'?' opens the keyboard-shortcuts help (UX-07)", () => {
 describe('the palette and help are advertised (UX-07)', () => {
     const statusBar = readFileSync(join(process.cwd(), 'src/lib/components/StatusBar.svelte'), 'utf8');
 
-    it('status bar hint strip advertises ?:help', () => {
+    it('status bar shortcut control advertises ?:help', () => {
+        expect(statusBar).toContain('shortcutsOpen.set(true)');
         expect(statusBar).toContain('?:help');
     });
 
-    it('status bar hint strip advertises Cmd+P:commands', () => {
+    it('status bar command control advertises Cmd+P:commands', () => {
+        expect(statusBar).toContain("openCommandPalette('commands')");
         expect(statusBar).toContain('Cmd+P:commands');
     });
 });

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -33,7 +33,7 @@
     import GenerationResultsStrip from '$lib/components/GenerationResultsStrip.svelte';
     import PreviewDisplay from '$lib/components/PreviewDisplay.svelte';
     import { handleKeydown } from '$lib/keys';
-    import { totalCount, images, focusedIndex, focusedImage, viewMode, sidebarVisible, zenMode, minSizeFilter, showToast, settingsOpen, aboutOpen, agentSkillsOpen, searchOpen, showMissing, smartCollections, activeSmartCollection, activeFolder, activeCollection, activeDetectedClass, staticPublishingEnabled, clientToolsEnabled, voiceDictationEnabled, pluginsEnabled, selectedIds, activeCanvas, activeSession, collections, windowLabel } from '$lib/stores';
+    import { images, focusedIndex, focusedImage, viewMode, sidebarVisible, zenMode, minSizeFilter, showToast, settingsOpen, aboutOpen, agentSkillsOpen, searchOpen, showMissing, smartCollections, activeSmartCollection, activeFolder, activeCollection, activeDetectedClass, staticPublishingEnabled, clientToolsEnabled, voiceDictationEnabled, pluginsEnabled, selectedIds, activeCanvas, activeSession, collections, windowLabel } from '$lib/stores';
     import { trashImages, deleteImagesPermanently, getAppSetting, setAppSetting, checkLibraryHealth, regenerateThumbnailsByIds, listSmartCollections, updatePreviewState, captureAgentWindowSnapshot, completeAgentViewSnapshot, type ImageWithFile, type PreviewState } from '$lib/api';
     import { initDeepLink } from '$lib/deeplink';
     import { initMenu } from '$lib/menu';
@@ -57,7 +57,8 @@
         setPreviewDisplayOverlay,
     } from '$lib/preview-display-store';
     import { saveAppState, restoreAppStateBeforeImages, applyRestoredViewState, type PersistedState } from '$lib/persistence';
-    import { loadImagesForCurrentScope, type ImageLoadOptions } from '$lib/image-loading';
+    import { invalidateImageCache, loadImagesForCurrentScope, refreshImageCount, type ImageLoadOptions } from '$lib/image-loading';
+    import { clampFocusIndexToList, nextFocusIndexAfterFocusedRemoval } from '$lib/image-removal';
     import { buildAgentSnapshotManifest, collectVisibleImageTargets, drawAnnotatedSnapshot, type AgentSnapshotScope } from '$lib/agent-view-snapshot';
     import { listen } from '@tauri-apps/api/event';
     import { onMount } from 'svelte';
@@ -89,18 +90,29 @@
         activeDetectedClass.set(null);
     }
 
+    function removeVisibleImageById(imageId: string, plannedFocusIndex: number) {
+        let nextLength = 0;
+        images.update(list => {
+            const next = list.filter(item => item.image.id !== imageId);
+            nextLength = next.length;
+            return next;
+        });
+        focusedIndex.set(clampFocusIndexToList(plannedFocusIndex, nextLength));
+    }
+
     async function executeTrash() {
         const imgs = $images;
         const idx = $focusedIndex;
         const img = imgs[idx];
         if (!img) return;
+        const nextFocusIndex = nextFocusIndexAfterFocusedRemoval(idx, imgs.length);
         const count = await trashImages([img.image.id]);
         if (count > 0) {
             const name = img.path.split('/').pop() ?? '';
             showToast(`Moved to Trash`, { detail: name, type: 'info', duration: 5000 });
-            images.update(list => list.filter((_, i) => i !== idx));
-            focusedIndex.update(i => Math.min(i, $images.length - 1));
-            totalCount.update(c => c - 1);
+            invalidateImageCache();
+            removeVisibleImageById(img.image.id, nextFocusIndex);
+            refreshImageCount().catch(e => console.error('Failed to refresh image count after trash:', e));
         }
     }
 
@@ -140,9 +152,9 @@
         const count = await deleteImagesPermanently([img.image.id]);
         if (count > 0) {
             showToast(`Deleted permanently`, { detail: name, type: 'warning', duration: 5000 });
-            images.update(list => list.filter((_, i) => i !== idx));
-            focusedIndex.update(i => Math.min(i, $images.length - 1));
-            totalCount.update(c => c - 1);
+            invalidateImageCache();
+            removeVisibleImageById(img.image.id, nextFocusIndexAfterFocusedRemoval(idx, imgs.length));
+            refreshImageCount().catch(e => console.error('Failed to refresh image count after delete:', e));
         }
     }
 
@@ -387,7 +399,7 @@
 
         window.addEventListener('trash-focused-image', handleTrash);
         window.addEventListener('delete-focused-image', handlePermanentDelete);
-        const handleReloadImages = () => loadImages({ force: true, invalidateCache: true }).catch(e => console.error('Failed to reload:', e));
+        const handleReloadImages = () => loadImages({ resetFocus: false, force: true, invalidateCache: true }).catch(e => console.error('Failed to reload:', e));
         window.addEventListener('reload-images', handleReloadImages);
         const handleAgentSnapshotCommand = (event: Event) => {
             const detail = event instanceof CustomEvent ? event.detail : {};
@@ -397,7 +409,7 @@
         window.addEventListener('capture-agent-view-snapshot', handleAgentSnapshotCommand);
 
         const watcherUnlisten = listen<void>('images:changed', () => {
-            loadImages({ force: true, invalidateCache: true }).catch(e => console.error('Failed to reload after fs change:', e));
+            loadImages({ resetFocus: false, force: true, invalidateCache: true }).catch(e => console.error('Failed to reload after fs change:', e));
         });
 
         const agentSnapshotRequestUnlisten = listen<{

--- a/tests/e2e/smoke.py
+++ b/tests/e2e/smoke.py
@@ -890,9 +890,15 @@ def test_command_palette_arrows_and_favorite(page: Page) -> None:
 
 
 def test_keyboard_shortcuts_panel(page: Page) -> None:
-    """zu0.7/zu0.8 — palette opens the searchable keyboard-shortcuts panel."""
+    """zu0.7/zu0.8 — palette and status bar open the searchable keyboard-shortcuts panel."""
     press(page, "Meta+1")
     wait_mode(page, "grid")
+
+    page.locator('.statusbar .shortcut-button[title="?:help"]').click()
+    expect(page.locator(".shortcuts-panel")).to_be_visible()
+    expect(page.locator(".shortcuts-row").first).to_be_visible()
+    page.locator(".shortcuts-close").click()
+    expect(page.locator(".shortcuts-panel")).to_have_count(0)
 
     press(page, "Meta+K")
     expect(page.locator(".palette-panel")).to_be_visible()


### PR DESCRIPTION
## Summary

## Changes

## Test plan

- [ ] `npm run ci` passes
- [ ] Browser E2E classified: `npm run test:e2e` run when this PR touches UI navigation, keyboard/thumbnail navigation, command palette/search, drag/drop affordances, preview display/chrome, or Tauri mock/E2E harness behavior; otherwise marked not applicable per `docs/e2e-testing-policy.md`
- [ ] Tested in `cargo tauri dev`
- [ ] Docs updated, if behavior changed
- [ ] `docs/SYSTEM_MENU_AUDIT.md` updated, if native menu behavior changed
