### PR TITLE
chore(release): v0.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,13 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
-No changes yet.
+## [0.3.2] - 2026-08-07
+
+### Fixed
+
+- Restored real PDF first-page previews and repaired legacy placeholders.
+- Prevented PDF preview preparation from blocking filtering or leaving the interface in Loading.
+- Prevented packaged interaction cache contamination and preserved empty Loupe and Recent Imports behavior.
 
 ## [0.3.1] - 2026-07-12
 

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -49,4 +49,4 @@ Cull reaches 1.0 when all three surfaces are `stable` and:
 
 ---
 
-Last updated: 0.3.1 (2026-07-12)
+Last updated: 0.3.2 (2026-08-07)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cull",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cull",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.3.200",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cull",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Local-first desktop image viewer for AI-generated art workflows.",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -898,7 +898,7 @@ checksum = "52560adf09603e58c9a7ee1fe1dcb95a16927b17c127f0ac02d6e768a0e25bc1"
 
 [[package]]
 name = "cull"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cull"
-version = "0.3.1"
+version = "0.3.2"
 description = "Local-first desktop image viewer for AI-generated art workflows."
 authors = ["Gleb Kalinin <glebis@gmail.com>"]
 license = "Apache-2.0"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Cull",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "identifier": "com.glebkalinin.cull",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## Release
- bumps Cull from 0.3.1 to 0.3.2
- records the verified PDF preview/loading, packaged interaction cache, empty Loupe, and Recent Imports fixes
- contains only the seven release-owned metadata and documentation files

## Verification
- authoritative release readiness: no blockers
- full release preflight passed
- compatibility fixtures and supply-chain audit passed
- production frontend build passed