### PR TITLE
fix(settings): keep dialog height stable across tabs

### DIFF
--- a/src/lib/components/McpSettings.svelte
+++ b/src/lib/components/McpSettings.svelte
@@ -86,7 +86,7 @@
 
 <style>
     .overlay { position: fixed; inset: 0; z-index: var(--z-modal); display: flex; align-items: center; justify-content: center; background: color-mix(in srgb, var(--bg) 78%, transparent); }
-    .panel { width: min(720px, calc(100vw - 32px)); max-height: min(84vh, 820px); display: grid; grid-template-rows: auto auto minmax(0, 1fr); overflow: hidden; background: var(--surface); border: 1px solid var(--border); border-radius: 8px; }
+    .panel { width: min(720px, calc(100vw - 32px)); height: 90vh; display: grid; grid-template-rows: auto auto minmax(0, 1fr); overflow: hidden; background: var(--surface); border: 1px solid var(--border); border-radius: 8px; }
     .panel-header { display: flex; align-items: center; justify-content: space-between; padding: 16px 20px; border-bottom: 1px solid var(--border); }
     h2 { margin: 0; color: var(--text); font-size: 14px; }
     .close { padding: 0 4px; background: none; border: 0; color: var(--text-secondary); font: 18px var(--font); cursor: pointer; }

--- a/src/lib/components/settings-tabs-contract.test.ts
+++ b/src/lib/components/settings-tabs-contract.test.ts
@@ -18,4 +18,10 @@ describe('Settings tabs', () => {
         expect(source).toContain('aria-selected=');
         expect(source).toContain('role="tabpanel"');
     });
+
+    it('keeps one viewport-sized dialog frame while tab content scrolls inside it', () => {
+        expect(source).toMatch(/\.overlay\s*\{[^}]*align-items:\s*center/s);
+        expect(source).toMatch(/\.panel\s*\{[^}]*height:\s*90vh/s);
+        expect(source).toMatch(/\.content\s*\{[^}]*overflow-y:\s*auto/s);
+    });
 });


### PR DESCRIPTION
## Summary
- keep Settings centred at a fixed 90% of viewport height
- preserve a stable frame when switching between tabs
- keep overflow scrolling inside the tab content region
- add a regression contract for height, centring, and internal scrolling

## Verification
- focused Settings and accessibility tests: 13 passed
- full frontend suite: 147 files, 1,126 tests passed
- full pre-push gate: formatting, clippy, and complete Rust suite passed

The pre-existing Settings border radius is intentionally unchanged.