### PR TITLE
site: taste-audit refinements to landing page

### DIFF
--- a/site/src/main.ts
+++ b/site/src/main.ts
@@ -22,7 +22,7 @@ document.querySelector<HTMLDivElement>("#app")!.innerHTML = `
             <span data-rotating-line-value="to">20 keepers</span>
           </button>
         </h1>
-        <p class="lede hero-step-3">Cull is a fast image review tool for people who shoot, generate, or produce at volume. Your files stay on your Mac. Work in the app, or drive the work through your agent via CLI or MCP.</p>
+        <p class="lede hero-step-3">A fast image review tool for people who shoot, generate, or produce at volume. Your files stay on your Mac.</p>
       </div>
       <figure class="product-shot hero-step-4">
         <img src="/images/cull-state-preview.png" alt="App state with batch counts, image decisions, prompt metadata, and agent queue" />
@@ -84,7 +84,6 @@ document.querySelector<HTMLDivElement>("#app")!.innerHTML = `
 
     <section class="workflow reveal-surface" aria-labelledby="workflow-title" data-reveal>
       <div class="reveal-item reveal-delay-0">
-        <p class="eyebrow">how it works</p>
         <h2 id="workflow-title">From folder to final set</h2>
       </div>
       <div class="workflow-list">
@@ -125,7 +124,6 @@ document.querySelector<HTMLDivElement>("#app")!.innerHTML = `
 
     <section class="bottom-signup reveal-surface" aria-labelledby="privacy-title" data-reveal>
       <div class="reveal-item reveal-delay-0">
-        <p class="eyebrow">early access</p>
         <h2 id="privacy-title">Be first when it ships</h2>
       </div>
       <div class="bottom-signup-copy reveal-item reveal-delay-2">

--- a/site/src/styles.css
+++ b/site/src/styles.css
@@ -44,7 +44,7 @@
 
 body {
   margin: 0;
-  min-height: 100vh;
+  min-height: 100dvh;
   background: var(--bg);
   color: var(--text);
   font-family: var(--font);
@@ -107,7 +107,7 @@ input {
   align-items: start;
   column-gap: calc(var(--spacing) * 7);
   row-gap: calc(var(--spacing) * 3);
-  min-height: calc(100vh - 72px);
+  min-height: calc(100dvh - 72px);
   padding-bottom: calc(var(--spacing) * 7);
   min-width: 0;
 }
@@ -184,9 +184,7 @@ h1 .rotating-line-control span {
 .rotating-line-control:hover:not(:disabled),
 .rotating-line-control:focus-visible {
   background: color-mix(in srgb, var(--rotating-line-color) 12%, transparent);
-  box-shadow:
-    0 0.12em 0 color-mix(in srgb, var(--rotating-line-color) 18%, transparent),
-    0 0 22px color-mix(in srgb, var(--rotating-line-color) 16%, transparent);
+  box-shadow: 0 0.12em 0 color-mix(in srgb, var(--rotating-line-color) 18%, transparent);
   color: var(--text);
   transform: translate3d(0, -1px, 0);
 }
@@ -235,7 +233,9 @@ h3 {
   border: 1px solid color-mix(in srgb, var(--blue) 62%, var(--field-border));
   border-radius: var(--radius);
   background: color-mix(in srgb, var(--surface) 64%, var(--blue) 36%);
-  box-shadow: 0 0 15px color-mix(in srgb, var(--blue) 18%, transparent);
+  box-shadow:
+    inset 0 1px 0 color-mix(in srgb, var(--blue) 22%, transparent),
+    0 8px 24px rgb(0 0 0 / 0.35);
 }
 
 .signup-form--featured::after {
@@ -653,10 +653,20 @@ input:focus-visible {
 
 .open-source-note {
   display: grid;
-  grid-template-columns: minmax(220px, 360px) minmax(0, 1fr);
+  grid-template-columns: minmax(0, 1fr) minmax(220px, 360px);
   align-items: center;
   gap: calc(var(--spacing) * 6);
   padding: calc(var(--spacing) * 8) 0;
+}
+
+.open-source-illustration {
+  grid-column: 2;
+  grid-row: 1;
+}
+
+.open-source-copy {
+  grid-column: 1;
+  grid-row: 1;
 }
 
 .open-source-illustration {
@@ -949,6 +959,31 @@ input:focus-visible {
   }
 }
 
+@media (min-width: 621px) and (max-width: 900px) {
+  .hero {
+    grid-template-columns: 1fr;
+    min-height: auto;
+    row-gap: calc(var(--spacing) * 4);
+    padding-bottom: calc(var(--spacing) * 5);
+  }
+
+  .hero-copy {
+    grid-column: 1;
+    grid-row: 1;
+  }
+
+  .product-shot {
+    grid-column: 1;
+    grid-row: 2;
+    max-width: 640px;
+  }
+
+  .hero > .signup-form {
+    grid-column: 1;
+    grid-row: 3;
+  }
+}
+
 @media (max-width: 620px) {
   .page-shell {
     width: calc(100% - 24px);
@@ -1057,6 +1092,13 @@ input:focus-visible {
 
   .open-source-illustration {
     width: 100%;
+    grid-column: 1;
+    grid-row: auto;
+  }
+
+  .open-source-copy {
+    grid-column: 1;
+    grid-row: auto;
   }
 
   .feature-note-illustration {


### PR DESCRIPTION
Anti-slop pass on the cull.company landing page, audited against the design-taste-frontend checklist and verified in-browser at 1280 / 760 / 390px.

## Changes
- **Hero lede** trimmed to 20 words so the hero fits the first impression
- **Eyebrows** dropped two generic ones ("how it works", "early access") — keeps the count within the 1-per-3-sections budget
- **`100dvh`** instead of `100vh` on body + hero (no iOS address-bar jump)
- **De-glowed** the featured signup form and rotating control — inner highlight + tinted drop shadow instead of a blue outer halo
- **Open-source section** flipped to illustration-right, breaking the third repeat of the illustration-left/copy-right layout family
- **Tablet breakpoint** (621–900px) stacks the hero so the 460px image column stops cramping the copy

## Verification
- `npm run build` (tsc + Vite) clean
- No horizontal overflow at 1280 / 760 / 390px
- `prefers-reduced-motion` path intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)