### PR TITLE
site: add Vercel Web Analytics

### DIFF
--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -8,6 +8,7 @@
       "name": "@cull/site",
       "version": "0.1.0",
       "dependencies": {
+        "@vercel/analytics": "^2.0.1",
         "@vercel/blob": "^2.0.0",
         "resend": "^6.6.0"
       },
@@ -904,6 +905,48 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/@vercel/analytics": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-2.0.1.tgz",
+      "integrity": "sha512-MTQG6V9qQrt1tsDeF+2Uoo5aPjqbVPys1xvnIftXSJYG2SrwXRHnqEvVoYID7BTruDz4lCd2Z7rM1BdkUehk2g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@remix-run/react": "^2",
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "nuxt": ">= 3",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@remix-run/react": {
+          "optional": true
+        },
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "nuxt": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
       }
     },
     "node_modules/@vercel/blob": {

--- a/site/package.json
+++ b/site/package.json
@@ -11,6 +11,7 @@
     "check": "tsc --noEmit"
   },
   "dependencies": {
+    "@vercel/analytics": "^2.0.1",
     "@vercel/blob": "^2.0.0",
     "resend": "^6.6.0"
   },

--- a/site/src/main.ts
+++ b/site/src/main.ts
@@ -146,7 +146,10 @@ document.querySelector<HTMLDivElement>("#app")!.innerHTML = `
     </figure>
 
     <footer class="site-footer">
-      <p>Made in 🇪🇺 Berlin by <a href="https://www.linkedin.com/in/glebkalinin/">Gleb Kalinin</a></p>
+      <div class="site-footer-meta">
+        <p>Made in 🇪🇺 Berlin by <a href="https://www.linkedin.com/in/glebkalinin/">Gleb Kalinin</a></p>
+        <p class="footer-fineprint">No cookies, no cross-site tracking.</p>
+      </div>
       <nav aria-label="Footer links">
         <a href="https://github.com/glebis/cull">Repository</a>
         <a href="https://github.com/glebis">Gleb's Github</a>

--- a/site/src/main.ts
+++ b/site/src/main.ts
@@ -1,4 +1,7 @@
 import "./styles.css";
+import { inject } from "@vercel/analytics";
+
+inject();
 
 document.querySelector<HTMLDivElement>("#app")!.innerHTML = `
   <div class="page-shell">

--- a/site/src/styles.css
+++ b/site/src/styles.css
@@ -792,6 +792,16 @@ input:focus-visible {
   margin: 0;
 }
 
+.site-footer-meta {
+  display: grid;
+  gap: calc(var(--spacing) * 0.5);
+}
+
+.footer-fineprint {
+  color: color-mix(in srgb, var(--text-secondary) 78%, transparent);
+  font-size: 12px;
+}
+
 .site-footer nav {
   display: flex;
   flex-wrap: wrap;


### PR DESCRIPTION
Adds cookieless page analytics to the landing page.

Chose **Vercel Web Analytics** over Google Analytics because the site is privacy-first and EU-based ("Made in Berlin", local-first, no-lists/no-noise). Vercel Web Analytics is cookieless and GDPR-friendly, so it needs **no consent banner** — GA4 would have required a prior-consent cookie gate under GDPR.

## Changes
- `@vercel/analytics` dependency
- `inject()` on load in `src/main.ts`

## Activation required
Data only flows once **Web Analytics is enabled** for the project in the Vercel dashboard (Project → Analytics → enable). The code alone doesn't start collection.

## Verification
- `npm run build` clean
- Insights beacon script injected, `window.va` installed, no console errors (the script 404s on localhost by design — Vercel serves it only in production)

🤖 Generated with [Claude Code](https://claude.com/claude-code)