### PR TITLE
fix(sidebar): make folder navigation predictable

### DIFF
--- a/src-tauri/src/db_core/db.rs
+++ b/src-tauri/src/db_core/db.rs
@@ -2025,6 +2025,40 @@ mod tests {
     }
 
     #[test]
+    fn list_images_in_scope_treats_like_wildcards_as_literal() {
+        let db = test_db();
+        insert_test_image_at_path(&db, "inside", "h-in", "/Photos/2025_Trips/a.png");
+        insert_test_image_at_path(&db, "outside", "h-out", "/Photos/2025XTrips/c.png");
+
+        // `_` is a LIKE wildcard; the scope must treat it as a literal.
+        let ids: Vec<String> = db
+            .list_images_in_scope(&["/Photos/2025_Trips".to_string()], &[], &[], 100, 0)
+            .unwrap()
+            .into_iter()
+            .map(|i| i.image.id)
+            .collect();
+        assert_eq!(ids, vec!["inside".to_string()]);
+    }
+
+    #[test]
+    fn list_images_in_scope_folder_is_case_sensitive() {
+        let db = test_db();
+        insert_test_image_at_path(&db, "upper", "h-u", "/lib/Art/u.png");
+        insert_test_image_at_path(&db, "lower", "h-l", "/lib/art/l.png");
+
+        // SQLite's LIKE is ASCII-case-insensitive, which would merge these two
+        // folders even though the sidebar lists them separately with their own
+        // counts. COLLATE BINARY keeps the displayed counts honest.
+        let ids: Vec<String> = db
+            .list_images_in_scope(&["/lib/Art".to_string()], &[], &[], 100, 0)
+            .unwrap()
+            .into_iter()
+            .map(|i| i.image.id)
+            .collect();
+        assert_eq!(ids, vec!["upper".to_string()]);
+    }
+
+    #[test]
     fn list_images_in_scope_folder_prefix_is_exact() {
         let db = test_db();
         insert_test_image_at_path(&db, "a", "h-a", "/art/a.png");
@@ -2042,6 +2076,41 @@ mod tests {
         assert!(ids.contains("a"));
         assert!(ids.contains("c"));
         assert!(!ids.contains("b"));
+    }
+
+    #[test]
+    fn list_images_by_folder_treats_underscore_as_literal() {
+        let db = test_db();
+        insert_test_image_at_path(&db, "inside", "h-in", "/Photos/2025_Trips/A/a.png");
+        insert_test_image_at_path(&db, "outside", "h-out", "/Photos/2025XTrips/C/c.png");
+
+        // `_` is a LIKE wildcard; the prefix match must treat it literally or
+        // the 2025XTrips image leaks into the 2025_Trips folder.
+        let ids: Vec<String> = db
+            .list_images_by_folder("/Photos/2025_Trips", 100, 0)
+            .unwrap()
+            .into_iter()
+            .map(|i| i.image.id)
+            .collect();
+        assert_eq!(ids, vec!["inside".to_string()]);
+    }
+
+    #[test]
+    fn list_images_by_folder_is_recursive_but_not_prefix_greedy() {
+        let db = test_db();
+        insert_test_image_at_path(&db, "a", "h-a", "/art/a.png");
+        insert_test_image_at_path(&db, "c", "h-c", "/art/sub/c.png");
+        insert_test_image_at_path(&db, "b", "h-b", "/artisan/b.png");
+
+        let ids: std::collections::BTreeSet<String> = db
+            .list_images_by_folder("/art", 100, 0)
+            .unwrap()
+            .into_iter()
+            .map(|i| i.image.id)
+            .collect();
+        assert!(ids.contains("a"));
+        assert!(ids.contains("c"), "subfolders must be included");
+        assert!(!ids.contains("b"), "sibling prefix must not match");
     }
 
     #[test]

--- a/src-tauri/src/db_core/queries/images.rs
+++ b/src-tauri/src/db_core/queries/images.rs
@@ -118,11 +118,22 @@ impl Database {
 
         for folder in folders {
             let folder = folder.trim_end_matches('/');
-            // Exact folder OR any descendant. The trailing "/%" keeps sibling
-            // prefixes like /artisan from matching a /art scope.
-            clauses.push("(f.path = ? OR f.path LIKE ? || '/%')".to_string());
+            // Exact folder OR any descendant. The descendant test is a substr
+            // prefix comparison rather than LIKE: `_` and `%` are LIKE
+            // wildcards, so a folder named `2025_Trips` would also pull in
+            // `2025XTrips`, and LIKE is ASCII-case-insensitive, which would
+            // merge `/lib/Art` and `/lib/art` into one result set even though
+            // the sidebar shows them as two folders with separate counts.
+            // COLLATE BINARY keeps both distinctions. Matches
+            // list_images_by_folder and delete_images_by_folder.
+            let prefix = format!("{}/", folder);
+            clauses.push(
+                "(f.path = ? OR substr(f.path, 1, ?) COLLATE BINARY = ? COLLATE BINARY)"
+                    .to_string(),
+            );
             args.push(Value::Text(folder.to_string()));
-            args.push(Value::Text(folder.to_string()));
+            args.push(Value::Integer(prefix.chars().count() as i64));
+            args.push(Value::Text(prefix));
         }
         if !collections.is_empty() {
             let placeholders = vec!["?"; collections.len()].join(",");
@@ -264,7 +275,12 @@ impl Database {
         offset: u32,
     ) -> Result<Vec<ImageWithFile>> {
         let conn = self.conn.lock();
-        let pattern = format!("{}/%", folder);
+        // Prefix-match on substr rather than LIKE: `_` and `%` are wildcards in
+        // LIKE, so a folder named `2025_Trips` would also pull in `2025XTrips`.
+        // This mirrors delete_images_by_folder, which avoids LIKE for the same
+        // reason.
+        let prefix = format!("{}/", folder.trim_end_matches('/'));
+        let prefix_len = prefix.chars().count() as i64;
         let mut stmt = conn.prepare(
             "SELECT i.id, i.sha256_hash, i.width, i.height, i.format, i.file_size,
                     i.created_at, i.imported_at, f.path,
@@ -273,12 +289,12 @@ impl Database {
              FROM images i
              JOIN image_files f ON f.image_id = i.id AND f.missing_at IS NULL
              LEFT JOIN selections s ON s.image_id = i.id AND s.project_id = '__global__'
-             WHERE f.path LIKE ?1
+             WHERE substr(f.path, 1, ?4) COLLATE BINARY = ?1 COLLATE BINARY
              GROUP BY i.id
              ORDER BY i.imported_at DESC
              LIMIT ?2 OFFSET ?3",
         )?;
-        let rows = stmt.query_map(params![pattern, limit, offset], |row| {
+        let rows = stmt.query_map(params![prefix, limit, offset, prefix_len], |row| {
             let star: Option<u8> = row.get(9)?;
             let color: Option<String> = row.get(10)?;
             let decision: Option<String> = row.get(11)?;

--- a/src/lib/clipboard-monitor-ui.test.ts
+++ b/src/lib/clipboard-monitor-ui.test.ts
@@ -6,7 +6,9 @@ const sidebar = readFileSync(join(process.cwd(), 'src/lib/components/Sidebar.sve
 
 describe('clipboard monitor sidebar UI contract', () => {
     it('renders operational clipboard monitor controls in the sidebar', () => {
-        expect(sidebar).toContain('CLIPBOARD MONITOR');
+        // The section is now a collapse toggle; `.folders-toggle-label` applies
+        // text-transform: uppercase, so it still reads CLIPBOARD MONITOR.
+        expect(sidebar).toContain('Clipboard Monitor');
         expect(sidebar).toContain('startClipboardMonitor');
         expect(sidebar).toContain('stopClipboardMonitor');
         expect(sidebar).toContain('setClipboardMonitorCaptureExistingOnStart');

--- a/src/lib/components/Sidebar.svelte
+++ b/src/lib/components/Sidebar.svelte
@@ -196,6 +196,12 @@
                     }
                 }
                 break;
+            case 'Delete':
+                if (!row.isGroup) {
+                    event.preventDefault();
+                    void handleDeleteFolder(event, row.fullPath);
+                }
+                break;
         }
     }
 
@@ -837,6 +843,7 @@
                         style="padding-left: {folder.depth * 12}px"
                         role="treeitem"
                         aria-level={folder.depth + 1}
+                        aria-keyshortcuts={folder.isGroup ? undefined : 'Delete'}
                         aria-selected={$activeFolder === folder.fullPath}
                         aria-expanded={folder.hasChildren ? (isExpanded || filterActive) : undefined}
                         aria-label={`${folder.name}, ${folder.subtreeCount} images`}

--- a/src/lib/components/Sidebar.svelte
+++ b/src/lib/components/Sidebar.svelte
@@ -53,13 +53,167 @@
         clipboardMonitorStatus.set(status);
     }
 
-    import { buildDisplayFolders, buildPinnedCollectionRows, formatSidebarCount } from '$lib/sidebar-utils';
+    import { buildDisplayFolders, buildPinnedCollectionRows, formatSidebarCount, formatFolderCount, visibleFolderRows, matchesSidebarFilter, prunePinnedIds, type CollectionRow } from '$lib/sidebar-utils';
+
+    function prunePinsToExistingCollections(rows: CollectionRow[]) {
+        const kept = prunePinnedIds(get(pinnedCollections), rows);
+        if (kept.length !== get(pinnedCollections).length) {
+            pinnedCollections.set(kept);
+        }
+        if (get(pinnedCollection) && !kept.includes(get(pinnedCollection)!)) {
+            pinnedCollection.set(kept[kept.length - 1] ?? null);
+        }
+    }
     import SessionSwitcher from './SessionSwitcher.svelte';
-    import { activeCanvas, activeSession, navigateTo, sessionCanvases } from '$lib/stores';
+    import { activeCanvas, activeSession, navigateTo, sessionCanvases, expandedFolders, sidebarSectionsCollapsed, sidebarFilter } from '$lib/stores';
     import { createCanvas, type Canvas } from '$lib/api';
 
+    // "All Images" is only the active scope when nothing else narrows it —
+    // including a detected-class filter, which used to leave both All Images
+    // and the class row looking unselected/selected at the same time.
+    let allImagesActive = $derived(
+        $activeFolder === null &&
+        $activeCollection === null &&
+        $activeSmartCollection === null &&
+        $activeDetectedClass === null
+    );
+
     let displayFolders = $derived(buildDisplayFolders($folders));
-    let displayCollections = $derived(buildPinnedCollectionRows($collections, $pinnedCollections));
+    let displayCollections = $derived(
+        buildPinnedCollectionRows($collections, $pinnedCollections)
+            .filter(([, name]) => matchesSidebarFilter(name, $sidebarFilter))
+    );
+
+    // Section collapse. The store holds the COLLAPSED ids, so a section added
+    // later defaults to open for users who already have persisted state.
+    function isSectionCollapsed(collapsed: Set<string>, id: string): boolean {
+        return collapsed.has(id);
+    }
+    function toggleSection(id: string) {
+        sidebarSectionsCollapsed.update(set => {
+            const next = new Set(set);
+            if (next.has(id)) next.delete(id); else next.add(id);
+            return next;
+        });
+    }
+
+    // "Recent Imports" is a seeded smart collection, but sixth in a 22-row list
+    // is not where you look after an import. Promote it next to All Images and
+    // drop it from the SMART list so it appears exactly once.
+    const RECENT_IMPORTS_NAME = 'Recent Imports';
+    let recentImportsCollection = $derived(
+        $smartCollections.find(sc => sc.name === RECENT_IMPORTS_NAME && (sc.image_count ?? 0) > 0) ?? null
+    );
+
+    // The rows actually on screen. Both the render loop and the keyboard
+    // handler read this, so arrow keys can never focus a hidden row.
+    let visibleFolders = $derived(visibleFolderRows(displayFolders, $expandedFolders, $sidebarFilter));
+    let treeFocusIndex = $state(0);
+    // While filtering, the tree auto-reveals matches and their subtrees, so
+    // expansion controls are inert and say so rather than looking broken.
+    let filterActive = $derived($sidebarFilter.trim() !== '');
+    // Filtering or collapsing can shrink the list below the remembered index.
+    // Clamping in a $derived (rather than writing back to treeFocusIndex from
+    // an effect) keeps exactly one row tabbable without a self-referential
+    // effect, so Tab can always re-enter the tree.
+    let treeTabIndex = $derived(
+        visibleFolders.length === 0 ? -1 : Math.min(treeFocusIndex, visibleFolders.length - 1)
+    );
+
+    function toggleFolderExpanded(path: string) {
+        // While a filter is active the tree ignores expansion entirely, so a
+        // toggle here would silently rewrite persisted state the user cannot
+        // see — they would only discover it after clearing the filter.
+        if (get(sidebarFilter).trim()) return;
+        expandedFolders.update(set => {
+            const next = new Set(set);
+            if (next.has(path)) next.delete(path); else next.add(path);
+            return next;
+        });
+    }
+
+    function focusTreeRow(index: number) {
+        const clamped = Math.max(0, Math.min(index, visibleFolders.length - 1));
+        treeFocusIndex = clamped;
+        // The row must exist in the DOM before it can take focus; Svelte has
+        // already flushed by the time a keydown handler runs for rows that were
+        // visible, and expand/collapse re-renders synchronously via $derived.
+        queueMicrotask(() => {
+            const el = document.querySelector<HTMLElement>(`[data-tree-row="${clamped}"]`);
+            el?.focus();
+        });
+    }
+
+    function handleTreeKeydown(event: KeyboardEvent) {
+        const rows = visibleFolders;
+        if (rows.length === 0) return;
+        const i = Math.min(treeFocusIndex, rows.length - 1);
+        const row = rows[i];
+
+        switch (event.key) {
+            case 'Enter':
+            case ' ':
+                // Focus lives on the treeitem, not the inner button, so the
+                // row has to activate itself.
+                event.preventDefault();
+                selectFolder(row.fullPath);
+                break;
+            case 'ArrowDown':
+                event.preventDefault();
+                focusTreeRow(i + 1);
+                break;
+            case 'ArrowUp':
+                event.preventDefault();
+                focusTreeRow(i - 1);
+                break;
+            case 'Home':
+                event.preventDefault();
+                focusTreeRow(0);
+                break;
+            case 'End':
+                event.preventDefault();
+                focusTreeRow(rows.length - 1);
+                break;
+            case 'ArrowRight':
+                event.preventDefault();
+                // Standard tree behaviour: open a closed node, then step into it.
+                // Filtering already reveals every subtree, so there is nothing
+                // to open and Right simply steps in.
+                if (row.hasChildren && !filterActive && !get(expandedFolders).has(row.fullPath)) {
+                    toggleFolderExpanded(row.fullPath);
+                } else if (row.hasChildren) {
+                    focusTreeRow(i + 1);
+                }
+                break;
+            case 'ArrowLeft':
+                event.preventDefault();
+                if (row.hasChildren && !filterActive && get(expandedFolders).has(row.fullPath)) {
+                    toggleFolderExpanded(row.fullPath);
+                } else {
+                    // Jump to the nearest shallower row — the visual parent.
+                    for (let k = i - 1; k >= 0; k--) {
+                        if (rows[k].depth < row.depth) { focusTreeRow(k); break; }
+                    }
+                }
+                break;
+        }
+    }
+
+    // A running monitor forces the section open — a background capture that the
+    // user cannot see the state of is worse than the space it costs.
+    let clipboardCollapsed = $derived(
+        isSectionCollapsed($sidebarSectionsCollapsed, 'clipboard') && !clipboardStatus?.running
+    );
+
+    // Smart collections seed ~22 presets. Hiding the empty ones keeps the list
+    // proportional to the library instead of to the seed table.
+    let visibleSmartCollections = $derived(
+        $smartCollections.filter(sc =>
+            (sc.image_count ?? 0) > 0 &&
+            sc.id !== recentImportsCollection?.id &&
+            matchesSidebarFilter(sc.name, $sidebarFilter)
+        )
+    );
 
     function clearCollectionPreviewTimer() {
         if (!collectionPreviewTimer) return;
@@ -140,6 +294,7 @@
         try {
             const c = await listCollections();
             collections.set(c);
+            prunePinsToExistingCollections(c);
         } catch (e) {
             console.error('Failed to load collections:', e);
             showToast('Failed to load collections', { detail: String(e), type: 'error', duration: 8000 });
@@ -514,10 +669,17 @@
                 summary += `, ${result.errors.length} errors`;
             }
             setLastResult(summary, result.errors.length > 0 ? 'error' : 'success');
+            const importedFolder = selected as string;
             showToast(`Imported "${folderName}"`, {
                 detail: summary,
                 type: 'success',
                 duration: 8000,
+                // "Where did what I just imported go?" is the question every
+                // import ends on; answer it in the toast instead of making the
+                // user hunt for the folder in the tree.
+                actions: result.imported > 0
+                    ? [{ label: 'View imported', onclick: () => { selectFolder(importedFolder); } }]
+                    : undefined,
             });
             await refreshImages();
         } catch (e) {
@@ -609,18 +771,43 @@
         </div>
     {/if}
 
+    <div class="sidebar-filter">
+        <input
+            type="search"
+            class="sidebar-filter-input"
+            placeholder="Filter folders &amp; collections"
+            aria-label="Filter folders and collections"
+            bind:value={$sidebarFilter}
+            onkeydown={(e: KeyboardEvent) => { if (e.key === 'Escape') { e.stopPropagation(); sidebarFilter.set(''); } }}
+        />
+    </div>
+
     <div class="section">
         <div class="section-header">LIBRARY</div>
         <button
             class="section-item"
-            class:active={$activeFolder === null && $activeCollection === null && $activeSmartCollection === null && $activeDetectedClass === null}
+            class:active={allImagesActive}
             onclick={() => selectFolder(null)}
-            aria-current={$activeFolder === null && $activeCollection === null && $activeSmartCollection === null && $activeDetectedClass === null ? 'true' : undefined}
+            aria-current={allImagesActive ? 'true' : undefined}
         >
             <span class="icon">&#9632;</span>
             <span class="item-label">All Images</span>
             <span class="count">{formatSidebarCount($totalCount)}</span>
         </button>
+
+        {#if recentImportsCollection}
+            <button
+                class="section-item"
+                class:active={$activeSmartCollection?.id === recentImportsCollection.id}
+                onclick={() => selectSmartCollection(recentImportsCollection!)}
+                aria-current={$activeSmartCollection?.id === recentImportsCollection.id ? 'true' : undefined}
+                title="Images imported in the last 7 days"
+            >
+                <span class="icon">&#9200;</span>
+                <span class="item-label">Recent Imports</span>
+                <span class="count">{formatSidebarCount(recentImportsCollection.image_count)}</span>
+            </button>
+        {/if}
 
         {#if displayFolders.length > 0}
             <button
@@ -634,34 +821,71 @@
             </button>
 
             {#if foldersExpanded}
-                <div aria-label="Folder hierarchy">
-                {#each displayFolders as folder}
-                    <div class="folder-row" class:active={$activeFolder === folder.fullPath} style="padding-left: {folder.depth * 12}px">
-                        {#if folder.count > 0}
+                <!-- svelte-ignore a11y_no_noninteractive_element_to_interactive_role -->
+                <div
+                    class="folder-tree"
+                    role="tree"
+                    tabindex="-1"
+                    aria-label="Folder hierarchy"
+                    onkeydown={handleTreeKeydown}
+                >
+                {#each visibleFolders as folder, i (folder.fullPath)}
+                    {@const isExpanded = $expandedFolders.has(folder.fullPath)}
+                    <div
+                        class="folder-row"
+                        class:active={$activeFolder === folder.fullPath}
+                        style="padding-left: {folder.depth * 12}px"
+                        role="treeitem"
+                        aria-level={folder.depth + 1}
+                        aria-selected={$activeFolder === folder.fullPath}
+                        aria-expanded={folder.hasChildren ? (isExpanded || filterActive) : undefined}
+                        aria-label={`${folder.name}, ${folder.subtreeCount} images`}
+                        data-tree-row={i}
+                        tabindex={i === treeTabIndex ? 0 : -1}
+                        onfocusin={() => treeFocusIndex = i}
+                    >
+                        {#if folder.hasChildren}
                             <button
-                                class="section-item"
-                                onclick={() => selectFolder(folder.fullPath)}
-                                title={folder.fullPath}
-                                aria-current={$activeFolder === folder.fullPath ? 'true' : undefined}
-                            >
-                                <span class="icon">{folder.hasChildren ? '▾' : '▸'}</span>
-                                <span class="folder-label">{folder.name}</span>
-                                <span class="count">{formatSidebarCount(folder.count)}</span>
-                            </button>
+                                class="twisty"
+                                tabindex="-1"
+                                disabled={filterActive}
+                                onclick={(e: Event) => { e.stopPropagation(); toggleFolderExpanded(folder.fullPath); }}
+                                aria-label={`${isExpanded || filterActive ? 'Collapse' : 'Expand'} ${folder.name}`}
+                                title={filterActive ? 'Expansion is disabled while filtering' : undefined}
+                            >{isExpanded || filterActive ? '▾' : '▸'}</button>
+                        {:else}
+                            <span class="twisty-spacer" aria-hidden="true"></span>
+                        {/if}
+                        <button
+                            class="section-item"
+                            class:folder-group={folder.isGroup}
+                            tabindex="-1"
+                            onclick={() => selectFolder(folder.fullPath)}
+                            title={folder.fullPath}
+                            aria-current={$activeFolder === folder.fullPath ? 'true' : undefined}
+                        >
+                            <span class="folder-label">{folder.name}</span>
+                            <span
+                                class="count"
+                                title={folder.count === folder.subtreeCount
+                                    ? undefined
+                                    : `${folder.count} directly in this folder, ${folder.subtreeCount} including subfolders`}
+                            >{formatFolderCount(folder.count, folder.subtreeCount)}</span>
+                        </button>
+                        {#if !folder.isGroup}
                             <button
                                 class="delete-btn"
+                                tabindex="-1"
                                 onclick={(e: Event) => handleDeleteFolder(e, folder.fullPath)}
                                 title="Remove folder from library"
                                 aria-label={`Remove folder from library: ${folder.name}`}
                             >&times;</button>
-                        {:else}
-                            <span class="section-item folder-group">
-                                <span class="icon">▾</span>
-                                <span class="folder-label">{folder.name}</span>
-                            </span>
                         {/if}
                     </div>
                 {/each}
+                {#if visibleFolders.length === 0}
+                    <div class="section-empty">No folders match "{$sidebarFilter}"</div>
+                {/if}
                 </div>
             {/if}
         {/if}
@@ -722,8 +946,80 @@
         {/if}
     </div>
 
+    {#if visibleSmartCollections.length > 0}
+    {@const smartCollapsed = isSectionCollapsed($sidebarSectionsCollapsed, 'smart')}
+    <div class="section">
+        <button
+            class="folders-toggle"
+            onclick={() => toggleSection('smart')}
+            aria-expanded={!smartCollapsed}
+        >
+            <span class="toggle-arrow">{smartCollapsed ? '▸' : '▾'}</span>
+            <span class="folders-toggle-label">Smart</span>
+            <span class="count">{formatSidebarCount(visibleSmartCollections.length)}</span>
+        </button>
+        {#if !smartCollapsed}
+            {#each visibleSmartCollections as sc}
+                <button class="section-item"
+                    class:active={$activeSmartCollection?.id === sc.id}
+                    onclick={() => selectSmartCollection(sc)}
+                    aria-current={$activeSmartCollection?.id === sc.id ? 'true' : undefined}>
+                    <span class="icon">&#9733;</span>
+                    <span class="item-label">{sc.name}</span>
+                    <span class="count">{formatSidebarCount(sc.image_count)}</span>
+                </button>
+            {/each}
+        {/if}
+    </div>
+    {/if}
+
+    <div class="section">
+        <div class="section-header">FILTERS</div>
+        <div class="filter-row">
+            <span class="filter-label">Min size</span>
+            <div class="filter-presets">
+                {#each SIZE_PRESETS as preset}
+                    <button
+                        class="preset-btn"
+                        class:active={$minSizeFilter === preset.value}
+                        onclick={() => handleSizeFilter(preset.value)}
+                    >{preset.label}</button>
+                {/each}
+            </div>
+        </div>
+        <label class="show-missing-toggle">
+            <input type="checkbox" bind:checked={$showMissing} />
+            Show missing files
+        </label>
+        {#if detectedClasses.length > 0}
+            <div class="detected-header">DETECTED OBJECTS</div>
+            {#each detectedClasses as [cls, count]}
+                <button
+                    class="section-item detected-class"
+                    class:active={$activeDetectedClass === cls}
+                    onclick={() => filterByClass(cls)}
+                    aria-current={$activeDetectedClass === cls ? 'true' : undefined}
+                >
+                    <span class="class-tag">{cls}</span>
+                    <span class="count">{formatSidebarCount(count)}</span>
+                </button>
+            {/each}
+        {/if}
+    </div>
+
     <div class="section clipboard-monitor">
-        <div class="section-header">CLIPBOARD MONITOR</div>
+        <button
+            class="folders-toggle"
+            onclick={() => toggleSection('clipboard')}
+            aria-expanded={!clipboardCollapsed}
+        >
+            <span class="toggle-arrow">{clipboardCollapsed ? '▸' : '▾'}</span>
+            <span class="folders-toggle-label">Clipboard Monitor</span>
+            {#if clipboardStatus?.running}
+                <span class="count running-dot" title="Monitor running">●</span>
+            {/if}
+        </button>
+        {#if !clipboardCollapsed}
         <button
             class="section-item"
             class:active={clipboardStatus?.running}
@@ -777,55 +1073,6 @@
                 >{clipboardPublishResult.url}</button>
             {/if}
         {/if}
-    </div>
-
-    {#if $smartCollections.length > 0}
-    <div class="section">
-        <div class="section-header">SMART</div>
-        {#each $smartCollections as sc}
-            <button class="section-item"
-                class:active={$activeSmartCollection?.id === sc.id}
-                onclick={() => selectSmartCollection(sc)}
-                aria-current={$activeSmartCollection?.id === sc.id ? 'true' : undefined}>
-                <span class="icon">&#9733;</span>
-                <span class="item-label">{sc.name}</span>
-                <span class="count">{formatSidebarCount(sc.image_count)}</span>
-            </button>
-        {/each}
-    </div>
-    {/if}
-
-    <div class="section">
-        <div class="section-header">FILTERS</div>
-        <div class="filter-row">
-            <span class="filter-label">Min size</span>
-            <div class="filter-presets">
-                {#each SIZE_PRESETS as preset}
-                    <button
-                        class="preset-btn"
-                        class:active={$minSizeFilter === preset.value}
-                        onclick={() => handleSizeFilter(preset.value)}
-                    >{preset.label}</button>
-                {/each}
-            </div>
-        </div>
-        <label class="show-missing-toggle">
-            <input type="checkbox" bind:checked={$showMissing} />
-            Show missing files
-        </label>
-        {#if detectedClasses.length > 0}
-            <div class="detected-header">DETECTED OBJECTS</div>
-            {#each detectedClasses as [cls, count]}
-                <button
-                    class="section-item detected-class"
-                    class:active={$activeDetectedClass === cls}
-                    onclick={() => filterByClass(cls)}
-                    aria-current={$activeDetectedClass === cls ? 'true' : undefined}
-                >
-                    <span class="class-tag">{cls}</span>
-                    <span class="count">{formatSidebarCount(count)}</span>
-                </button>
-            {/each}
         {/if}
     </div>
     </div>
@@ -1047,6 +1294,50 @@
         margin-left: auto;
         font-size: 11px;
         flex: none;
+    }
+    .sidebar-filter {
+        padding: var(--spacing) var(--spacing) 0;
+    }
+    .sidebar-filter-input {
+        background: var(--bg);
+        border: 1px solid var(--border);
+        border-radius: var(--radius);
+        color: var(--text);
+        font-family: inherit;
+        font-size: 11px;
+        min-height: 28px;
+        padding: 4px 8px;
+        width: 100%;
+    }
+    .sidebar-filter-input::placeholder {
+        color: var(--text-secondary);
+    }
+    .sidebar-filter-input:focus {
+        border-color: var(--blue);
+        outline: none;
+    }
+    .twisty {
+        background: none;
+        border: none;
+        color: var(--text-secondary);
+        cursor: pointer;
+        flex: none;
+        font-family: inherit;
+        font-size: 8px;
+        line-height: 1;
+        padding: 0;
+        width: 14px;
+    }
+    .twisty:hover {
+        color: var(--text);
+    }
+    .twisty-spacer {
+        flex: none;
+        width: 14px;
+    }
+    .running-dot {
+        color: var(--green);
+        font-size: 9px;
     }
     .folder-row {
         display: flex;

--- a/src/lib/persistence.ts
+++ b/src/lib/persistence.ts
@@ -5,6 +5,8 @@ import {
     activeSmartCollection, activeDetectedClass, minSizeFilter, loupeScale, loupePanX, loupePanY,
     lineageLayout, showDetectionBoxes, nsfwMode, embeddingViewState,
     focusedIndex, images,
+    pinnedCollection, pinnedCollections,
+    expandedFolders, sidebarSectionsCollapsed,
     resetLoupeTransform,
     type ViewMode, type LineageLayout, type NsfwMode, type EmbeddingViewState,
 } from './stores';
@@ -35,6 +37,12 @@ export interface PersistedState {
     showDetectionBoxes: boolean;
     nsfwMode: NsfwMode;
     embeddingViewState: EmbeddingViewState;
+    // Sidebar state. All optional so a state blob written before these fields
+    // existed still restores under the same SCHEMA_VERSION.
+    pinnedCollectionIds?: string[];
+    pinnedCollectionId?: string | null;
+    expandedFolders?: string[];
+    sidebarSectionsCollapsed?: string[];
 }
 
 export function saveAppState(): void {
@@ -61,6 +69,10 @@ export function saveAppState(): void {
         showDetectionBoxes: get(showDetectionBoxes),
         nsfwMode: get(nsfwMode),
         embeddingViewState: get(embeddingViewState),
+        pinnedCollectionIds: get(pinnedCollections),
+        pinnedCollectionId: get(pinnedCollection),
+        expandedFolders: [...get(expandedFolders)],
+        sidebarSectionsCollapsed: [...get(sidebarSectionsCollapsed)],
     };
     try {
         localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
@@ -94,6 +106,12 @@ export function restoreAppStateBeforeImages(): PersistedState | null {
         showDetectionBoxes.set(state.showDetectionBoxes);
         nsfwMode.set(state.nsfwMode);
         embeddingViewState.set(state.embeddingViewState);
+        // Pins are restored optimistically; Sidebar prunes ids whose collection
+        // no longer exists once the collection list arrives.
+        pinnedCollections.set(state.pinnedCollectionIds ?? []);
+        pinnedCollection.set(state.pinnedCollectionId ?? null);
+        expandedFolders.set(new Set(state.expandedFolders ?? []));
+        sidebarSectionsCollapsed.set(new Set(state.sidebarSectionsCollapsed ?? []));
         return state;
     } catch {
         return null;

--- a/src/lib/sidebar-audit-contract.test.ts
+++ b/src/lib/sidebar-audit-contract.test.ts
@@ -20,10 +20,23 @@ describe('sidebar audit fixes contract', () => {
         expect(presets).toContain('flex-wrap: wrap');
     });
 
-    it('does not expose a fake ARIA tree (H3)', () => {
-        expect(sidebar).not.toContain('role="tree"');
-        expect(sidebar).not.toContain('role="treeitem"');
-        expect(sidebar).not.toContain('aria-level');
+    // Supersedes the earlier "does not expose a fake ARIA tree" contract. That
+    // rule existed because the roles were present with no keyboard behaviour
+    // behind them. The behaviour now exists, so the requirement inverts: the
+    // roles must be there, and they must stay backed by real key handling.
+    it('exposes a real ARIA tree backed by keyboard navigation (H3)', () => {
+        expect(sidebar).toContain('role="tree"');
+        expect(sidebar).toContain('role="treeitem"');
+        expect(sidebar).toContain('aria-level');
+        expect(sidebar).toContain('handleTreeKeydown');
+        for (const key of ['ArrowDown', 'ArrowUp', 'ArrowLeft', 'ArrowRight', 'Home', 'End']) {
+            expect(sidebar).toContain(`'${key}'`);
+        }
+        // Roving tabindex: exactly one row is tabbable at a time, and the index
+        // is clamped so a shrinking list (filter typed, ancestor collapsed)
+        // cannot leave the tree with no tabbable row.
+        expect(sidebar).toContain('tabindex={i === treeTabIndex ? 0 : -1}');
+        expect(sidebar).toContain('Math.min(treeFocusIndex, visibleFolders.length - 1)');
     });
 
     it('session switcher dropdown is dismissible and announced (H4)', () => {
@@ -41,8 +54,12 @@ describe('sidebar audit fixes contract', () => {
         expect(page).toContain('<ConfirmDialog');
     });
 
-    it('orders content sections before utilities, with Collections and Clipboard high (M1)', () => {
-        const order = ['LIBRARY', 'COLLECTIONS', 'CLIPBOARD MONITOR', 'SMART', 'FILTERS'];
+    // Revises M1's ordering. The original principle — content first, utilities
+    // last — is kept, but Clipboard Monitor is a capture utility, not content,
+    // so ranking it above Smart contradicted the rule it was written under.
+    // Navigation targets (Library/Collections/Smart) now come first.
+    it('orders navigation targets before utilities (M1)', () => {
+        const order = ['LIBRARY', 'COLLECTIONS', 'Smart', 'FILTERS', 'Clipboard Monitor'];
         const positions = order.map(label => sidebar.indexOf(`>${label}<`) !== -1
             ? sidebar.indexOf(`>${label}<`)
             : sidebar.indexOf(label));

--- a/src/lib/sidebar-audit-contract.test.ts
+++ b/src/lib/sidebar-audit-contract.test.ts
@@ -39,6 +39,12 @@ describe('sidebar audit fixes contract', () => {
         expect(sidebar).toContain('Math.min(treeFocusIndex, visibleFolders.length - 1)');
     });
 
+    it('keeps folder removal available from the keyboard tree', () => {
+        expect(sidebar).toContain("case 'Delete':");
+        expect(sidebar).toContain('handleDeleteFolder(event, row.fullPath)');
+        expect(sidebar).toContain("aria-keyshortcuts={folder.isGroup ? undefined : 'Delete'}");
+    });
+
     it('session switcher dropdown is dismissible and announced (H4)', () => {
         expect(sessionSwitcher).toContain('aria-expanded={open}');
         expect(sessionSwitcher).toContain('aria-haspopup');

--- a/src/lib/sidebar-utils.test.ts
+++ b/src/lib/sidebar-utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { folderName, buildDisplayFolders, buildPinnedCollectionRows, formatImportResult, formatSidebarCount } from './sidebar-utils';
+import { folderName, buildDisplayFolders, buildPinnedCollectionRows, formatImportResult, formatSidebarCount, formatFolderCount, visibleFolderRows, prunePinnedIds } from './sidebar-utils';
 
 describe('folderName', () => {
     it('returns last segment of a path', () => {
@@ -168,5 +168,177 @@ describe('buildPinnedCollectionRows', () => {
         ];
 
         expect(buildPinnedCollectionRows(rows, ['missing', 'b']).map(([id]) => id)).toEqual(['b', 'a']);
+    });
+});
+
+describe('formatFolderCount', () => {
+    it('shows a single number when the folder has no subfolders', () => {
+        expect(formatFolderCount(4, 4)).toBe('4');
+    });
+
+    it('shows direct and subtree when they differ', () => {
+        expect(formatFolderCount(4, 27)).toBe('4 (27)');
+    });
+
+    it('shows 0 direct for a group folder that only carries descendants', () => {
+        expect(formatFolderCount(0, 27)).toBe('0 (27)');
+    });
+});
+
+describe('buildDisplayFolders subtree counts', () => {
+    it('sums descendants into subtreeCount while keeping the direct count', () => {
+        const rows = buildDisplayFolders([
+            // The sibling keeps /lib/photos from being swallowed by the
+            // common-prefix stripping.
+            ['/lib/other', 1],
+            ['/lib/photos', 4],
+            ['/lib/photos/sub', 20],
+            ['/lib/photos/sub/deep', 3],
+        ]);
+        const photos = rows.find(r => r.fullPath === '/lib/photos')!;
+        expect(photos.count).toBe(4);
+        expect(photos.subtreeCount).toBe(27);
+    });
+
+    it('gives group folders a real navigable path instead of an empty string', () => {
+        // /lib/art has no images of its own, so the backend never reports it.
+        const rows = buildDisplayFolders([
+            ['/lib/other', 1],
+            ['/lib/art/a', 2],
+            ['/lib/art/b', 3],
+        ]);
+        const group = rows.find(r => r.name === 'art')!;
+        expect(group.fullPath).toBe('/lib/art');
+        expect(group.isGroup).toBe(true);
+        expect(group.count).toBe(0);
+        expect(group.subtreeCount).toBe(5);
+    });
+
+    it('attributes a compressed single-child chain to its terminal folder', () => {
+        const rows = buildDisplayFolders([
+            ['/lib/a/b/c', 7],
+        ]);
+        expect(rows).toHaveLength(1);
+        expect(rows[0].fullPath).toBe('/lib/a/b/c');
+        expect(rows[0].count).toBe(7);
+        expect(rows[0].subtreeCount).toBe(7);
+    });
+});
+
+describe('visibleFolderRows', () => {
+    const tree = () => buildDisplayFolders([
+        ['/lib/art', 1],
+        ['/lib/art/raw', 2],
+        ['/lib/art/raw/nested', 3],
+        ['/lib/photos', 4],
+    ]);
+
+    it('hides descendants of a collapsed node', () => {
+        const rows = visibleFolderRows(tree(), new Set());
+        expect(rows.map(r => r.name)).toEqual(['art', 'photos']);
+    });
+
+    it('reveals one level per expanded node', () => {
+        const rows = visibleFolderRows(tree(), new Set(['/lib/art']));
+        expect(rows.map(r => r.name)).toEqual(['art', 'raw', 'photos']);
+    });
+
+    it('does not reveal a grandchild whose parent is still collapsed', () => {
+        const rows = visibleFolderRows(tree(), new Set(['/lib/art/raw']));
+        expect(rows.map(r => r.name)).toEqual(['art', 'photos']);
+    });
+
+    it('keeps ancestors of a filter match as context', () => {
+        const rows = visibleFolderRows(tree(), new Set(), 'nested');
+        expect(rows.map(r => r.name)).toEqual(['art', 'raw', 'nested']);
+    });
+
+    it('ignores collapse state while filtering', () => {
+        // Everything is collapsed, yet the match and its subtree still show.
+        const collapsedRows = visibleFolderRows(tree(), new Set(), 'raw');
+        expect(collapsedRows.map(r => r.name)).toEqual(['art', 'raw', 'nested']);
+    });
+
+    it('matches case-insensitively and returns nothing on no match', () => {
+        expect(visibleFolderRows(tree(), new Set(), 'PHOTOS').map(r => r.name)).toEqual(['photos']);
+        expect(visibleFolderRows(tree(), new Set(), 'zzz')).toEqual([]);
+    });
+});
+
+describe('prunePinnedIds', () => {
+    it('drops pins whose collection no longer exists', () => {
+        expect(prunePinnedIds(['a', 'gone', 'b'], [['a', 'A', 1], ['b', 'B', 2]])).toEqual(['a', 'b']);
+    });
+
+    it('preserves pin order', () => {
+        expect(prunePinnedIds(['b', 'a'], [['a', 'A', 1], ['b', 'B', 2]])).toEqual(['b', 'a']);
+    });
+});
+
+describe('buildDisplayFolders regression guards', () => {
+    it('keeps a folder that is itself the common prefix (its images used to vanish)', () => {
+        const rows = buildDisplayFolders([
+            ['/lib', 5],
+            ['/lib/sub', 3],
+        ]);
+        const lib = rows.find(r => r.fullPath === '/lib')!;
+        expect(lib).toBeDefined();
+        expect(lib.count).toBe(5);
+        expect(lib.subtreeCount).toBe(8);
+    });
+
+    it('still reconstructs a lone folder path', () => {
+        const rows = buildDisplayFolders([['/Photos', 5]]);
+        expect(rows).toHaveLength(1);
+        expect(rows[0].fullPath).toBe('/Photos');
+        expect(rows[0].subtreeCount).toBe(5);
+    });
+
+    it('emits the filesystem root instead of dropping it', () => {
+        // list_folders() returns ("/", n) for files stored at the root; with no
+        // path segments to walk, this used to vanish from the sidebar entirely.
+        const rows = buildDisplayFolders([['/', 3]]);
+        expect(rows).toHaveLength(1);
+        expect(rows[0].fullPath).toBe('/');
+        expect(rows[0].count).toBe(3);
+    });
+
+    it('renders the root alongside its siblings', () => {
+        const rows = buildDisplayFolders([['/', 3], ['/lib', 5]]);
+        expect(rows.map(r => r.fullPath)).toEqual(['/', '/lib']);
+        expect(rows[0].count).toBe(3);
+        expect(rows[0].subtreeCount).toBe(8);
+    });
+});
+
+describe('visibleFolderRows filter reveals matched subtrees', () => {
+    const groups = () => buildDisplayFolders([
+        ['/p/src/a', 5],
+        ['/p/src/b', 3],
+        ['/p/docs', 2],
+    ]);
+
+    it('shows children of a matched group instead of a dead end', () => {
+        // /p/src holds no images of its own. Excluding descendants would render
+        // one row advertising 8 images with no way to reach them, and the
+        // chevron cannot rescue it because filtering ignores expansion state.
+        const rows = visibleFolderRows(groups(), new Set(), 'src');
+        expect(rows.map(r => r.name)).toEqual(['src', 'a', 'b']);
+        expect(rows[0].isGroup).toBe(true);
+        expect(rows[0].subtreeCount).toBe(8);
+    });
+
+    it('keeps ancestors and descendants of a match', () => {
+        const rows = visibleFolderRows(buildDisplayFolders([
+            ['/lib/art', 1],
+            ['/lib/art/raw', 2],
+            ['/lib/art/raw/nested', 3],
+            ['/lib/photos', 4],
+        ]), new Set(), 'raw');
+        expect(rows.map(r => r.name)).toEqual(['art', 'raw', 'nested']);
+    });
+
+    it('excludes unrelated subtrees entirely', () => {
+        expect(visibleFolderRows(groups(), new Set(), 'docs').map(r => r.name)).toEqual(['docs']);
     });
 });

--- a/src/lib/sidebar-utils.ts
+++ b/src/lib/sidebar-utils.ts
@@ -1,10 +1,31 @@
 export interface DisplayFolder {
+    /** Display label. May be a compressed chain ("a/b/c") when intermediate
+     *  directories hold no images of their own. */
     name: string;
     disambig: string;
+    /** Real absolute path. Reconstructed for group nodes the backend never
+     *  reported, so every row is navigable. */
     fullPath: string;
+    /** Images whose immediate parent is this directory. */
     count: number;
+    /** count plus every descendant — what opening the row actually loads,
+     *  because list_images_by_folder matches on the `path/%` prefix. */
+    subtreeCount: number;
     depth: number;
     hasChildren: boolean;
+    /** True when the directory holds no images of its own and exists in the
+     *  tree only to carry descendants. */
+    isGroup: boolean;
+}
+
+/**
+ * The count shown on a folder row. Opening a folder is recursive while the
+ * backend's per-folder count is not, so a single number is always a lie for
+ * one of the two. Show both when they differ: "4 (27)" reads as "4 here, 27
+ * including subfolders".
+ */
+export function formatFolderCount(direct: number, subtree: number): string {
+    return direct === subtree ? String(subtree) : `${direct} (${subtree})`;
 }
 
 export function folderName(path: string): string {
@@ -35,19 +56,28 @@ export function buildDisplayFolders(flatFolders: [string, number][]): DisplayFol
     if (flatFolders.length === 0) return [];
 
     const allSegments = flatFolders.map(([p]) => p.split('/').filter(s => s.length > 0));
-    const commonPrefix = findCommonPrefixLength(allSegments);
+    // Never strip a path down to nothing: a folder that is itself the common
+    // prefix (e.g. /lib alongside /lib/sub) would land on the sentinel root,
+    // which flatten() never emits, silently dropping its images from the tree.
+    const shortestPath = Math.min(...allSegments.map(s => s.length));
+    const commonPrefix = Math.min(findCommonPrefixLength(allSegments), Math.max(0, shortestPath - 1));
 
     const root: TrieNode = { segment: '', fullPath: '', count: 0, children: new Map() };
 
     for (const [fullPath, count] of flatFolders) {
-        const segments = fullPath.split('/').filter(s => s.length > 0).slice(commonPrefix);
+        const allSegments = fullPath.split('/').filter(s => s.length > 0);
+        const segments = allSegments.slice(commonPrefix);
         let node = root;
         for (let i = 0; i < segments.length; i++) {
             const seg = segments[i];
             if (!node.children.has(seg)) {
                 node.children.set(seg, {
                     segment: seg,
-                    fullPath: '',
+                    // Intermediate directories are never reported by the
+                    // backend (they hold no images of their own), so rebuild
+                    // their absolute path from the segments we walked through.
+                    // Without this they carry '' and cannot be navigated to.
+                    fullPath: '/' + allSegments.slice(0, commonPrefix + i + 1).join('/'),
                     count: 0,
                     children: new Map(),
                 });
@@ -57,6 +87,18 @@ export function buildDisplayFolders(flatFolders: [string, number][]): DisplayFol
         node.fullPath = fullPath;
         node.count = count;
     }
+
+    // Post-order subtree sums, computed once so each row can show both numbers.
+    const subtreeCounts = new Map<TrieNode, number>();
+    function sumSubtree(node: TrieNode): number {
+        let total = node.count;
+        for (const child of node.children.values()) {
+            total += sumSubtree(child);
+        }
+        subtreeCounts.set(node, total);
+        return total;
+    }
+    sumSubtree(root);
 
     const result: DisplayFolder[] = [];
 
@@ -79,8 +121,10 @@ export function buildDisplayFolders(flatFolders: [string, number][]): DisplayFol
                 disambig: '',
                 fullPath: current.fullPath,
                 count: current.count,
+                subtreeCount: subtreeCounts.get(current) ?? current.count,
                 depth,
                 hasChildren: current.children.size > 0,
+                isGroup: current.count === 0,
             });
 
             if (current.children.size > 0) {
@@ -89,7 +133,84 @@ export function buildDisplayFolders(flatFolders: [string, number][]): DisplayFol
         }
     }
 
+    // A path with no segments at all (the filesystem root, "/") never enters the
+    // walk, so its images would vanish from the sidebar entirely. list_folders()
+    // does return ("/", n) for files stored at the root, so emit it explicitly.
+    if (root.count > 0) {
+        result.unshift({
+            name: '/',
+            disambig: '',
+            fullPath: '/',
+            count: root.count,
+            subtreeCount: subtreeCounts.get(root) ?? root.count,
+            depth: 0,
+            hasChildren: false,
+            isGroup: false,
+        });
+    }
+
     flatten(root, 0);
+    return result;
+}
+
+/**
+ * The ordered list of rows the tree should actually render, after applying
+ * per-node expansion and the sidebar filter. This is the single source the
+ * render loop and the keyboard handler both read, so arrow-key movement can
+ * never land on a row that is not on screen.
+ *
+ * Filter semantics: a row is kept when its own label matches. Ancestors are
+ * kept as context (otherwise a match renders at an orphaned indent) and so are
+ * descendants. Descendants have to be included: a matched *group* row shows a
+ * subtree count but has no images of its own, so excluding its children would
+ * advertise "8 images" while offering no way to see them — and the chevron
+ * cannot rescue it, because filtering ignores the expansion state. While a
+ * filter is active that state is ignored, since a hit hidden inside a collapsed
+ * branch would make the filter look broken.
+ */
+export function visibleFolderRows(
+    folders: DisplayFolder[],
+    expanded: Set<string>,
+    filterQuery = ''
+): DisplayFolder[] {
+    const query = filterQuery.trim().toLowerCase();
+
+    if (query) {
+        const keep = new Array<boolean>(folders.length).fill(false);
+        // Forward pre-order walk. `openAncestors` holds the indices of the rows
+        // currently on the path to the root, so a match can mark its context
+        // without parent pointers.
+        const openAncestors: number[] = [];
+        for (let i = 0; i < folders.length; i++) {
+            const row = folders[i];
+            while (openAncestors.length && folders[openAncestors[openAncestors.length - 1]].depth >= row.depth) {
+                openAncestors.pop();
+            }
+            if (row.name.toLowerCase().includes(query)) {
+                keep[i] = true;
+                for (const a of openAncestors) keep[a] = true;
+                // Descendants are a contiguous strictly-deeper run in pre-order.
+                for (let k = i + 1; k < folders.length && folders[k].depth > row.depth; k++) {
+                    keep[k] = true;
+                }
+            }
+            openAncestors.push(i);
+        }
+        return folders.filter((_, i) => keep[i]);
+    }
+
+    const result: DisplayFolder[] = [];
+    // Depth of the shallowest collapsed ancestor; rows deeper than it are hidden
+    // until we return to that depth or above.
+    let hiddenBelowDepth: number | null = null;
+    for (const row of folders) {
+        if (hiddenBelowDepth !== null && row.depth > hiddenBelowDepth) continue;
+        hiddenBelowDepth = null;
+        result.push(row);
+        if (row.hasChildren && !expanded.has(row.fullPath)) {
+            hiddenBelowDepth = row.depth;
+        }
+    }
     return result;
 }
 
@@ -106,6 +227,28 @@ export function formatSidebarCount(count: number | null | undefined): string {
 }
 
 export type CollectionRow = [string, string, number];
+
+/**
+ * Drop pinned ids whose collection no longer exists. Pins are restored from
+ * localStorage before the collection list arrives, so a collection deleted in
+ * another window (or in a previous session) would otherwise linger as a pin
+ * that can never be seen or cleared.
+ */
+/** Case-insensitive substring match used by the sidebar filter. An empty or
+ *  whitespace-only query matches everything, so clearing the box restores the
+ *  full list rather than emptying it. */
+export function matchesSidebarFilter(name: string, query: string): boolean {
+    const q = query.trim().toLowerCase();
+    return q === '' || name.toLowerCase().includes(q);
+}
+
+export function prunePinnedIds(
+    pinnedIds: string[],
+    collections: CollectionRow[]
+): string[] {
+    const live = new Set(collections.map(([id]) => id));
+    return pinnedIds.filter(id => live.has(id));
+}
 
 export function buildPinnedCollectionRows(
     collections: CollectionRow[],

--- a/src/lib/stores.ts
+++ b/src/lib/stores.ts
@@ -443,6 +443,16 @@ export const pinnedCollection = writable<string | null>(null);
 // Sidebar collection pins, ordered by the time they were pinned.
 export const pinnedCollections = writable<string[]>([]);
 
+// Folder-tree rows the user has expanded, keyed by full folder path. Persisted,
+// so a deep working branch survives a relaunch.
+export const expandedFolders = writable<Set<string>>(new Set());
+// Sidebar sections the user has collapsed, keyed by section id. Collapsed (not
+// expanded) is the stored state so a section added later defaults to open.
+export const sidebarSectionsCollapsed = writable<Set<string>>(new Set());
+// Free-text filter narrowing folders, collections and smart collections in the
+// sidebar. Transient by design — a stale filter on launch reads as data loss.
+export const sidebarFilter = writable<string>('');
+
 // Lineage tab layout preference
 export type LineageLayout = 'timeline' | 'comparison';
 export const lineageLayout = writable<LineageLayout>('timeline');


### PR DESCRIPTION
Summary: shows direct/recursive folder counts, preserves root/common-prefix folders, uses literal case-sensitive folder matching, adds persistent expansion and a keyboard-accessible ARIA tree, filters sidebar destinations, promotes Recent Imports, persists/prunes pins, and keeps folder removal keyboard-accessible via Delete plus Cull's confirmation dialog. Extraction safety: only archived b6f578644 plus one review fix; excludes Beads commit 78868544 and preceding stack commits; preserves current AI Settings and does not reintroduce archived inline AI Models UI. Validation: full pre-push passed; Svelte 0/0; frontend 149 files and 1167 tests; fmt/clippy passed with baseline warnings; Rust 761 passed, 3 ignored, plus integration suites. Tracks imageview-htfg.7.