### PR TITLE
site: reshape claims into a 1+2 bento

### DIFF
--- a/site/src/main.ts
+++ b/site/src/main.ts
@@ -22,7 +22,7 @@ document.querySelector<HTMLDivElement>("#app")!.innerHTML = `
             <span data-rotating-line-value="to">20 keepers</span>
           </button>
         </h1>
-        <p class="lede hero-step-3">Cull is a fast image review tool for people who shoot, generate, or produce at volume. Your files stay on your Mac. Work in the app, or drive the work through your agent via CLI or MCP.</p>
+        <p class="lede hero-step-3">A fast image review tool for people who shoot, generate, or produce at volume. Your files stay on your Mac.</p>
       </div>
       <figure class="product-shot hero-step-4">
         <img src="/images/cull-state-preview.png" alt="App state with batch counts, image decisions, prompt metadata, and agent queue" />
@@ -84,7 +84,6 @@ document.querySelector<HTMLDivElement>("#app")!.innerHTML = `
 
     <section class="workflow reveal-surface" aria-labelledby="workflow-title" data-reveal>
       <div class="reveal-item reveal-delay-0">
-        <p class="eyebrow">how it works</p>
         <h2 id="workflow-title">From folder to final set</h2>
       </div>
       <div class="workflow-list">
@@ -125,7 +124,6 @@ document.querySelector<HTMLDivElement>("#app")!.innerHTML = `
 
     <section class="bottom-signup reveal-surface" aria-labelledby="privacy-title" data-reveal>
       <div class="reveal-item reveal-delay-0">
-        <p class="eyebrow">early access</p>
         <h2 id="privacy-title">Be first when it ships</h2>
       </div>
       <div class="bottom-signup-copy reveal-item reveal-delay-2">

--- a/site/src/styles.css
+++ b/site/src/styles.css
@@ -44,7 +44,7 @@
 
 body {
   margin: 0;
-  min-height: 100vh;
+  min-height: 100dvh;
   background: var(--bg);
   color: var(--text);
   font-family: var(--font);
@@ -107,7 +107,7 @@ input {
   align-items: start;
   column-gap: calc(var(--spacing) * 7);
   row-gap: calc(var(--spacing) * 3);
-  min-height: calc(100vh - 72px);
+  min-height: calc(100dvh - 72px);
   padding-bottom: calc(var(--spacing) * 7);
   min-width: 0;
 }
@@ -184,9 +184,7 @@ h1 .rotating-line-control span {
 .rotating-line-control:hover:not(:disabled),
 .rotating-line-control:focus-visible {
   background: color-mix(in srgb, var(--rotating-line-color) 12%, transparent);
-  box-shadow:
-    0 0.12em 0 color-mix(in srgb, var(--rotating-line-color) 18%, transparent),
-    0 0 22px color-mix(in srgb, var(--rotating-line-color) 16%, transparent);
+  box-shadow: 0 0.12em 0 color-mix(in srgb, var(--rotating-line-color) 18%, transparent);
   color: var(--text);
   transform: translate3d(0, -1px, 0);
 }
@@ -235,7 +233,9 @@ h3 {
   border: 1px solid color-mix(in srgb, var(--blue) 62%, var(--field-border));
   border-radius: var(--radius);
   background: color-mix(in srgb, var(--surface) 64%, var(--blue) 36%);
-  box-shadow: 0 0 15px color-mix(in srgb, var(--blue) 18%, transparent);
+  box-shadow:
+    inset 0 1px 0 color-mix(in srgb, var(--blue) 22%, transparent),
+    0 8px 24px rgb(0 0 0 / 0.35);
 }
 
 .signup-form--featured::after {
@@ -653,10 +653,20 @@ input:focus-visible {
 
 .open-source-note {
   display: grid;
-  grid-template-columns: minmax(220px, 360px) minmax(0, 1fr);
+  grid-template-columns: minmax(0, 1fr) minmax(220px, 360px);
   align-items: center;
   gap: calc(var(--spacing) * 6);
   padding: calc(var(--spacing) * 8) 0;
+}
+
+.open-source-illustration {
+  grid-column: 2;
+  grid-row: 1;
+}
+
+.open-source-copy {
+  grid-column: 1;
+  grid-row: 1;
 }
 
 .open-source-illustration {
@@ -949,6 +959,31 @@ input:focus-visible {
   }
 }
 
+@media (min-width: 621px) and (max-width: 900px) {
+  .hero {
+    grid-template-columns: 1fr;
+    min-height: auto;
+    row-gap: calc(var(--spacing) * 4);
+    padding-bottom: calc(var(--spacing) * 5);
+  }
+
+  .hero-copy {
+    grid-column: 1;
+    grid-row: 1;
+  }
+
+  .product-shot {
+    grid-column: 1;
+    grid-row: 2;
+    max-width: 640px;
+  }
+
+  .hero > .signup-form {
+    grid-column: 1;
+    grid-row: 3;
+  }
+}
+
 @media (max-width: 620px) {
   .page-shell {
     width: calc(100% - 24px);
@@ -1057,6 +1092,13 @@ input:focus-visible {
 
   .open-source-illustration {
     width: 100%;
+    grid-column: 1;
+    grid-row: auto;
+  }
+
+  .open-source-copy {
+    grid-column: 1;
+    grid-row: auto;
   }
 
   .feature-note-illustration {

--- a/site/src/styles.css
+++ b/site/src/styles.css
@@ -502,8 +502,8 @@ input:focus-visible {
 
 .claims {
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: calc(var(--spacing) * 6);
+  grid-template-columns: minmax(0, 1.1fr) minmax(0, 1fr);
+  gap: calc(var(--spacing) * 5) calc(var(--spacing) * 7);
   padding: calc(var(--spacing) * 8) 0;
 }
 
@@ -512,6 +512,36 @@ input:focus-visible {
   align-content: start;
   gap: calc(var(--spacing) * 1.5);
   min-width: 0;
+}
+
+/* Feature the local-first claim as a tall tile on the left */
+.claim:first-child {
+  grid-column: 1;
+  grid-row: 1 / span 2;
+}
+
+.claim:first-child .claim-illustration {
+  width: 100%;
+  max-width: 460px;
+  aspect-ratio: 4 / 3;
+  margin-bottom: calc(var(--spacing) * 2);
+}
+
+/* Stack the other two as compact horizontal rows on the right */
+.claim:nth-child(2),
+.claim:nth-child(3) {
+  grid-column: 2;
+  grid-template-columns: 88px minmax(0, 1fr);
+  align-content: center;
+  gap: calc(var(--spacing) * 0.5) calc(var(--spacing) * 2.5);
+}
+
+.claim:nth-child(2) .claim-illustration,
+.claim:nth-child(3) .claim-illustration {
+  grid-column: 1;
+  grid-row: 1 / span 2;
+  width: 88px;
+  margin: 0;
 }
 
 .claim-illustration {
@@ -1059,8 +1089,22 @@ input:focus-visible {
     padding: calc(var(--spacing) * 5) 0;
   }
 
-  .claim-illustration {
+  .claim:first-child,
+  .claim:nth-child(2),
+  .claim:nth-child(3) {
+    grid-column: 1;
+    grid-row: auto;
+    grid-template-columns: 1fr;
+  }
+
+  .claim:first-child .claim-illustration,
+  .claim:nth-child(2) .claim-illustration,
+  .claim:nth-child(3) .claim-illustration {
+    grid-column: auto;
+    grid-row: auto;
     width: 100%;
+    max-width: none;
+    aspect-ratio: 1;
   }
 
   .workflow,


### PR DESCRIPTION
Follow-up to #30 (the audit item I'd flagged as a judgment call).

Replaces the three-equal claim cards with an asymmetric **1+2 bento**:
- The local-first claim ("Your library, your machine" — the page's lead differentiator, also its meta description) becomes a tall feature tile on the left.
- The other two claims stack as compact icon+text rows on the right, vertically balanced against the feature (centers land at 23% / 77% of the feature height).

This breaks the banned three-identical-cards pattern with genuine hierarchy rather than an arbitrary stagger, and reads distinctly from the workflow grid directly below it. Collapses to three full-width stacked cards under 620px.

## Verification
- Browser-checked at 1280 / 390px: balanced right pair, no horizontal overflow, mobile reset clean
- `npm run build` (tsc + Vite) clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)