### PR TITLE
Bump Rust toolchain and CI tauri-action; prepare Dependabot batch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
           cache: npm
 
       - name: Install pinned Rust
-        uses: dtolnay/rust-toolchain@1.89.0
+        uses: dtolnay/rust-toolchain@1.95.0
         with:
           components: rustfmt, clippy
 
@@ -47,7 +47,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install pinned Rust
-        uses: dtolnay/rust-toolchain@1.89.0
+        uses: dtolnay/rust-toolchain@1.95.0
 
       - name: Install cargo-deny and cargo-audit
         uses: taiki-e/install-action@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
           cache: npm
 
       - name: Install pinned Rust
-        uses: dtolnay/rust-toolchain@1.89.0
+        uses: dtolnay/rust-toolchain@1.95.0
         with:
           components: rustfmt, clippy
           targets: ${{ matrix.target }}
@@ -79,7 +79,7 @@ jobs:
           test -n "$CERT_ID"
           echo "APPLE_SIGNING_IDENTITY=$CERT_ID" >> "$GITHUB_ENV"
 
-      - uses: tauri-apps/tauri-action@v0
+      - uses: tauri-apps/tauri-action@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           APPLE_ID: ${{ secrets.APPLE_ID }}

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.89.0"
+channel = "1.95.0"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
### Motivation
- Bring CI and local toolchain up to a recent stable Rust to match current ecosystem needs and enable later dependency bumps. 
- Upgrade the release workflow's `tauri-apps/tauri-action` to its v1 entrypoint for compatibility with newer Tauri releases. 
- Prepare a safe Dependabot batch: apply only low-risk workflow/tooling changes now and surface higher-risk crate/npm upgrades for follow-up after network/registry access and full lockfile regeneration.

### Description
- Updated `rust-toolchain.toml` to set the `channel` from `1.89.0` to `1.95.0` and preserved `components = ["rustfmt", "clippy"]`.
- Updated `.github/workflows/ci.yml` and `.github/workflows/release.yml` to use `dtolnay/rust-toolchain@1.95.0` instead of `@1.89.0`.
- Updated the release workflow to use `tauri-apps/tauri-action@v1` instead of `@v0`.
- Attempted higher-risk dependency bumps (`notify` -> `8.2.0`, `rusqlite` -> `0.40.1`, and frontend packages like `@sveltejs/kit`, `@tauri-apps/api`, `vite`), but network access to crates.io/npm was blocked so lockfile/package-lock changes were not made.

### Testing
- Ran `npm run check`, which completed successfully with Svelte diagnostics returning no errors. 
- Ran `npm test` (`vitest`), which completed successfully: test files 133 passed and 969 tests passed. 
- Ran `cargo +1.95.0 fmt --manifest-path src-tauri/Cargo.toml --all -- --check`, which completed successfully. 
- Attempted `cargo +1.95.0 test --manifest-path src-tauri/Cargo.toml --lib`, which could not complete due to the environment missing the system library `glib-2.0` required by `glib-sys` (native package missing), and attempts to update crates were blocked by HTTP 403 errors to the crates.io index, so lockfile regeneration was not performed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a50b0081b88832b8a339808463a347d)