### PR TITLE
Fix PDF preview and loading regressions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,43 @@ jobs:
       - name: Rust checks
         run: bash scripts/check-ci.sh rust
 
+  packaged-interaction-smoke:
+    name: Packaged production interaction smoke
+    runs-on: macos-14
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: .node-version
+          cache: npm
+
+      - name: Install pinned Rust
+        uses: dtolnay/rust-toolchain@1.95.0
+
+      - name: Cache packaged app build
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri -> target
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run packaged production interaction smoke
+        env:
+          CULL_NATIVE_SMOKE_SHOTS: ${{ runner.temp }}/cull-native-interaction-smoke
+        run: bash tests/native/run-packaged-interaction-smoke.sh
+
+      - name: Upload packaged smoke artifacts
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: packaged-interaction-smoke-${{ github.run_id }}
+          path: ${{ runner.temp }}/cull-native-interaction-smoke
+          if-no-files-found: warn
+          retention-days: 14
+
   site:
     name: Site checks
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ node_modules/
 /package
 
 # Vite
+/.vite-cache/
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
 

--- a/docs/e2e-testing-policy.md
+++ b/docs/e2e-testing-policy.md
@@ -3,13 +3,39 @@
 Cull has one browser E2E smoke suite, run by `npm run test:e2e` / `bash tests/e2e/run-e2e.sh`.
 The runner starts Vite with `CULL_E2E_MOCK=1` and executes `tests/e2e/smoke.py` against the browser-only Tauri mock.
 
-## Classification
+## Packaged production interaction gate
 
-**Current classification: pre-push manual gate plus machine-classified release CI.**
+Every pull request and push to `main` runs a separate macOS gate against a
+packaged `Cull.app` and its production WKWebView. It does not use Vite,
+Playwright, or `tauri-mock.ts` at runtime. The gate seeds two images into a
+dedicated smoke database and verifies pointer hit-testing plus observable UI
+outcomes for a folder click, Recent Imports, the sidebar filter, image
+selection, double-click Loupe navigation, and the image context menu.
+
+```bash
+bash tests/native/run-packaged-interaction-smoke.sh
+```
+
+The GitHub `CI` job is named `Packaged production interaction smoke`. A failed
+assertion exits non-zero, fails the workflow before merge, and uploads the app
+log, result manifest, and PNG failure capture from the smoke artifact directory. Its bundle
+identifier is `com.glebkalinin.cull.interaction-smoke`, so it cannot open or
+mutate the user's `com.glebkalinin.cull` database.
+
+Vite's optimized dependencies use checkout-local, build-variant directories
+under `.vite-cache`, not `node_modules/.vite`. This prevents a shared dependency
+directory from hydrating one worktree with paths pre-bundled in another
+worktree, and prevents a running dev server from sharing optimized modules with
+the native-smoke build.
+
+## Browser smoke classification
+
+**Current browser-suite classification: pre-push manual gate plus machine-classified release CI.**
 
 Run the browser E2E smoke suite before pushing a branch or opening a PR when the
 change touches one of the required file areas below. The ordinary `CI` workflow
-does not run it. The signed canary and production release workflows classify the
+does not run the browser/mock suite; it runs the packaged production gate above.
+The signed canary and production release workflows classify the
 exact changed paths with `release.config.json`; when a covered path matches, the
 release gate runs the browser suite on the GitHub macOS runner and records the
 classification and result in immutable gate evidence.

--- a/scripts/release-gate.test.ts
+++ b/scripts/release-gate.test.ts
@@ -409,8 +409,8 @@ describe('release gate', () => {
     expect(workflow).toContain('permissions:\n  contents: read');
     expect(workflow).toContain('group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}');
     expect(workflow).toContain('cancel-in-progress: true');
-    expect(workflow.match(/uses: Swatinem\/rust-cache@/g)).toHaveLength(2);
-    expect(workflow.match(/workspaces: src-tauri -> target/g)).toHaveLength(2);
+    expect(workflow.match(/uses: Swatinem\/rust-cache@/g)).toHaveLength(3);
+    expect(workflow.match(/workspaces: src-tauri -> target/g)).toHaveLength(3);
     expect(workflow).toMatch(/\n  site:\n[\s\S]*?working-directory: site[\s\S]*?npm ci[\s\S]*?npm run check[\s\S]*?npm test[\s\S]*?npm run build/);
 
     const ciScript = readFileSync(resolve(import.meta.dirname, 'check-ci.sh'), 'utf8');

--- a/src-tauri/src/commands/library.rs
+++ b/src-tauri/src/commands/library.rs
@@ -389,7 +389,9 @@ pub async fn check_library_health(
                 missing_sources += 1;
             } else {
                 let thumb = crate::db_core::thumbnails::thumbnail_path(app_data_dir, &img.image.id);
-                if !thumb.exists() {
+                let legacy_pdf_placeholder = img.image.format.eq_ignore_ascii_case("pdf")
+                    && crate::db_core::thumbnails::is_legacy_document_placeholder(&thumb);
+                if !thumb.exists() || legacy_pdf_placeholder {
                     to_regenerate.push(img.image.id.clone());
                 }
             }

--- a/src-tauri/src/db_core/db.rs
+++ b/src-tauri/src/db_core/db.rs
@@ -756,6 +756,17 @@ impl Database {
             |row| row.get(0),
         )?;
 
+        let recent_imports_filter =
+            r#"{"type":"rule","field":"imported_at","op":"last_n_days","value":7.0}"#;
+        conn.execute(
+            "UPDATE projects
+             SET name = 'Recent Imports'
+             WHERE is_preset = 1
+               AND filter_json = ?1
+               AND name != 'Recent Imports'",
+            params![recent_imports_filter],
+        )?;
+
         if existing > 0 {
             return Ok(());
         }
@@ -786,11 +797,7 @@ impl Database {
                 r#"{"type":"group","op":"and","children":[{"type":"rule","field":"rating","op":"eq","value":0.0},{"type":"rule","field":"decision","op":"eq","value":"undecided"}]}"#,
                 5,
             ),
-            (
-                "Recent Imports",
-                r#"{"type":"rule","field":"imported_at","op":"last_n_days","value":7.0}"#,
-                6,
-            ),
+            ("Recent Imports", recent_imports_filter, 6),
             (
                 "Imported Today",
                 r#"{"type":"rule","field":"imported_at","op":"last_n_days","value":1.0}"#,
@@ -1583,6 +1590,34 @@ mod tests {
             last_seen_mtime: None,
         };
         db.insert_image_file(&file).unwrap();
+    }
+
+    #[test]
+    fn preset_seeding_repairs_the_recent_imports_name_without_reseeding() {
+        let db = test_db();
+        let recent_imports_filter =
+            r#"{"type":"rule","field":"imported_at","op":"last_n_days","value":7.0}"#;
+        {
+            let conn = db.conn.lock();
+            conn.execute(
+                "UPDATE projects SET name = 'Recent' WHERE is_preset = 1 AND filter_json = ?1",
+                params![recent_imports_filter],
+            )
+            .unwrap();
+        }
+
+        db.seed_preset_collections().unwrap();
+
+        let repaired_name: String = db
+            .conn
+            .lock()
+            .query_row(
+                "SELECT name FROM projects WHERE is_preset = 1 AND filter_json = ?1",
+                params![recent_imports_filter],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(repaired_name, "Recent Imports");
     }
 
     #[test]

--- a/src-tauri/src/db_core/image_decode.rs
+++ b/src-tauri/src/db_core/image_decode.rs
@@ -1,5 +1,8 @@
 use std::path::Path;
 
+#[cfg(target_os = "macos")]
+const PLATFORM_DECODE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+
 #[derive(Debug)]
 pub struct DecodedImage {
     pub image: image::DynamicImage,
@@ -54,34 +57,82 @@ fn decode_with_platform(path: &Path, ext: &str) -> Result<image::DynamicImage, S
         return Err(format!("No platform decoder configured for .{} files", ext));
     }
 
+    decode_with_sips(path, None)
+}
+
+#[cfg(target_os = "macos")]
+pub(crate) fn decode_pdf_preview_with_platform(
+    path: &Path,
+    max_dimension: u32,
+) -> Result<image::DynamicImage, String> {
+    decode_with_sips(path, Some(max_dimension))
+}
+
+#[cfg(target_os = "macos")]
+fn decode_with_sips(
+    path: &Path,
+    max_dimension: Option<u32>,
+) -> Result<image::DynamicImage, String> {
+    use std::process::Stdio;
+
     let temp = tempfile::Builder::new()
         .prefix("cull-decode-")
         .suffix(".png")
         .tempfile()
         .map_err(|e| format!("Failed to create decode temp file: {}", e))?;
 
-    let output = std::process::Command::new("/usr/bin/sips")
-        .arg("-s")
-        .arg("format")
-        .arg("png")
+    let mut command = std::process::Command::new("/usr/bin/sips");
+    command.arg("-s").arg("format").arg("png");
+    if let Some(max_dimension) = max_dimension {
+        command
+            .arg("--resampleHeightWidthMax")
+            .arg(max_dimension.to_string());
+    }
+    let mut child = command
         .arg(path)
         .arg("--out")
         .arg(temp.path())
-        .output()
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
         .map_err(|e| format!("Failed to run macOS ImageIO decoder: {}", e))?;
 
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        let stdout = String::from_utf8_lossy(&output.stdout);
-        let detail = if stderr.trim().is_empty() {
-            stdout.trim()
-        } else {
-            stderr.trim()
-        };
-        return Err(format!("sips exited with {}: {}", output.status, detail));
+    let status = wait_for_child_with_timeout(&mut child, PLATFORM_DECODE_TIMEOUT)?;
+    if !status.success() {
+        return Err(format!("sips exited with {}", status));
     }
 
     image::open(temp.path()).map_err(|e| format!("sips produced unreadable PNG: {}", e))
+}
+
+#[cfg(target_os = "macos")]
+fn wait_for_child_with_timeout(
+    child: &mut std::process::Child,
+    timeout: std::time::Duration,
+) -> Result<std::process::ExitStatus, String> {
+    let started = std::time::Instant::now();
+    loop {
+        match child.try_wait() {
+            Ok(Some(status)) => return Ok(status),
+            Ok(None) if started.elapsed() < timeout => {
+                std::thread::sleep(std::time::Duration::from_millis(10));
+            }
+            Ok(None) => {
+                let _ = child.kill();
+                let _ = child.wait();
+                return Err(format!(
+                    "macOS ImageIO decoder timed out after {} seconds",
+                    timeout.as_secs_f32()
+                ));
+            }
+            Err(error) => {
+                return Err(format!(
+                    "Failed waiting for macOS ImageIO decoder: {}",
+                    error
+                ))
+            }
+        }
+    }
 }
 
 #[cfg(not(target_os = "macos"))]
@@ -122,5 +173,35 @@ mod tests {
         assert_eq!(decoded.image.width(), 64);
         assert_eq!(decoded.image.height(), 48);
         assert!(decoded.raw_metadata.is_none());
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn decodes_a_real_pdf_first_page_with_the_bounded_macos_fallback() {
+        let path =
+            Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/pdf/sample_two_page.pdf");
+
+        let preview = decode_pdf_preview_with_platform(&path, 1200).unwrap();
+
+        assert!(preview.width() > 0);
+        assert!(preview.height() > preview.width());
+        assert!(preview.width().max(preview.height()) <= 1200);
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn platform_decoder_terminates_a_child_that_exceeds_its_deadline() {
+        let mut child = std::process::Command::new("/bin/sleep")
+            .arg("5")
+            .spawn()
+            .unwrap();
+        let started = std::time::Instant::now();
+
+        let result = wait_for_child_with_timeout(&mut child, std::time::Duration::from_millis(25));
+
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("timed out"));
+        assert!(started.elapsed() < std::time::Duration::from_secs(1));
+        assert!(child.try_wait().unwrap().is_some());
     }
 }

--- a/src-tauri/src/db_core/import.rs
+++ b/src-tauri/src/db_core/import.rs
@@ -153,6 +153,10 @@ pub fn sync_file(
             run_sidecar_detection(db, file_path, &image_id);
             run_perceptual_hash(db, file_path, &image_id, decoded.as_ref().map(|d| &d.image));
             run_color_metrics(db, file_path, &image_id, decoded.as_ref().map(|d| &d.image));
+        } else if is_document {
+            validate_pdf_import(file_path)?;
+            let _ = thumbnails::generate_document_thumbnail(file_path, app_data_dir, &image_id);
+            persist_pdf_media_metadata(db, file_path, &image_id)?;
         }
         return Ok(SyncOutcome::ContentChanged { image_id });
     }
@@ -580,6 +584,34 @@ mod tests {
         let image_id = import_file(&db, &pdf_path, &app_data_dir).unwrap().unwrap();
 
         assert!(crate::db_core::thumbnails::thumbnail_path(&app_data_dir, &image_id).exists());
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn changed_pdf_content_generates_a_preview_for_the_replacement_image() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = Database::open(&dir.path().join("test.db")).unwrap();
+        let app_data_dir = dir.path().join("app-data");
+        let pdf_path = dir.path().join("changing.pdf");
+        let fixture =
+            Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/pdf/sample_two_page.pdf");
+        std::fs::copy(&fixture, &pdf_path).unwrap();
+
+        let original_id = import_file(&db, &pdf_path, &app_data_dir).unwrap().unwrap();
+        let mut changed = std::fs::read(&fixture).unwrap();
+        changed.extend_from_slice(b"\n% changed content\n");
+        std::fs::write(&pdf_path, changed).unwrap();
+
+        let outcome = sync_file(&db, &pdf_path, &app_data_dir).unwrap();
+        let replacement_id = match outcome {
+            SyncOutcome::ContentChanged { image_id } => image_id,
+            other => panic!("expected changed PDF content, got {other:?}"),
+        };
+
+        assert_ne!(replacement_id, original_id);
+        assert!(
+            crate::db_core::thumbnails::thumbnail_path(&app_data_dir, &replacement_id).exists()
+        );
     }
 
     #[test]

--- a/src-tauri/src/db_core/thumbnails.rs
+++ b/src-tauri/src/db_core/thumbnails.rs
@@ -99,13 +99,49 @@ pub fn generate_document_thumbnail(
     image_id: &str,
 ) -> Result<PathBuf, String> {
     let thumb_path = thumbnail_path(app_data_dir, image_id);
-    if thumb_path.exists() {
+    if thumb_path.exists() && !is_legacy_document_placeholder(&thumb_path) {
         return Ok(thumb_path);
     }
 
     let preview = render_pdf_first_page_thumbnail(source_path)
         .unwrap_or_else(|_| placeholder_document_thumbnail());
     generate_thumbnail_from_image(&preview, app_data_dir, image_id)
+}
+
+/// The first PDF implementation wrote the same dark diagonal placeholder for
+/// every document when the unbundled PDFium library was unavailable. Detect
+/// that generated image by its pixels so existing libraries can repair it once
+/// without regenerating legitimate PDF previews on every launch.
+pub fn is_legacy_document_placeholder(path: &Path) -> bool {
+    let Ok(existing) = image::open(path) else {
+        return false;
+    };
+    if existing.width() != existing.height() {
+        return false;
+    }
+
+    let expected = placeholder_document_thumbnail();
+    let sample_size = 64;
+    let existing = existing
+        .resize_exact(sample_size, sample_size, FilterType::Triangle)
+        .to_rgb8();
+    let expected = expected
+        .resize_exact(sample_size, sample_size, FilterType::Triangle)
+        .to_rgb8();
+    let total_difference: u64 = existing
+        .pixels()
+        .zip(expected.pixels())
+        .flat_map(|(actual, expected)| {
+            actual
+                .0
+                .into_iter()
+                .zip(expected.0)
+                .map(|(actual, expected)| actual.abs_diff(expected) as u64)
+        })
+        .sum();
+    let channel_count = (sample_size * sample_size * 3) as u64;
+
+    total_difference / channel_count <= 3
 }
 
 pub fn read_pdf_page_count(source_path: &Path) -> Result<u32, String> {
@@ -173,6 +209,18 @@ pub fn read_pdf_page_metrics(
 }
 
 fn render_pdf_first_page_thumbnail(source_path: &Path) -> Result<DynamicImage, String> {
+    #[cfg(target_os = "macos")]
+    {
+        // Cull is a macOS app. ImageIO (via sips) is available in packaged
+        // builds, unlike the optional PDFium dylib, and the decoder enforces a
+        // hard child-process deadline so a bad document cannot hang the app.
+        return crate::db_core::image_decode::decode_pdf_preview_with_platform(
+            source_path,
+            DOCUMENT_PREVIEW_DIMENSION,
+        );
+    }
+
+    #[cfg(not(target_os = "macos"))]
     with_open_pdf(source_path, |document| {
         let page = document
             .pages()
@@ -354,5 +402,22 @@ mod tests {
         let page_two = texts[1].1.as_deref().unwrap_or("");
         assert!(page_one.contains("page one"), "page 0 text: {:?}", page_one);
         assert!(page_two.contains("page two"), "page 1 text: {:?}", page_two);
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn legacy_document_placeholder_is_detected_and_replaced_by_a_real_preview() {
+        let dir = tempfile::tempdir().unwrap();
+        let image_id = "legacy-pdf";
+        let placeholder = placeholder_document_thumbnail();
+        generate_thumbnail_from_image(&placeholder, dir.path(), image_id).unwrap();
+        let path = thumbnail_path(dir.path(), image_id);
+
+        assert!(is_legacy_document_placeholder(&path));
+
+        generate_document_thumbnail(&fixture_pdf(), dir.path(), image_id).unwrap();
+        let preview = image::open(&path).unwrap();
+        assert!(preview.height() > preview.width());
+        assert!(!is_legacy_document_placeholder(&path));
     }
 }

--- a/src/lib/ci-contract.test.ts
+++ b/src/lib/ci-contract.test.ts
@@ -4,6 +4,16 @@ import { describe, expect, it } from 'vitest';
 const read = (path: string) => readFileSync(path, 'utf8');
 
 describe('CI quality gate contract', () => {
+  it('blocks ordinary merge CI on the packaged macOS interaction smoke and retains failure artifacts', () => {
+    const ciWorkflow = read('.github/workflows/ci.yml');
+
+    expect(ciWorkflow).toContain('packaged-interaction-smoke:');
+    expect(ciWorkflow).toContain('bash tests/native/run-packaged-interaction-smoke.sh');
+    expect(ciWorkflow).toContain('CULL_NATIVE_SMOKE_SHOTS: ${{ runner.temp }}/cull-native-interaction-smoke');
+    expect(ciWorkflow).toContain('if: always()');
+    expect(ciWorkflow).toContain('name: packaged-interaction-smoke-${{ github.run_id }}');
+  });
+
   it('runs the production frontend build in every frontend CI tier', () => {
     const checkCi = read('scripts/check-ci.sh');
     const ciWorkflow = read('.github/workflows/ci.yml');
@@ -23,6 +33,15 @@ describe('CI quality gate contract', () => {
 
     expect(viteConfig).toContain('configDefaults.exclude');
     expect(viteConfig).toContain('"**/.worktrees/**"');
+  });
+
+  it('keeps optimized Vite dependencies local to each worktree', () => {
+    const viteConfig = read('vite.config.js');
+    const gitignore = read('.gitignore');
+
+    expect(viteConfig).toContain('const viteCacheVariant = nativeInteractionSmoke');
+    expect(viteConfig).toContain('cacheDir: `.vite-cache/${viteCacheVariant}`');
+    expect(gitignore).toContain('/.vite-cache/');
   });
 
   it('keeps the independently installed site package out of root Vitest discovery', () => {

--- a/src/lib/components/Loupe.svelte
+++ b/src/lib/components/Loupe.svelte
@@ -61,7 +61,9 @@
     let mediaAsset = $state<MediaAsset | null>(null);
     let pdfPages = $state<PdfPage[]>([]);
     let pdfPageIndex = $state(0);
-    let pdfLookupSeq = $state(0);
+    // Request identity must not be reactive: the PDF effect increments it.
+    // A rune here makes the effect depend on its own write and loop forever.
+    let pdfLookupSeq = 0;
     let isPdf = $derived(image?.image.format.toLowerCase() === 'pdf');
     let filename = $derived(image?.path.split('/').pop() ?? '');
     let dimensions = $derived(image ? `${image.image.width}x${image.image.height}` : '');
@@ -391,7 +393,7 @@
         const imageId = current?.image.id;
 
         if (!current || !isPdf) {
-            pdfLookupSeq = 0;
+            pdfLookupSeq += 1;
             mediaAsset = null;
             pdfPages = [];
             pdfPageIndex = 0;

--- a/src/lib/components/Loupe.svelte
+++ b/src/lib/components/Loupe.svelte
@@ -1078,8 +1078,6 @@
                 </div>
             {/if}
         </div>
-    {:else}
-        <div class="empty">No image selected</div>
     {/if}
 
     {#if cropMode}
@@ -1191,6 +1189,7 @@
 
     {#if !hideOverlays}
     <div class="overlay-bar">
+        {#if image}
         <span class="filename">{filename}</span>
         <span class="sep">|</span>
         <span class="dim">{infoDimensions}</span>
@@ -1231,6 +1230,9 @@
             <span class="decision" class:accept={decision === 'accept'} class:reject={decision === 'reject'}>
                 {decision}
             </span>
+        {/if}
+        {:else}
+            <span class="empty-status">No image selected</span>
         {/if}
         <span class="sep">|</span>
         <button
@@ -1432,9 +1434,8 @@
         font-size: 14px;
         text-align: center;
     }
-    .empty {
+    .empty-status {
         color: var(--text-secondary);
-        font-size: 14px;
     }
     .overlay-bar {
         position: relative;
@@ -1445,6 +1446,7 @@
         align-items: center;
         gap: 8px;
         min-height: 32px;
+        margin-top: auto;
         padding: 0 12px;
         background: var(--bg);
         font-size: 11px;

--- a/src/lib/components/Thumbnail.svelte
+++ b/src/lib/components/Thumbnail.svelte
@@ -59,13 +59,16 @@
     let imgError = $state(false);
     let regenerating = $state(false);
     let pdfPageCount = $state<number | null>(null);
-    let pageLookupSeq = $state(0);
+    // Request identity is deliberately non-reactive. Making this a rune causes
+    // the effect below to subscribe to its own increment and rerun forever.
+    let pageLookupSeq = 0;
     const isPdf = $derived(item.image.format.toLowerCase() === 'pdf');
 
     $effect(() => {
         const imageId = item.image.id;
 
         if (!isPdf) {
+            pageLookupSeq += 1;
             pdfPageCount = null;
             return;
         }

--- a/src/lib/components/init-error-state.test.ts
+++ b/src/lib/components/init-error-state.test.ts
@@ -84,6 +84,24 @@ describe('backend init failure produces a distinct error state', () => {
         expect(resolveLibraryViewState(stateInput())).toBe('empty');
     });
 
+    it('a backend request that never settles cannot leave the library loading forever', async () => {
+        vi.useFakeTimers();
+        try {
+            vi.mocked(listImages).mockReturnValue(new Promise(() => {}));
+
+            void loadImagesForCurrentScope({ force: true });
+            await vi.advanceTimersByTimeAsync(15_000);
+
+            const state = get(imageLoadState);
+            expect(state.loading).toBe(false);
+            expect(state.error).toContain('timed out');
+            expect(resolveLibraryViewState(stateInput())).toBe('error');
+        } finally {
+            vi.useRealTimers();
+            resetImagePaging();
+        }
+    });
+
     it('never reports empty before the first query settles', () => {
         expect(
             resolveLibraryViewState({ loading: true, error: null, loaded: false, imageCount: 0 }),

--- a/src/lib/components/pdf-preview-regression.behavior.test.ts
+++ b/src/lib/components/pdf-preview-regression.behavior.test.ts
@@ -1,0 +1,122 @@
+// @vitest-environment jsdom
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import '@testing-library/jest-dom/vitest';
+import { cleanup, render, screen, waitFor } from '@testing-library/svelte';
+
+const mediaAsset = {
+    id: 'ma_pdf-1',
+    media_type: 'pdf',
+    primary_image_id: 'pdf-1',
+    sha256_hash: 'hash',
+    format: 'pdf',
+    file_size: 4096,
+    page_count: 2,
+    title: 'Test PDF',
+    created_at: '2026-08-06T20:00:00Z',
+    imported_at: '2026-08-06T20:00:00Z',
+};
+
+const pdfPages = [0, 1].map(page_index => ({
+    id: `page-${page_index}`,
+    media_asset_id: mediaAsset.id,
+    page_index,
+    width_points: 612,
+    height_points: 792,
+    thumbnail_path: null,
+    preview_path: null,
+    extracted_text: null,
+    text_extracted_at: null,
+}));
+
+const pdfImage = {
+    image: {
+        id: 'pdf-1',
+        sha256_hash: 'hash',
+        width: 1200,
+        height: 1200,
+        format: 'pdf',
+        file_size: 4096,
+        created_at: '2026-08-06T20:00:00Z',
+        imported_at: '2026-08-06T20:00:00Z',
+        ai_prompt: null,
+        raw_metadata: null,
+    },
+    path: '/Users/test/document.pdf',
+    thumbnail_path: '/Users/test/Library/Application Support/com.glebkalinin.cull/thumbnails/pdf-1.jpg',
+    selection: null,
+    source_label: null,
+    missing_at: null,
+};
+
+const api = vi.hoisted(() => ({
+    getMediaAssetForImage: vi.fn(),
+    listPdfPages: vi.fn(),
+}));
+
+vi.mock('@tauri-apps/api/core', () => ({
+    convertFileSrc: (path: string) => `asset://${path}`,
+}));
+
+vi.mock('$lib/api', () => ({
+    cropImage: vi.fn(),
+    getDetections: vi.fn().mockResolvedValue([]),
+    getGenerationRun: vi.fn().mockResolvedValue(null),
+    getImageFileBytes: vi.fn(),
+    getImageHistogram: vi.fn(),
+    getImagesByIds: vi.fn().mockResolvedValue([]),
+    getMediaAssetForImage: api.getMediaAssetForImage,
+    getVisionMetadata: vi.fn().mockResolvedValue([]),
+    isRawFormat: (format: string) => format.toLowerCase() === 'pdf',
+    listPdfPages: api.listPdfPages,
+    regenerateSingleThumbnail: vi.fn(),
+}));
+
+import Loupe from './Loupe.svelte';
+import Thumbnail from './Thumbnail.svelte';
+import { focusedIndex, images } from '$lib/stores';
+
+beforeAll(() => {
+    vi.stubGlobal('ResizeObserver', class {
+        observe() {}
+        disconnect() {}
+    });
+});
+
+afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+    images.set([]);
+    focusedIndex.set(0);
+});
+
+describe('PDF preview metadata requests', () => {
+    it('loads a mounted PDF thumbnail page count once and renders its badge', async () => {
+        api.getMediaAssetForImage.mockResolvedValue(mediaAsset);
+
+        render(Thumbnail, {
+            item: pdfImage,
+            size: 160,
+            focused: true,
+            selected: false,
+            onclick: vi.fn(),
+            ondblclick: vi.fn(),
+        });
+
+        expect(await screen.findByText('PDF · 2p')).toBeVisible();
+        await new Promise(resolve => setTimeout(resolve, 20));
+        expect(api.getMediaAssetForImage).toHaveBeenCalledOnce();
+    });
+
+    it('loads focused PDF metadata once and allows the page label to settle', async () => {
+        api.getMediaAssetForImage.mockResolvedValue(mediaAsset);
+        api.listPdfPages.mockResolvedValue(pdfPages);
+        images.set([pdfImage]);
+        focusedIndex.set(0);
+
+        render(Loupe);
+
+        expect(await screen.findByText('Page 1/2')).toBeVisible();
+        await waitFor(() => expect(api.listPdfPages).toHaveBeenCalledOnce());
+        expect(api.getMediaAssetForImage).toHaveBeenCalledOnce();
+    });
+});

--- a/src/lib/image-loading.ts
+++ b/src/lib/image-loading.ts
@@ -26,6 +26,7 @@ import { formatLibraryLoadError } from './library-view-state';
 
 export const IMAGE_PAGE_SIZE = 200;
 const MAX_SCOPE_CACHE_ENTRIES = 5;
+const LIBRARY_LOAD_TIMEOUT_MS = 15_000;
 
 export interface ImageLoadOptions {
     resetFocus?: boolean;
@@ -53,6 +54,21 @@ interface CachedScopeState {
     hasMore: boolean;
     focusedIndex: number;
     scrollTop: number;
+}
+
+async function withLibraryLoadTimeout<T>(operation: Promise<T>): Promise<T> {
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const timeout = new Promise<never>((_, reject) => {
+        timer = setTimeout(() => {
+            reject(new Error('Library load timed out after 15 seconds'));
+        }, LIBRARY_LOAD_TIMEOUT_MS);
+    });
+
+    try {
+        return await Promise.race([operation, timeout]);
+    } finally {
+        if (timer !== undefined) clearTimeout(timer);
+    }
 }
 
 let activeScopeKey = '';
@@ -246,7 +262,7 @@ export async function loadImagesForCurrentScope(options: ImageLoadOptions = {}) 
         let lastRawCount = 0;
 
         do {
-            const page = await fetchPage(scope, offset, IMAGE_PAGE_SIZE);
+            const page = await withLibraryLoadTimeout(fetchPage(scope, offset, IMAGE_PAGE_SIZE));
             if (seq !== requestSeq || key !== activeScopeKey) return;
 
             lastRawCount = page.rawCount;
@@ -292,7 +308,7 @@ export async function loadMoreImagesForCurrentScope() {
     setLoadState();
 
     try {
-        const page = await fetchPage(scope, offset, IMAGE_PAGE_SIZE);
+        const page = await withLibraryLoadTimeout(fetchPage(scope, offset, IMAGE_PAGE_SIZE));
         if (seq !== requestSeq || key !== activeScopeKey) return;
 
         nextOffset += IMAGE_PAGE_SIZE;

--- a/src/lib/native-interaction-smoke.test.ts
+++ b/src/lib/native-interaction-smoke.test.ts
@@ -1,0 +1,159 @@
+// @vitest-environment jsdom
+
+import { describe, expect, it } from 'vitest';
+
+type SmokeModule = typeof import('./native-interaction-smoke');
+
+async function loadSmokeModule(): Promise<Partial<SmokeModule>> {
+    return import('./native-interaction-smoke').catch(() => ({}));
+}
+
+function installInteractiveFixture() {
+    document.body.innerHTML = `
+        <div class="folder-tree">
+            <div class="folder-row"><button class="section-item"><span class="folder-label">Smoke Alpha</span></button></div>
+            <div class="folder-row"><button class="section-item"><span class="folder-label">Smoke Beta</span></button></div>
+        </div>
+        <button class="section-item recent"><span class="item-label">Recent Imports</span></button>
+        <div class="grid-container">
+            <div class="thumb" aria-selected="false"></div>
+            <div class="thumb" aria-selected="false"></div>
+        </div>
+        <input class="sidebar-filter-input" />
+    `;
+
+    const folderButtons = [...document.querySelectorAll<HTMLButtonElement>('.folder-row .section-item')];
+    for (const button of folderButtons) {
+        button.addEventListener('click', () => button.setAttribute('aria-current', 'true'));
+    }
+
+    document.querySelector<HTMLButtonElement>('.recent')!.addEventListener('click', (event) => {
+        (event.currentTarget as HTMLButtonElement).setAttribute('aria-current', 'true');
+    });
+
+    const input = document.querySelector<HTMLInputElement>('.sidebar-filter-input')!;
+    input.addEventListener('input', () => {
+        for (const row of document.querySelectorAll<HTMLElement>('.folder-row')) {
+            row.hidden = !row.textContent!.toLowerCase().includes(input.value.toLowerCase());
+        }
+    });
+
+    const thumb = document.querySelector<HTMLElement>('.thumb')!;
+    thumb.addEventListener('click', () => thumb.setAttribute('aria-selected', 'true'));
+    thumb.addEventListener('contextmenu', (event) => {
+        event.preventDefault();
+        const menu = document.createElement('div');
+        menu.className = 'context-menu';
+        menu.setAttribute('role', 'menu');
+        document.body.append(menu);
+    });
+    window.addEventListener('keydown', (event) => {
+        if (event.key === 'Escape') document.querySelector('.context-menu')?.remove();
+    }, { once: true });
+    thumb.addEventListener('dblclick', () => {
+        document.querySelector('.grid-container')?.remove();
+        const loupe = document.createElement('div');
+        loupe.className = 'loupe-container';
+        document.body.append(loupe);
+    });
+}
+
+describe('packaged native interaction smoke', () => {
+    it('drives click, Recent Imports, filter, context menu, and double-click through observable UI outcomes', async () => {
+        installInteractiveFixture();
+        const smokeModule = await loadSmokeModule();
+        const finishCodes: number[] = [];
+        const screenshots: string[] = [];
+        const recordedResults: unknown[] = [];
+
+        expect(smokeModule.runNativeInteractionSmoke).toBeTypeOf('function');
+        const result = await smokeModule.runNativeInteractionSmoke!({
+            root: document,
+            timeoutMs: 500,
+            finish: async (code) => { finishCodes.push(code); },
+            captureFailure: async (message) => { screenshots.push(message); },
+            recordResult: async (result) => { recordedResults.push(result); },
+            log: () => {},
+            hitTest: target => target,
+        });
+
+        expect(result).toEqual({ ok: true, completed: [
+            'folder-click',
+            'recent-imports-click',
+            'sidebar-filter',
+            'image-click-selection',
+            'image-context-menu',
+            'image-double-click-loupe',
+        ] });
+        expect(finishCodes).toEqual([0]);
+        expect(screenshots).toEqual([]);
+        expect(recordedResults).toEqual([{ ok: true, completed: [
+            'folder-click',
+            'recent-imports-click',
+            'sidebar-filter',
+            'image-click-selection',
+            'image-context-menu',
+            'image-double-click-loupe',
+        ] }]);
+    });
+
+    it('captures a failure artifact and exits non-zero when the event root does not react', async () => {
+        installInteractiveFixture();
+        const smokeModule = await loadSmokeModule();
+        const folderButtons = document.querySelectorAll<HTMLButtonElement>('.folder-row .section-item');
+        const folderButton = folderButtons[folderButtons.length - 1]!;
+        folderButton.replaceWith(folderButton.cloneNode(true));
+        const finishCodes: number[] = [];
+        const screenshots: string[] = [];
+        const recordedResults: unknown[] = [];
+
+        expect(smokeModule.runNativeInteractionSmoke).toBeTypeOf('function');
+        const result = await smokeModule.runNativeInteractionSmoke!({
+            root: document,
+            timeoutMs: 25,
+            finish: async (code) => { finishCodes.push(code); },
+            captureFailure: async (message) => { screenshots.push(message); },
+            recordResult: async (result) => { recordedResults.push(result); },
+            log: () => {},
+            hitTest: target => target,
+        });
+
+        expect(result.ok).toBe(false);
+        expect(result.completed).toEqual([]);
+        expect(result.error).toContain('folder click did not activate');
+        expect(finishCodes).toEqual([1]);
+        expect(screenshots).toHaveLength(1);
+        expect(recordedResults).toEqual([expect.objectContaining({
+            ok: false,
+            error: expect.stringContaining('folder click did not activate'),
+        })]);
+    });
+
+    it('fails before dispatch when an overlay owns the pointer hit target', async () => {
+        installInteractiveFixture();
+        const smokeModule = await loadSmokeModule();
+        const overlay = document.createElement('div');
+        overlay.className = 'blocking-overlay';
+        document.body.append(overlay);
+        const finishCodes: number[] = [];
+        const screenshots: string[] = [];
+        const recordedResults: unknown[] = [];
+
+        expect(smokeModule.runNativeInteractionSmoke).toBeTypeOf('function');
+        const result = await smokeModule.runNativeInteractionSmoke!({
+            root: document,
+            timeoutMs: 25,
+            finish: async (code) => { finishCodes.push(code); },
+            captureFailure: async (message) => { screenshots.push(message); },
+            recordResult: async (result) => { recordedResults.push(result); },
+            log: () => {},
+            hitTest: () => overlay,
+        });
+
+        expect(result.ok).toBe(false);
+        expect(result.error).toContain('blocked by div.blocking-overlay');
+        expect(finishCodes).toEqual([1]);
+        expect(screenshots).toEqual([expect.stringContaining('blocked by div.blocking-overlay')]);
+        expect(recordedResults).toEqual([expect.objectContaining({ ok: false })]);
+    });
+});

--- a/src/lib/native-interaction-smoke.ts
+++ b/src/lib/native-interaction-smoke.ts
@@ -1,0 +1,307 @@
+export interface NativeInteractionSmokeResult {
+    ok: boolean;
+    completed: string[];
+    error?: string;
+}
+
+export interface NativeInteractionSmokeOptions {
+    root?: Document;
+    timeoutMs?: number;
+    finish?: (code: number) => Promise<void>;
+    captureFailure?: (message: string) => Promise<void>;
+    recordResult?: (result: NativeInteractionSmokeResult) => Promise<void>;
+    log?: (message: string) => void;
+    hitTest?: (target: Element, x: number, y: number) => Element | null;
+}
+
+const DEFAULT_TIMEOUT_MS = 15_000;
+
+function visibleFolderRows(root: Document): HTMLElement[] {
+    return [...root.querySelectorAll<HTMLElement>('.folder-tree .folder-row')]
+        .filter(row => !row.hidden && row.getAttribute('aria-hidden') !== 'true');
+}
+
+function requireElement<T extends Element>(root: ParentNode, selector: string, description: string): T {
+    const element = root.querySelector<T>(selector);
+    if (!element) throw new Error(`${description} is missing`);
+    return element;
+}
+
+function recentImportsButton(root: Document): HTMLButtonElement {
+    const button = [...root.querySelectorAll<HTMLButtonElement>('button.section-item')]
+        .find(candidate => candidate.querySelector('.item-label')?.textContent?.trim() === 'Recent Imports');
+    if (!button) throw new Error('Recent Imports button is missing');
+    return button;
+}
+
+function describeElement(element: Element | null): string {
+    if (!element) return '<none>';
+    const id = element.id ? `#${element.id}` : '';
+    const classes = [...element.classList].map(value => `.${value}`).join('');
+    return `${element.tagName.toLowerCase()}${id}${classes}`;
+}
+
+function dispatchMouse(root: Document, target: Element, type: string, init: MouseEventInit = {}) {
+    const windowRef = root.defaultView;
+    const EventCtor = type.startsWith('pointer') && windowRef?.PointerEvent
+        ? windowRef.PointerEvent
+        : (windowRef?.MouseEvent ?? MouseEvent);
+    target.dispatchEvent(new EventCtor(type, { bubbles: true, cancelable: true, ...init }));
+}
+
+function dispatchPointerAction(
+    root: Document,
+    target: Element,
+    action: 'click' | 'dblclick' | 'contextmenu',
+    hitTest: NativeInteractionSmokeOptions['hitTest'],
+    init: MouseEventInit = {},
+) {
+    const rect = target.getBoundingClientRect();
+    const x = rect.left + rect.width / 2;
+    const y = rect.top + rect.height / 2;
+    const hit = hitTest
+        ? hitTest(target, x, y)
+        : root.elementFromPoint(x, y);
+    if (!hit || (hit !== target && !target.contains(hit))) {
+        throw new Error(
+            `${action} hit-test for ${describeElement(target)} was blocked by ${describeElement(hit)}`,
+        );
+    }
+
+    const button = action === 'contextmenu' ? 2 : 0;
+    const buttons = action === 'contextmenu' ? 2 : 1;
+    const base = { clientX: x, clientY: y, button, buttons, ...init };
+    dispatchMouse(root, hit, 'pointerdown', base);
+    dispatchMouse(root, hit, 'pointerup', { ...base, buttons: 0 });
+    if (action === 'click') {
+        dispatchMouse(root, hit, 'click', { ...base, buttons: 0 });
+    } else if (action === 'dblclick') {
+        dispatchMouse(root, hit, 'click', { ...base, buttons: 0, detail: 1 });
+        dispatchMouse(root, hit, 'click', { ...base, buttons: 0, detail: 2 });
+        dispatchMouse(root, hit, 'dblclick', { ...base, buttons: 0, detail: 2 });
+    } else {
+        dispatchMouse(root, hit, 'contextmenu', base);
+    }
+}
+
+function setBoundInput(root: Document, input: HTMLInputElement, value: string) {
+    const InputCtor = root.defaultView?.HTMLInputElement ?? HTMLInputElement;
+    const setter = Object.getOwnPropertyDescriptor(InputCtor.prototype, 'value')?.set;
+    if (!setter) throw new Error('native input value setter is unavailable');
+    setter.call(input, value);
+    const EventCtor = root.defaultView?.Event ?? Event;
+    input.dispatchEvent(new EventCtor('input', { bubbles: true, cancelable: true }));
+}
+
+function dispatchEscape(root: Document) {
+    const KeyboardEventCtor = root.defaultView?.KeyboardEvent ?? KeyboardEvent;
+    (root.defaultView ?? window).dispatchEvent(new KeyboardEventCtor('keydown', {
+        key: 'Escape',
+        code: 'Escape',
+        bubbles: true,
+        cancelable: true,
+    }));
+}
+
+async function waitFor(
+    predicate: () => boolean,
+    failure: string,
+    timeoutMs: number,
+): Promise<void> {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() <= deadline) {
+        if (predicate()) return;
+        await new Promise(resolve => setTimeout(resolve, 20));
+    }
+    throw new Error(failure);
+}
+
+async function defaultCaptureFailure(message: string): Promise<void> {
+    const [{ captureAgentWindowSnapshot, completeAgentViewSnapshot }, { toPng }] = await Promise.all([
+        import('$lib/api'),
+        import('html-to-image'),
+    ]);
+    const snapshotId = `native_interaction_smoke_failure_${Date.now()}`;
+    let rawPng: string;
+    try {
+        rawPng = await captureAgentWindowSnapshot();
+    } catch (nativeCaptureError) {
+        console.error('[native-interaction-smoke] native capture failed; using DOM capture', nativeCaptureError);
+        rawPng = await toPng(document.documentElement, {
+            cacheBust: true,
+            pixelRatio: 1,
+            skipFonts: true,
+        });
+    }
+
+    await completeAgentViewSnapshot({
+        snapshot_id: snapshotId,
+        manifest: {
+            schema_version: 1,
+            snapshot_id: snapshotId,
+            created_at: new Date().toISOString(),
+            capture_reason: 'native-interaction-smoke-failure',
+            error: message,
+        },
+        raw_png_base64: rawPng,
+        annotated_png_base64: rawPng,
+        clipboard: false,
+    });
+}
+
+async function defaultFinish(code: number): Promise<void> {
+    const { exit } = await import('@tauri-apps/plugin-process');
+    await exit(code);
+}
+
+const ONE_PIXEL_PNG_BASE64 = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=';
+
+async function defaultRecordResult(result: NativeInteractionSmokeResult): Promise<void> {
+    const { completeAgentViewSnapshot } = await import('$lib/api');
+    await completeAgentViewSnapshot({
+        snapshot_id: 'native_interaction_smoke_result',
+        manifest: {
+            schema_version: 1,
+            capture_reason: 'native-interaction-smoke-result',
+            smoke_result: result,
+        },
+        raw_png_base64: ONE_PIXEL_PNG_BASE64,
+        annotated_png_base64: ONE_PIXEL_PNG_BASE64,
+        clipboard: false,
+    });
+}
+
+export async function runNativeInteractionSmoke(
+    options: NativeInteractionSmokeOptions = {},
+): Promise<NativeInteractionSmokeResult> {
+    const root = options.root ?? document;
+    const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+    const finish = options.finish ?? defaultFinish;
+    const captureFailure = options.captureFailure ?? defaultCaptureFailure;
+    const recordResult = options.recordResult ?? defaultRecordResult;
+    const log = options.log ?? console.log;
+    const hitTest = options.hitTest;
+    const completed: string[] = [];
+
+    try {
+        await waitFor(
+            () => visibleFolderRows(root).length >= 1 && root.querySelectorAll('.thumb').length >= 2,
+            'seeded folder and images did not render',
+            timeoutMs,
+        );
+        if (visibleFolderRows(root).length < 2) {
+            const expandButton = requireElement<HTMLButtonElement>(
+                visibleFolderRows(root)[0],
+                '.twisty',
+                'seeded folder expand button',
+            );
+            dispatchPointerAction(root, expandButton, 'click', hitTest);
+            await waitFor(
+                () => visibleFolderRows(root).length >= 2,
+                'seeded folder tree did not expand',
+                timeoutMs,
+            );
+        }
+
+        const folderButton = requireElement<HTMLButtonElement>(
+            visibleFolderRows(root).at(-1)!,
+            '.section-item',
+            'folder button',
+        );
+        dispatchPointerAction(root, folderButton, 'click', hitTest);
+        await waitFor(
+            () => folderButton.getAttribute('aria-current') === 'true' && root.querySelectorAll('.thumb').length >= 1,
+            'folder click did not activate the folder',
+            timeoutMs,
+        );
+        completed.push('folder-click');
+
+        const recentButton = recentImportsButton(root);
+        dispatchPointerAction(root, recentButton, 'click', hitTest);
+        await waitFor(
+            () => recentButton.getAttribute('aria-current') === 'true' && root.querySelectorAll('.thumb').length >= 2,
+            'Recent Imports click did not activate the smart collection',
+            timeoutMs,
+        );
+        completed.push('recent-imports-click');
+
+        const filterInput = requireElement<HTMLInputElement>(
+            root,
+            '.sidebar-filter-input',
+            'sidebar filter',
+        );
+        const foldersBeforeFilter = visibleFolderRows(root);
+        const filterValue = foldersBeforeFilter.at(-1)?.querySelector('.folder-label')?.textContent?.trim();
+        if (!filterValue) throw new Error('seeded folder label is empty');
+        setBoundInput(root, filterInput, filterValue);
+        await waitFor(
+            () => {
+                const rows = visibleFolderRows(root);
+                return rows.length > 0 && rows.length < foldersBeforeFilter.length;
+            },
+            'sidebar filter input did not change visible folder results',
+            timeoutMs,
+        );
+        setBoundInput(root, filterInput, '');
+        await waitFor(
+            () => visibleFolderRows(root).length === foldersBeforeFilter.length,
+            'clearing sidebar filter did not restore folder results',
+            timeoutMs,
+        );
+        completed.push('sidebar-filter');
+
+        const thumb = requireElement<HTMLElement>(root, '.thumb', 'image thumbnail');
+        const selectionBefore = thumb.getAttribute('aria-selected');
+        dispatchPointerAction(root, thumb, 'click', hitTest, { metaKey: true });
+        await waitFor(
+            () => thumb.getAttribute('aria-selected') !== selectionBefore,
+            'image click did not change selection',
+            timeoutMs,
+        );
+        completed.push('image-click-selection');
+
+        dispatchPointerAction(root, thumb, 'contextmenu', hitTest);
+        await waitFor(
+            () => root.querySelector('.context-menu, [role="menu"]') !== null,
+            'image context menu did not appear',
+            timeoutMs,
+        );
+        completed.push('image-context-menu');
+        dispatchEscape(root);
+        await waitFor(
+            () => root.querySelector('.context-menu, [role="menu"]') === null,
+            'image context menu did not close with Escape',
+            timeoutMs,
+        );
+
+        dispatchPointerAction(root, thumb, 'dblclick', hitTest);
+        await waitFor(
+            () => root.querySelector('.loupe-container') !== null,
+            'image double-click did not open Loupe',
+            timeoutMs,
+        );
+        completed.push('image-double-click-loupe');
+
+        log(`[native-interaction-smoke] PASS ${completed.join(', ')}`);
+        const result = { ok: true, completed } satisfies NativeInteractionSmokeResult;
+        await recordResult(result);
+        await finish(0);
+        return result;
+    } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        log(`[native-interaction-smoke] FAIL ${message}`);
+        try {
+            await captureFailure(message);
+        } catch (captureError) {
+            log(`[native-interaction-smoke] failure capture also failed: ${String(captureError)}`);
+        }
+        const result = { ok: false, completed, error: message } satisfies NativeInteractionSmokeResult;
+        try {
+            await recordResult(result);
+        } catch (recordError) {
+            log(`[native-interaction-smoke] result recording also failed: ${String(recordError)}`);
+        }
+        await finish(1);
+        return result;
+    }
+}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -805,10 +805,18 @@
                 console.error('Library health check failed:', e);
             }
         };
-        init().catch(e => {
+        const initPromise = init();
+        initPromise.catch(e => {
             console.error('Failed to initialize app:', e);
             showToast('App initialization failed', { detail: String(e), type: 'error', duration: 10000 });
         });
+        if (import.meta.env.CULL_NATIVE_INTERACTION_SMOKE) {
+            initPromise.finally(() => {
+                import('$lib/native-interaction-smoke')
+                    .then(({ runNativeInteractionSmoke }) => runNativeInteractionSmoke())
+                    .catch(e => console.error('[native-interaction-smoke] failed to start:', e));
+            }).catch(() => {});
+        }
         initMenu().catch(e => console.error('Failed to init menu:', e));
 
         const dragUnlisten = listen<boolean>('drag-hover', (event) => {

--- a/tests/native/run-packaged-interaction-smoke.sh
+++ b/tests/native/run-packaged-interaction-smoke.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$(uname -s)" != "Darwin" ]; then
+  echo "Packaged interaction smoke requires the macOS WKWebView runtime" >&2
+  exit 2
+fi
+
+repo_root="$(cd "$(dirname "$0")/../.." && pwd)"
+shots_dir="${CULL_NATIVE_SMOKE_SHOTS:-${RUNNER_TEMP:-/tmp}/cull-native-interaction-smoke}"
+work_dir="${CULL_NATIVE_SMOKE_WORK:-$(mktemp -d "${RUNNER_TEMP:-${TMPDIR:-/tmp}}/cull-native-smoke.XXXXXX")}"
+smoke_home="$work_dir/home"
+fixture_root="$work_dir/fixtures"
+app_data="${CULL_NATIVE_SMOKE_APP_DATA:-$HOME/Library/Application Support/com.glebkalinin.cull.interaction-smoke}"
+app_bundle="${CULL_NATIVE_SMOKE_APP:-$repo_root/src-tauri/target/release/bundle/macos/Cull.app}"
+app_binary="$app_bundle/Contents/MacOS/cull"
+app_log="$shots_dir/cull-native-interaction-smoke.log"
+timeout_seconds="${CULL_NATIVE_SMOKE_TIMEOUT_SECONDS:-180}"
+
+if [ -d "$app_data" ]; then
+  if command -v trash >/dev/null 2>&1; then
+    trash "$app_data"
+  else
+    echo "Refusing to reuse non-empty smoke app data without the trash command: $app_data" >&2
+    exit 2
+  fi
+fi
+mkdir -p "$shots_dir" "$smoke_home" "$fixture_root/Smoke Alpha" "$fixture_root/Smoke Beta" "$app_data"
+
+cleanup() {
+  if [ "${CULL_NATIVE_SMOKE_KEEP_DATA:-0}" != "1" ] && command -v trash >/dev/null 2>&1; then
+    [ ! -d "$app_data" ] || trash "$app_data" >/dev/null 2>&1 || true
+    [ ! -d "$work_dir" ] || trash "$work_dir" >/dev/null 2>&1 || true
+  fi
+}
+trap cleanup EXIT
+
+# Two distinct, valid PNGs make folder filtering and image navigation observable.
+cp "$repo_root/design/icons/tahoe/masters-unmasked/cull-red.png" "$fixture_root/Smoke Alpha/alpha.png"
+cp "$repo_root/design/icons/tahoe/masters-unmasked/cull-blue.png" "$fixture_root/Smoke Beta/beta.png"
+
+if [ "${CULL_NATIVE_SMOKE_SKIP_BUILD:-0}" != "1" ]; then
+  echo "[native-smoke] Building packaged production Cull.app"
+  (
+    cd "$repo_root"
+    CULL_NATIVE_INTERACTION_SMOKE=1 npm run tauri -- build \
+      --bundles app \
+      --no-sign \
+      --ci \
+      --config tests/native/tauri.smoke.conf.json
+  )
+fi
+
+if [ ! -x "$app_binary" ]; then
+  echo "Packaged app executable is missing: $app_binary" >&2
+  exit 2
+fi
+
+echo "[native-smoke] Seeding isolated database at $app_data"
+HOME="$smoke_home" "$app_binary" \
+  --db "$app_data/cull.db" \
+  --app-data-dir "$app_data" \
+  import_folder --folder-path "$fixture_root" >/dev/null
+
+echo "[native-smoke] Launching packaged WKWebView"
+set +e
+HOME="$smoke_home" "$app_binary" >"$app_log" 2>&1 &
+app_pid="$!"
+set -e
+
+deadline=$((SECONDS + timeout_seconds))
+timed_out=0
+while kill -0 "$app_pid" 2>/dev/null; do
+  if [ "$SECONDS" -ge "$deadline" ]; then
+    timed_out=1
+    /usr/sbin/screencapture -x "$shots_dir/native-interaction-smoke-timeout.png" >/dev/null 2>&1 || true
+    kill -TERM "$app_pid" 2>/dev/null || true
+    break
+  fi
+  sleep 1
+done
+
+set +e
+wait "$app_pid"
+status="$?"
+set -e
+
+if [ "$timed_out" = "1" ]; then
+  status=124
+fi
+
+snapshot_root="$app_data/Agent Snapshots"
+result_manifest="$snapshot_root/native_interaction_smoke_result/manifest.json"
+if [ -d "$snapshot_root" ]; then
+  while IFS= read -r artifact; do
+    cp "$artifact" "$shots_dir/$(basename "$(dirname "$artifact")")-$(basename "$artifact")"
+  done < <(find "$snapshot_root" -type f \( -name '*.png' -o -name 'manifest.json' \) -print)
+fi
+
+if [ -f "$result_manifest" ]; then
+  if grep -Eq '"ok"[[:space:]]*:[[:space:]]*true' "$result_manifest"; then
+    status=0
+  else
+    status=1
+  fi
+fi
+
+if [ "$status" -ne 0 ]; then
+  echo "[native-smoke] FAIL (exit $status); artifacts: $shots_dir" >&2
+  exit "$status"
+fi
+
+echo "[native-smoke] PASS"

--- a/tests/native/tauri.smoke.conf.json
+++ b/tests/native/tauri.smoke.conf.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://schema.tauri.app/config/2",
+  "identifier": "com.glebkalinin.cull.interaction-smoke",
+  "bundle": {
+    "createUpdaterArtifacts": false
+  }
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -4,6 +4,12 @@ import { svelteTesting } from "@testing-library/svelte/vite";
 
 const host = process.env.TAURI_DEV_HOST;
 const e2eMock = process.env.CULL_E2E_MOCK === "1";
+const nativeInteractionSmoke = process.env.CULL_NATIVE_INTERACTION_SMOKE === "1";
+const viteCacheVariant = nativeInteractionSmoke
+  ? "native-smoke"
+  : e2eMock
+    ? "browser-e2e"
+    : "app";
 const tauriMock = decodeURIComponent(new URL("./src/lib/tauri-mock.ts", import.meta.url).pathname);
 const tauriMockAliases = [
   "@tauri-apps/api/core",
@@ -18,6 +24,13 @@ const tauriMockAliases = [
 // https://vite.dev/config/
 export default defineConfig(async () => ({
   plugins: [sveltekit(), svelteTesting()],
+  // Keep optimized dependency paths scoped to this checkout. Some local
+  // worktrees intentionally share node_modules, whose default .vite cache can
+  // otherwise hydrate the app with modules pre-bundled from another worktree.
+  cacheDir: `.vite-cache/${viteCacheVariant}`,
+  define: {
+    "import.meta.env.CULL_NATIVE_INTERACTION_SMOKE": JSON.stringify(nativeInteractionSmoke),
+  },
   resolve: e2eMock ? { alias: tauriMockAliases } : undefined,
   test: {
     exclude: [


### PR DESCRIPTION
## Summary
- bound and cancel PDF preview preparation so filtering cannot be held in Loading
- regenerate legacy PDF placeholders with real first-page previews
- isolate Vite caches to prevent packaged interaction regressions
- preserve the empty Loupe state and repair the Recent Imports preset name

## Verification
- npm run preflight -- full
- 1,068 frontend tests passed
- 763 Rust tests passed (3 ignored)
- cargo fmt and clippy completed

Only the four reviewed regression fixes are included; unrelated feature work and dependency updates are excluded.