### PR TITLE
fix(history): render readable stable action rows

### DIFF
--- a/src/lib/components/UndoHistoryPanel.svelte
+++ b/src/lib/components/UndoHistoryPanel.svelte
@@ -471,6 +471,7 @@
     }
 
     .history-section-title {
+        flex: 0 0 auto;
         margin: 4px 0 0;
         color: var(--text-secondary);
         font-size: 10px;
@@ -480,6 +481,7 @@
     }
 
     .history-item {
+        flex: 0 0 auto;
         border: 1px solid var(--border);
         border-radius: var(--radius);
         background: var(--bg);

--- a/src/lib/components/UndoHistoryPanel.svelte
+++ b/src/lib/components/UndoHistoryPanel.svelte
@@ -8,7 +8,12 @@
     let error = $state<string | null>(null);
     let undoHistory = $state<UndoRecord[]>([]);
     let activityEvents = $state<SessionEvent[]>([]);
-    let expanded = $state<string | null>(null);
+
+    const undoBackedEventTypes = new Set([
+        'rating_set',
+        'decision_set',
+        'image_moved_to_trash',
+    ]);
 
     function closeHistory() {
         undoHistoryOpen.set(false);
@@ -101,18 +106,6 @@
         return event.subject_type ?? 'event';
     }
 
-    function formatJson(payload: string): string {
-        try {
-            return JSON.stringify(JSON.parse(payload), null, 2);
-        } catch {
-            return payload;
-        }
-    }
-
-    function toggleExpanded(id: string) {
-        expanded = expanded === id ? null : id;
-    }
-
     async function loadHistory() {
         loading = true;
         error = null;
@@ -122,7 +115,7 @@
                 getActivityContext(null, 40),
             ]);
             undoHistory = undoRows;
-            activityEvents = activity.recent_events;
+            activityEvents = activity.recent_events.filter(event => !undoBackedEventTypes.has(event.event_type));
         } catch (e) {
             error = String(e);
         } finally {
@@ -258,45 +251,12 @@
                         <h3 class="history-section-title">Undoable actions</h3>
                         {#each undoHistory as entry (entry.id)}
                             <article class="history-item" role="listitem">
-                                <button class="history-row" type="button" onclick={() => toggleExpanded(`undo:${entry.id}`)}>
+                                <div class="history-summary">
                                     <span class="history-type">{actionLabel(entry.action_type)}</span>
                                     <span class="history-label" title={displayLabel(entry)}>{displayLabel(entry)}</span>
-                                    <span class="history-meta">{formatTime(entry.created_at)}</span>
                                     <span class="history-count">{affectedCount(entry.affected_image_ids)} image{affectedCount(entry.affected_image_ids) === 1 ? '' : 's'}</span>
-                                    <span class="history-chevron">{expanded === `undo:${entry.id}` ? '▼' : '▶'}</span>
-                                </button>
-                                {#if expanded === `undo:${entry.id}`}
-                                    <div class="history-details">
-                                        <div class="detail-grid">
-                                            <div class="detail-item">
-                                                <span class="detail-key">Seq</span>
-                                                <span class="detail-value">#{entry.seq}</span>
-                                            </div>
-                                            <div class="detail-item">
-                                                <span class="detail-key">Action ID</span>
-                                                <span class="detail-value">{entry.id}</span>
-                                            </div>
-                                            <div class="detail-item">
-                                                <span class="detail-key">File backup</span>
-                                                <span class="detail-value">{entry.has_file_backup ? 'Yes' : 'No'}</span>
-                                            </div>
-                                            <div class="detail-item">
-                                                <span class="detail-key">Affected image IDs</span>
-                                                <span class="detail-value">{entry.affected_image_ids ?? 'None'}</span>
-                                            </div>
-                                        </div>
-                                        <div class="history-json-block">
-                                            <div class="history-json-col">
-                                                <h4>Before</h4>
-                                                <pre>{formatJson(entry.before_json)}</pre>
-                                            </div>
-                                            <div class="history-json-col">
-                                                <h4>After</h4>
-                                                <pre>{formatJson(entry.after_json)}</pre>
-                                            </div>
-                                        </div>
-                                    </div>
-                                {/if}
+                                    <time class="history-time" datetime={entry.created_at}>{formatTime(entry.created_at)}</time>
+                                </div>
                             </article>
                         {/each}
                     {/if}
@@ -305,41 +265,12 @@
                         <h3 class="history-section-title">Critical activity</h3>
                         {#each activityEvents as event (event.id)}
                             <article class="history-item" role="listitem">
-                                <button class="history-row" type="button" onclick={() => toggleExpanded(`event:${event.id}`)}>
+                                <div class="history-summary">
                                     <span class="history-type">{eventTypeLabel(event.event_type)}</span>
                                     <span class="history-label" title={eventLabel(event)}>{eventLabel(event)}</span>
-                                    <span class="history-meta">{formatTime(event.created_at)}</span>
                                     <span class="history-count">{eventCount(event)}</span>
-                                    <span class="history-chevron">{expanded === `event:${event.id}` ? '▼' : '▶'}</span>
-                                </button>
-                                {#if expanded === `event:${event.id}`}
-                                    <div class="history-details">
-                                        <div class="detail-grid">
-                                            <div class="detail-item">
-                                                <span class="detail-key">Event ID</span>
-                                                <span class="detail-value">{event.id}</span>
-                                            </div>
-                                            <div class="detail-item">
-                                                <span class="detail-key">Actor</span>
-                                                <span class="detail-value">{event.actor_type}</span>
-                                            </div>
-                                            <div class="detail-item">
-                                                <span class="detail-key">Subject</span>
-                                                <span class="detail-value">{event.subject_type ?? 'None'}</span>
-                                            </div>
-                                            <div class="detail-item">
-                                                <span class="detail-key">Subject ID</span>
-                                                <span class="detail-value">{event.subject_id ?? 'None'}</span>
-                                            </div>
-                                        </div>
-                                        <div class="history-json-block single">
-                                            <div class="history-json-col">
-                                                <h4>Payload</h4>
-                                                <pre>{formatJson(event.payload_json)}</pre>
-                                            </div>
-                                        </div>
-                                    </div>
-                                {/if}
+                                    <time class="history-time" datetime={event.created_at}>{formatTime(event.created_at)}</time>
+                                </div>
                             </article>
                         {/each}
                     {/if}
@@ -555,19 +486,14 @@
         overflow: hidden;
     }
 
-    .history-row {
-        width: 100%;
-        border: none;
-        background: transparent;
-        color: inherit;
-        font: inherit;
+    .history-summary {
         display: grid;
-        grid-template-columns: 110px minmax(240px, 1fr) 190px 120px 24px;
+        grid-template-columns: 130px minmax(180px, 1fr) 100px 180px;
         gap: 10px;
         align-items: center;
-        padding: 8px 10px;
-        text-align: left;
-        cursor: pointer;
+        min-height: 42px;
+        padding: 9px 12px;
+        box-sizing: border-box;
     }
 
     .history-type {
@@ -584,7 +510,7 @@
         text-overflow: ellipsis;
     }
 
-    .history-meta,
+    .history-time,
     .history-count {
         color: var(--text-secondary);
         font-size: 11px;
@@ -593,74 +519,6 @@
 
     .history-count {
         text-align: left;
-    }
-
-    .history-chevron {
-        color: var(--text-secondary);
-    }
-
-    .history-details {
-        border-top: 1px solid var(--border);
-        padding: 10px;
-        display: flex;
-        flex-direction: column;
-        gap: 10px;
-    }
-
-    .detail-grid {
-        display: grid;
-        grid-template-columns: repeat(2, minmax(0, 1fr));
-        gap: 8px;
-    }
-
-    .detail-item {
-        display: flex;
-        flex-direction: column;
-        gap: 4px;
-        min-width: 0;
-    }
-
-    .detail-key {
-        color: var(--text-secondary);
-        font-size: 10px;
-    }
-
-    .detail-value {
-        font-size: 11px;
-        color: var(--text);
-        word-break: break-all;
-    }
-
-    .history-json-block {
-        display: grid;
-        grid-template-columns: repeat(2, minmax(0, 1fr));
-        gap: 8px;
-    }
-
-    .history-json-block.single {
-        grid-template-columns: 1fr;
-    }
-
-    .history-json-col h4 {
-        margin: 0 0 6px;
-        color: var(--text-secondary);
-        font-size: 11px;
-        text-transform: uppercase;
-        letter-spacing: 0.3px;
-    }
-
-    .history-json-col pre {
-        margin: 0;
-        max-height: 130px;
-        overflow: auto;
-        background: var(--surface);
-        border: 1px solid var(--border);
-        border-radius: var(--radius);
-        padding: 6px;
-        font-size: 11px;
-        color: var(--text);
-        white-space: pre-wrap;
-        word-break: break-word;
     }
 
     @media (max-width: 880px) {
@@ -672,18 +530,13 @@
             padding: 10px;
         }
 
-        .history-row {
-            grid-template-columns: 80px minmax(120px, 1fr) auto 20px;
+        .history-summary {
+            grid-template-columns: 100px minmax(120px, 1fr) auto;
         }
 
         .history-count,
-        .history-meta {
+        .history-time {
             display: none;
-        }
-
-        .detail-grid,
-        .history-json-block {
-            grid-template-columns: 1fr;
         }
     }
 </style>

--- a/src/lib/components/UndoHistoryPanel.svelte
+++ b/src/lib/components/UndoHistoryPanel.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
     import { onMount } from 'svelte';
     import { undo, redo, listUndoHistory, getActivityContext, type SessionEvent, type UndoRecord } from '$lib/api';
+    import { filterUndoBackedActivity } from '$lib/history-activity';
     import { showToast, undoHistoryOpen } from '$lib/stores';
 
     let loading = $state(false);
@@ -8,12 +9,6 @@
     let error = $state<string | null>(null);
     let undoHistory = $state<UndoRecord[]>([]);
     let activityEvents = $state<SessionEvent[]>([]);
-
-    const undoBackedEventTypes = new Set([
-        'rating_set',
-        'decision_set',
-        'image_moved_to_trash',
-    ]);
 
     function closeHistory() {
         undoHistoryOpen.set(false);
@@ -115,7 +110,7 @@
                 getActivityContext(null, 40),
             ]);
             undoHistory = undoRows;
-            activityEvents = activity.recent_events.filter(event => !undoBackedEventTypes.has(event.event_type));
+            activityEvents = filterUndoBackedActivity(activity.recent_events, undoRows);
         } catch (e) {
             error = String(e);
         } finally {
@@ -493,8 +488,8 @@
         grid-template-columns: 130px minmax(180px, 1fr) 100px 180px;
         gap: 10px;
         align-items: center;
-        min-height: 42px;
-        padding: 9px 12px;
+        min-height: 40px;
+        padding: 8px 16px;
         box-sizing: border-box;
     }
 

--- a/src/lib/components/undo-history-panel.test.ts
+++ b/src/lib/components/undo-history-panel.test.ts
@@ -50,6 +50,23 @@ describe('undo history panel contract', () => {
         expect(panel).toContain("window.addEventListener('session-events-refresh', onReload);");
     });
 
+    it('renders readable history rows without expandable diagnostic output', () => {
+        expect(panel).toContain('class="history-summary"');
+        expect(panel).toContain('class="history-time"');
+        expect(panel).not.toContain('class="history-row"');
+        expect(panel).not.toContain('class="history-details"');
+        expect(panel).not.toContain('<pre>{formatJson(');
+        expect(panel).not.toContain('Affected image IDs');
+        expect(panel).not.toContain('Event ID');
+    });
+
+    it('does not repeat undo-backed activity in the secondary activity section', () => {
+        expect(panel).toContain('const undoBackedEventTypes = new Set([');
+        expect(panel).toContain("'rating_set'");
+        expect(panel).toContain("'decision_set'");
+        expect(panel).toContain('activityEvents = activity.recent_events.filter');
+    });
+
     it('documents the commands that currently feed action history', () => {
         expect(selectionCommands).toContain('Action::SetRating');
         expect(selectionCommands).toContain('Action::SetDecision');

--- a/src/lib/components/undo-history-panel.test.ts
+++ b/src/lib/components/undo-history-panel.test.ts
@@ -53,6 +53,7 @@ describe('undo history panel contract', () => {
     it('renders readable history rows without expandable diagnostic output', () => {
         expect(panel).toContain('class="history-summary"');
         expect(panel).toContain('class="history-time"');
+        expect(panel).toContain('flex: 0 0 auto;');
         expect(panel).not.toContain('class="history-row"');
         expect(panel).not.toContain('class="history-details"');
         expect(panel).not.toContain('<pre>{formatJson(');

--- a/src/lib/components/undo-history-panel.test.ts
+++ b/src/lib/components/undo-history-panel.test.ts
@@ -62,10 +62,8 @@ describe('undo history panel contract', () => {
     });
 
     it('does not repeat undo-backed activity in the secondary activity section', () => {
-        expect(panel).toContain('const undoBackedEventTypes = new Set([');
-        expect(panel).toContain("'rating_set'");
-        expect(panel).toContain("'decision_set'");
-        expect(panel).toContain('activityEvents = activity.recent_events.filter');
+        expect(panel).toContain("import { filterUndoBackedActivity } from '$lib/history-activity';");
+        expect(panel).toContain('filterUndoBackedActivity(activity.recent_events, undoRows)');
     });
 
     it('documents the commands that currently feed action history', () => {

--- a/src/lib/history-activity.test.ts
+++ b/src/lib/history-activity.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import type { SessionEvent, UndoRecord } from './api';
+import { filterUndoBackedActivity } from './history-activity';
+
+type ActivityFixture = Pick<SessionEvent, 'id' | 'event_type' | 'subject_id'>;
+type UndoFixture = Pick<UndoRecord, 'action_type' | 'affected_image_ids'>;
+
+function activity(id: string, eventType: string, subjectId: string | null): ActivityFixture {
+    return { id, event_type: eventType, subject_id: subjectId };
+}
+
+function undo(actionType: string, affectedImageIds: string | null): UndoFixture {
+    return { action_type: actionType, affected_image_ids: affectedImageIds };
+}
+
+describe('filterUndoBackedActivity', () => {
+    it('keeps undo-backed activity when no loaded undo record represents it', () => {
+        const events = [activity('event-1', 'rating_set', 'image-1')];
+
+        expect(filterUndoBackedActivity(events, [])).toEqual(events);
+    });
+
+    it('suppresses only as many matching events as loaded undo records', () => {
+        const events = [
+            activity('event-new', 'rating_set', 'image-1'),
+            activity('event-old', 'rating_set', 'image-1'),
+        ];
+
+        expect(filterUndoBackedActivity(events, [undo('set_rating', 'image-1')])).toEqual([
+            events[1],
+        ]);
+    });
+
+    it('matches each image in a batch trash undo record', () => {
+        const events = [
+            activity('event-1', 'image_moved_to_trash', 'image-1'),
+            activity('event-2', 'image_moved_to_trash', 'image-2'),
+            activity('event-3', 'image_moved_to_trash', 'image-3'),
+        ];
+
+        expect(filterUndoBackedActivity(events, [undo('trash_image', 'image-1, image-2')])).toEqual([
+            events[2],
+        ]);
+    });
+
+    it('preserves unrelated event types and events without a subject', () => {
+        const events = [
+            activity('event-1', 'collection_deleted', 'collection-1'),
+            activity('event-2', 'decision_set', null),
+        ];
+
+        expect(filterUndoBackedActivity(events, [undo('set_decision', 'image-1')])).toEqual(events);
+    });
+});

--- a/src/lib/history-activity.ts
+++ b/src/lib/history-activity.ts
@@ -1,0 +1,42 @@
+import type { SessionEvent, UndoRecord } from './api';
+
+type ActivityIdentity = Pick<SessionEvent, 'event_type' | 'subject_id'>;
+type UndoIdentity = Pick<UndoRecord, 'action_type' | 'affected_image_ids'>;
+
+const undoActionByEventType: Readonly<Record<string, string>> = {
+    rating_set: 'set_rating',
+    decision_set: 'set_decision',
+    image_moved_to_trash: 'trash_image',
+};
+
+function identityKey(actionType: string, subjectId: string): string {
+    return `${actionType}\u0000${subjectId}`;
+}
+
+export function filterUndoBackedActivity<T extends ActivityIdentity>(
+    events: readonly T[],
+    undoRecords: readonly UndoIdentity[],
+): T[] {
+    const availableMatches = new Map<string, number>();
+
+    for (const record of undoRecords) {
+        for (const subjectId of record.affected_image_ids?.split(',') ?? []) {
+            const normalizedId = subjectId.trim();
+            if (!normalizedId) continue;
+            const key = identityKey(record.action_type, normalizedId);
+            availableMatches.set(key, (availableMatches.get(key) ?? 0) + 1);
+        }
+    }
+
+    return events.filter(event => {
+        const undoAction = undoActionByEventType[event.event_type];
+        if (!undoAction || !event.subject_id) return true;
+
+        const key = identityKey(undoAction, event.subject_id);
+        const remaining = availableMatches.get(key) ?? 0;
+        if (remaining === 0) return true;
+
+        availableMatches.set(key, remaining - 1);
+        return false;
+    });
+}


### PR DESCRIPTION
## Summary
- replace expandable diagnostic history rows with concise readable summaries
- keep history sections and rows from collapsing inside the scrolling timeline
- suppress duplicate activity only when a loaded undo record actually represents the same action and image
- preserve unmatched activity when undo recording failed or the matching record is outside the loaded window

## Validation
- focused history suites: 12 tests passed
- Svelte check: 0 errors, 0 warnings
- full frontend: 148 files, 1,132 tests passed
- cargo fmt and clippy passed (pre-existing warnings remain non-fatal)
- Rust: 757 passed, 3 ignored, plus integration suites passed

Part of imageview-htfg.7. The broader opaque event-label enrichment remains separate because it requires backend event-payload changes.