### PR TITLE
Recover pixel overview and hover lens as a scoped feature

### DIFF
--- a/src/lib/components/Grid.svelte
+++ b/src/lib/components/Grid.svelte
@@ -26,6 +26,7 @@
         GRID_OVERVIEW_MAX_SIZE,
     } from '$lib/grid-overview';
     import {
+        gridHoverGroupBounds,
         gridIndexAtPointer,
         planGridHoverPreview,
         type GridHoverPreviewPlan,
@@ -194,8 +195,8 @@
     }
 
     let hoverPlan = $state<GridHoverPreviewPlan | null>(null);
-    let hoverX = $state(0);
-    let hoverY = $state(0);
+    let hoverAnchor = $state({ left: 0, top: 0, width: 1, height: 1 });
+    let hoverShape = $state({ rows: 1, cols: 1 });
     let hoverItems = $derived.by<ImageWithFile[]>(() => {
         const plan = hoverPlan;
         if (!plan) return [];
@@ -218,9 +219,7 @@
         if (!containerEl || event.pointerType === 'touch') return;
         const pointer = gridPointerCoordinates(event);
         if (!pointer) return;
-        hoverX = event.clientX;
-        hoverY = event.clientY;
-        hoverPlan = planGridHoverPreview({
+        const plan = planGridHoverPreview({
             pointerX: pointer.x,
             pointerY: pointer.y,
             scrollTop,
@@ -229,6 +228,35 @@
             thumbnailSize: size,
             totalItems: $images.length,
         });
+        hoverPlan = plan;
+        if (!plan) return;
+
+        const rect = containerEl.getBoundingClientRect();
+        const styles = getComputedStyle(containerEl);
+        const paddingLeft = Number.parseFloat(styles.paddingLeft) || 0;
+        const paddingTop = Number.parseFloat(styles.paddingTop) || 0;
+        const row = Math.floor(plan.anchorIndex / cols);
+        const col = plan.anchorIndex % cols;
+
+        if (plan.mode === 'single') {
+            hoverShape = { rows: 1, cols: 1 };
+            hoverAnchor = {
+                left: rect.left + paddingLeft + col * cellSize,
+                top: rect.top + paddingTop + row * cellSize - scrollTop,
+                width: size,
+                height: size,
+            };
+            return;
+        }
+
+        const bounds = gridHoverGroupBounds(plan.anchorIndex, cols, cellSize, $images.length);
+        hoverShape = { rows: bounds.rows, cols: bounds.cols };
+        hoverAnchor = {
+            left: rect.left + paddingLeft + bounds.startCol * cellSize,
+            top: rect.top + paddingTop + bounds.startRow * cellSize - scrollTop,
+            width: bounds.cols * cellSize,
+            height: bounds.rows * cellSize,
+        };
     }
 
     function overviewIndex(event: MouseEvent): number | null {
@@ -549,9 +577,7 @@
 </div>
 
 {#if hoverPlan && hoverItems.length > 0}
-    {#key hoverPlan.previewKey}
-        <GridHoverPreview plan={hoverPlan} items={hoverItems} x={hoverX} y={hoverY} />
-    {/key}
+    <GridHoverPreview plan={hoverPlan} items={hoverItems} anchor={hoverAnchor} sourceShape={hoverShape} />
 {/if}
 
 <style>

--- a/src/lib/components/Grid.svelte
+++ b/src/lib/components/Grid.svelte
@@ -195,8 +195,22 @@
     }
 
     let hoverPlan = $state<GridHoverPreviewPlan | null>(null);
+    let hoverSessionId = $state(0);
     let hoverAnchor = $state({ left: 0, top: 0, width: 1, height: 1 });
     let hoverShape = $state({ rows: 1, cols: 1 });
+    let previousHoverLayout: string | null = null;
+
+    $effect(() => {
+        const layoutKey = `${size}:${gap}:${cols}:${containerWidth}:${containerHeight}:${window.innerWidth}:${window.innerHeight}`;
+        if (previousHoverLayout === null) {
+            previousHoverLayout = layoutKey;
+            return;
+        }
+        if (layoutKey === previousHoverLayout) return;
+        previousHoverLayout = layoutKey;
+        hoverPlan = null;
+    });
+
     let hoverItems = $derived.by<ImageWithFile[]>(() => {
         const plan = hoverPlan;
         if (!plan) return [];
@@ -476,6 +490,7 @@
     tabindex="-1"
     aria-label={"Image grid, " + $images.length + " images"}
     onpointermove={updateHoverPreview}
+    onpointerenter={() => hoverSessionId += 1}
     onpointerleave={() => hoverPlan = null}
 >
     {#if libraryViewState === 'error'}
@@ -577,7 +592,9 @@
 </div>
 
 {#if hoverPlan && hoverItems.length > 0}
-    <GridHoverPreview plan={hoverPlan} items={hoverItems} anchor={hoverAnchor} sourceShape={hoverShape} />
+    {#key hoverSessionId}
+        <GridHoverPreview plan={hoverPlan} items={hoverItems} anchor={hoverAnchor} sourceShape={hoverShape} />
+    {/key}
 {/if}
 
 <style>

--- a/src/lib/components/Grid.svelte
+++ b/src/lib/components/Grid.svelte
@@ -4,7 +4,8 @@
     import { open } from '@tauri-apps/plugin-dialog';
     import { images, selectedIds, selectionAnchorIndex, focusedIndex, thumbnailSize, viewMode, gridGap, gridScrollTop, navigateTo, imageLoadState, showToast, totalCount, folders, gridPreset, GRID_PRESETS, activeSmartCollection, activeCollection, activeDetectedClass, activeFolder, minSizeFilter, clipboardMonitorStatus } from '$lib/stores';
     import { importFolder as apiImportFolder, getImageCount, listFolders } from '$lib/api';
-    import { IMAGE_PAGE_SIZE, loadImagesForCurrentScope, loadMoreImagesForCurrentScope } from '$lib/image-loading';
+    import type { ImageWithFile } from '$lib/api';
+    import { IMAGE_OVERVIEW_PAGE_SIZE, IMAGE_PAGE_SIZE, loadImagesForCurrentScope, loadMoreImagesForCurrentScope } from '$lib/image-loading';
     import { wheelGestureIntent } from '$lib/gesture-interactions';
     import { gridGestureZoom } from '$lib/grid-gesture-zoom';
     import { resolveLibraryViewState, scopeEmptyCopy, type LibraryScopeKind } from '$lib/library-view-state';
@@ -20,7 +21,18 @@
         type ScrollDirection,
     } from '$lib/view-utils';
     import { createPrefetchCache } from '$lib/prefetch-cache';
+    import {
+        GRID_FULL_SCOPE_OVERVIEW_MAX_SIZE,
+        GRID_OVERVIEW_MAX_SIZE,
+    } from '$lib/grid-overview';
+    import {
+        gridIndexAtPointer,
+        planGridHoverPreview,
+        type GridHoverPreviewPlan,
+    } from '$lib/grid-hover-preview';
     import clipboardMonitorEmptySrc from '$lib/assets/clipboard-monitor-empty.png';
+    import GridHoverPreview from './GridHoverPreview.svelte';
+    import GridOverviewCanvas from './GridOverviewCanvas.svelte';
     import Thumbnail from './Thumbnail.svelte';
 
     let containerEl: HTMLDivElement | undefined = $state(undefined);
@@ -62,6 +74,7 @@
 
     let visibleItems = $derived.by(() => {
         const imgs = $images;
+        if (size <= GRID_OVERVIEW_MAX_SIZE) return [];
         return computeVisibleItems(scrollTop, containerHeight, layout.cols, layout.cellSize, imgs.length, {
             overscanRowsBefore: overscan.before,
             overscanRowsAfter: overscan.after,
@@ -70,6 +83,7 @@
     });
 
     function warmPrefetch() {
+        if (size <= GRID_OVERVIEW_MAX_SIZE) return;
         if (cellSize <= 0 || cols <= 0) return;
         const imgs = $images;
         const indices = computePrefetchIndices(
@@ -112,6 +126,7 @@
     }
 
     function onScroll(e: Event) {
+        hoverPlan = null;
         const nextScrollTop = (e.target as HTMLDivElement).scrollTop;
         scrollDir = computeScrollDirection(prevScrollTop, nextScrollTop, scrollDir);
         prevScrollTop = nextScrollTop;
@@ -178,6 +193,67 @@
         navigateTo('loupe');
     }
 
+    let hoverPlan = $state<GridHoverPreviewPlan | null>(null);
+    let hoverX = $state(0);
+    let hoverY = $state(0);
+    let hoverItems = $derived.by<ImageWithFile[]>(() => {
+        const plan = hoverPlan;
+        if (!plan) return [];
+        return plan.indices
+            .map(index => $images[index])
+            .filter((item): item is ImageWithFile => item !== undefined);
+    });
+
+    function gridPointerCoordinates(event: MouseEvent): { x: number; y: number } | null {
+        if (!containerEl) return null;
+        const rect = containerEl.getBoundingClientRect();
+        const styles = getComputedStyle(containerEl);
+        return {
+            x: event.clientX - rect.left - (Number.parseFloat(styles.paddingLeft) || 0),
+            y: event.clientY - rect.top - (Number.parseFloat(styles.paddingTop) || 0),
+        };
+    }
+
+    function updateHoverPreview(event: PointerEvent) {
+        if (!containerEl || event.pointerType === 'touch') return;
+        const pointer = gridPointerCoordinates(event);
+        if (!pointer) return;
+        hoverX = event.clientX;
+        hoverY = event.clientY;
+        hoverPlan = planGridHoverPreview({
+            pointerX: pointer.x,
+            pointerY: pointer.y,
+            scrollTop,
+            cols,
+            cellSize,
+            thumbnailSize: size,
+            totalItems: $images.length,
+        });
+    }
+
+    function overviewIndex(event: MouseEvent): number | null {
+        const pointer = gridPointerCoordinates(event);
+        if (!pointer) return null;
+        return gridIndexAtPointer(
+            pointer.x,
+            pointer.y,
+            scrollTop,
+            cols,
+            cellSize,
+            $images.length,
+        );
+    }
+
+    function handleOverviewClick(event: MouseEvent) {
+        const index = overviewIndex(event);
+        if (index !== null) handleClick(index, event);
+    }
+
+    function handleOverviewDblClick(event: MouseEvent) {
+        const index = overviewIndex(event);
+        if (index !== null) handleDblClick(index);
+    }
+
     $effect(() => {
         if (!containerEl) return;
         const ro = new ResizeObserver((entries) => {
@@ -202,6 +278,16 @@
         $imageLoadState.loadingMore;
         maybeLoadMore();
         warmPrefetch();
+    });
+
+    // Pixel overview represents the full scope, not only the first paged window.
+    // Load remaining metadata progressively; image decoding stays bounded in the canvas.
+    $effect(() => {
+        if (size > GRID_FULL_SCOPE_OVERVIEW_MAX_SIZE) return;
+        if (!$imageLoadState.hasMore || $imageLoadState.loading || $imageLoadState.loadingMore) return;
+        $images.length;
+        const timer = window.setTimeout(() => void loadMoreImagesForCurrentScope(IMAGE_OVERVIEW_PAGE_SIZE), 16);
+        return () => window.clearTimeout(timer);
     });
 
     $effect(() => {
@@ -359,7 +445,10 @@
     onscroll={onScroll}
     onwheel={handleWheel}
     role="grid"
+    tabindex="-1"
     aria-label={"Image grid, " + $images.length + " images"}
+    onpointermove={updateHoverPreview}
+    onpointerleave={() => hoverPlan = null}
 >
     {#if libraryViewState === 'error'}
         <div class="load-error" role="alert" data-testid="library-error-banner">
@@ -411,37 +500,59 @@
         </div>
     {:else}
         <div class="grid-scroll" style="height: {totalHeight}px; position: relative;">
-            {#each visibleItems.filter(vi => vi.item) as vi (vi.item.image.id)}
-                <div
-                    class="grid-cell"
-                    style="position: absolute; left: {vi.x}px; top: {vi.y}px; width: {size}px; height: {size}px;"
-                    data-agent-image-id={vi.item.image.id}
-                    data-agent-filename={vi.item.path.split('/').filter(Boolean).pop() ?? vi.item.image.id}
-                    data-agent-path={vi.item.path}
-                    data-agent-thumbnail-path={vi.item.thumbnail_path ?? ''}
-                    data-agent-rating={vi.item.selection?.star_rating ?? ''}
-                    data-agent-decision={vi.item.selection?.decision ?? 'undecided'}
-                    data-agent-selected={$selectedIds.has(vi.item.image.id)}
-                    data-agent-focused={$focusedIndex === vi.index}
-                    data-agent-view-role="grid-cell"
-                >
-                    <Thumbnail
-                        item={vi.item}
-                        {size}
-                        focused={$focusedIndex === vi.index}
-                        selected={$selectedIds.has(vi.item.image.id)}
-                        onclick={(event) => handleClick(vi.index, event)}
-                        ondblclick={() => handleDblClick(vi.index)}
-                        loading="eager"
-                    />
-                </div>
-            {/each}
+            {#if size <= GRID_OVERVIEW_MAX_SIZE}
+                <GridOverviewCanvas
+                    items={$images}
+                    width={containerWidth}
+                    height={containerHeight}
+                    {scrollTop}
+                    {size}
+                    {gap}
+                    {cols}
+                    focusedIndex={$focusedIndex}
+                    selectedIds={$selectedIds}
+                    onclick={handleOverviewClick}
+                    ondblclick={handleOverviewDblClick}
+                />
+            {:else}
+                {#each visibleItems.filter(vi => vi.item) as vi (vi.item.image.id)}
+                    <div
+                        class="grid-cell"
+                        style="position: absolute; left: {vi.x}px; top: {vi.y}px; width: {size}px; height: {size}px;"
+                        data-agent-image-id={vi.item.image.id}
+                        data-agent-filename={vi.item.path.split('/').filter(Boolean).pop() ?? vi.item.image.id}
+                        data-agent-path={vi.item.path}
+                        data-agent-thumbnail-path={vi.item.thumbnail_path ?? ''}
+                        data-agent-rating={vi.item.selection?.star_rating ?? ''}
+                        data-agent-decision={vi.item.selection?.decision ?? 'undecided'}
+                        data-agent-selected={$selectedIds.has(vi.item.image.id)}
+                        data-agent-focused={$focusedIndex === vi.index}
+                        data-agent-view-role="grid-cell"
+                    >
+                        <Thumbnail
+                            item={vi.item}
+                            {size}
+                            focused={$focusedIndex === vi.index}
+                            selected={$selectedIds.has(vi.item.image.id)}
+                            onclick={(event) => handleClick(vi.index, event)}
+                            ondblclick={() => handleDblClick(vi.index)}
+                            loading="eager"
+                        />
+                    </div>
+                {/each}
+            {/if}
         </div>
         {#if $imageLoadState.loadingMore}
             <div class="load-indicator" aria-live="polite">Loading</div>
         {/if}
     {/if}
 </div>
+
+{#if hoverPlan && hoverItems.length > 0}
+    {#key hoverPlan.previewKey}
+        <GridHoverPreview plan={hoverPlan} items={hoverItems} x={hoverX} y={hoverY} />
+    {/key}
+{/if}
 
 <style>
     .grid-container {

--- a/src/lib/components/GridHoverPreview.svelte
+++ b/src/lib/components/GridHoverPreview.svelte
@@ -1,0 +1,124 @@
+<script lang="ts">
+    import { convertFileSrc } from '@tauri-apps/api/core';
+    import type { ImageWithFile } from '$lib/api';
+    import type { GridHoverPreviewPlan } from '$lib/grid-hover-preview';
+    import { safeAssetPreviewPath } from '$lib/view-utils';
+
+    interface Props {
+        plan: GridHoverPreviewPlan;
+        items: ImageWithFile[];
+        x: number;
+        y: number;
+    }
+
+    let { plan, items, x, y }: Props = $props();
+    let previewWidth = $derived(plan.mode === 'single' ? 320 : 284);
+    let left = $derived(Math.max(12, Math.min(x + 18, window.innerWidth - previewWidth - 12)));
+    let top = $derived(Math.max(12, Math.min(y + 18, window.innerHeight - (plan.mode === 'single' ? 286 : 332))));
+
+    function previewSrc(item: ImageWithFile): string {
+        const path = safeAssetPreviewPath(item, { displayPx: plan.mode === 'single' ? 320 : 88, dpr: window.devicePixelRatio || 1 });
+        return path ? convertFileSrc(path) : '';
+    }
+
+    function filename(item: ImageWithFile): string {
+        return item.path.split('/').filter(Boolean).pop() ?? item.image.id;
+    }
+</script>
+
+<aside
+    class="hover-preview"
+    class:group={plan.mode === 'group'}
+    style="left: {left}px; top: {top}px; width: {previewWidth}px;"
+    aria-hidden="true"
+>
+    {#if plan.mode === 'single' && items[0]}
+        {@const src = previewSrc(items[0])}
+        <div class="single-image">
+            {#if src}<img {src} alt="" />{/if}
+        </div>
+        <div class="caption">{filename(items[0])}</div>
+    {:else}
+        <div class="preview-grid">
+            {#each items as item (item.image.id)}
+                {@const src = previewSrc(item)}
+                <div class="preview-cell">
+                    {#if src}<img {src} alt="" />{/if}
+                </div>
+            {/each}
+        </div>
+        <div class="caption">{plan.groupCount} images around pointer</div>
+    {/if}
+</aside>
+
+<style>
+    .hover-preview {
+        position: fixed;
+        z-index: 320;
+        pointer-events: none;
+        padding: 8px;
+        border: 1px solid var(--border);
+        border-radius: calc(var(--radius) * 2);
+        background: color-mix(in srgb, var(--surface) 94%, transparent);
+        box-shadow: 0 16px 48px color-mix(in srgb, var(--bg) 78%, transparent), 0 0 0 1px color-mix(in srgb, var(--blue) 12%, transparent);
+        backdrop-filter: blur(14px);
+        transform-origin: 18px 18px;
+        transition: left 180ms cubic-bezier(0.22, 1, 0.36, 1), top 180ms cubic-bezier(0.22, 1, 0.36, 1);
+        animation: preview-arrive 220ms cubic-bezier(0.16, 1, 0.3, 1);
+        will-change: left, top, transform, opacity;
+    }
+
+    .single-image {
+        width: 100%;
+        height: 232px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        overflow: hidden;
+        border-radius: var(--radius);
+        background: var(--bg);
+    }
+
+    img {
+        width: 100%;
+        height: 100%;
+        object-fit: contain;
+        display: block;
+    }
+
+    .preview-grid {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: 3px;
+    }
+
+    .preview-cell {
+        aspect-ratio: 1;
+        overflow: hidden;
+        border-radius: var(--radius);
+        background: var(--bg);
+    }
+
+    .preview-cell img {
+        object-fit: cover;
+    }
+
+    .caption {
+        margin-top: 7px;
+        overflow: hidden;
+        color: var(--text-secondary);
+        font-size: 10px;
+        line-height: 14px;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+
+    @keyframes preview-arrive {
+        from { opacity: 0; transform: translateY(7px) scale(0.94); }
+        to { opacity: 1; transform: translateY(0) scale(1); }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+        .hover-preview { animation-duration: 1ms; }
+    }
+</style>

--- a/src/lib/components/GridHoverPreview.svelte
+++ b/src/lib/components/GridHoverPreview.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
     import { convertFileSrc } from '@tauri-apps/api/core';
+    import { untrack } from 'svelte';
     import { cubicOut } from 'svelte/easing';
     import { fade } from 'svelte/transition';
     import type { ImageWithFile } from '$lib/api';
@@ -34,13 +35,14 @@
         };
     }
 
-    let previewColumns = $derived.by(() => {
+    function previewColumnsForCurrentSource(): number {
         if (plan.mode !== 'group') return 1;
         if (items.length === plan.groupCount) return Math.max(1, sourceShape.cols);
         const aspect = Math.max(1, sourceShape.cols) / Math.max(1, sourceShape.rows);
         return Math.max(1, Math.ceil(Math.sqrt(items.length * aspect)));
-    });
-    let previewSize = $derived.by(() => {
+    }
+
+    function previewSizeForCurrentSource(): { width: number; height: number } {
         if (plan.mode === 'group' || !items[0]) {
             const aspect = Math.max(1, sourceShape.cols) / Math.max(1, sourceShape.rows);
             const width = aspect >= 1 ? groupExtent : groupExtent * aspect;
@@ -57,37 +59,49 @@
             width: Math.max(1, Math.round(imageWidth * scale)),
             height: Math.max(1, Math.round(imageHeight * scale)),
         };
-    });
-    let left = $derived(Math.max(
-        viewportInset,
-        Math.min(
-            anchor.left + anchor.width / 2 - previewSize.width / 2,
-            window.innerWidth - previewSize.width - viewportInset,
-        ),
-    ));
-    let top = $derived(Math.max(
-        viewportInset,
-        Math.min(
-            anchor.top + anchor.height / 2 - previewSize.height / 2,
-            window.innerHeight - previewSize.height - viewportInset,
-        ),
-    ));
-    let originX = $derived(anchor.left + anchor.width / 2 - left);
-    let originY = $derived(anchor.top + anchor.height / 2 - top);
-    let sourceScale = $derived.by(() => {
+    }
+
+    function sourceScaleForCurrentSource(
+        size: { width: number; height: number },
+        sourceAnchor: { left: number; top: number; width: number; height: number },
+    ): number {
         if (plan.mode === 'group') {
             return Math.max(0.015, Math.min(
                 1,
-                anchor.width / previewSize.width,
-                anchor.height / previewSize.height,
+                sourceAnchor.width / size.width,
+                sourceAnchor.height / size.height,
             ));
         }
         const item = items[0];
         if (!item) return 0.1;
         const aspect = Math.max(1, item.image.width) / Math.max(1, item.image.height);
-        const containedWidth = Math.min(anchor.width, anchor.height * aspect);
-        return Math.max(0.015, Math.min(1, containedWidth / previewSize.width));
-    });
+        const containedWidth = Math.min(sourceAnchor.width, sourceAnchor.height * aspect);
+        return Math.max(0.015, Math.min(1, containedWidth / size.width));
+    }
+
+    // A hover session gets one stable lens. Content changes inside it, but its
+    // geometry does not chase every thumbnail under the pointer.
+    let previewColumns = $derived(previewColumnsForCurrentSource());
+    let previewRows = $derived(Math.max(1, Math.ceil(items.length / previewColumns)));
+    const lensSize = previewSizeForCurrentSource();
+    const initialAnchor = untrack(() => ({ ...anchor }));
+    const lensLeft = Math.max(
+        viewportInset,
+        Math.min(
+            initialAnchor.left + initialAnchor.width / 2 - lensSize.width / 2,
+            window.innerWidth - lensSize.width - viewportInset,
+        ),
+    );
+    const lensTop = Math.max(
+        viewportInset,
+        Math.min(
+            initialAnchor.top + initialAnchor.height / 2 - lensSize.height / 2,
+            window.innerHeight - lensSize.height - viewportInset,
+        ),
+    );
+    const lensOriginX = initialAnchor.left + initialAnchor.width / 2 - lensLeft;
+    const lensOriginY = initialAnchor.top + initialAnchor.height / 2 - lensTop;
+    const lensSourceScale = sourceScaleForCurrentSource(lensSize, initialAnchor);
 
     function previewSrc(item: ImageWithFile): string {
         const path = safeAssetPreviewPath(item, { displayPx: plan.mode === 'single' ? 320 : 88, dpr: window.devicePixelRatio || 1 });
@@ -99,10 +113,10 @@
 <aside
     class="hover-preview"
     class:group={plan.mode === 'group'}
-    style:--preview-origin-x={`${originX}px`}
-    style:--preview-origin-y={`${originY}px`}
-    style="left: {left}px; top: {top}px; width: {previewSize.width}px; height: {previewSize.height}px;"
-    transition:organicZoom={{ start: sourceScale }}
+    style:--preview-origin-x={`${lensOriginX}px`}
+    style:--preview-origin-y={`${lensOriginY}px`}
+    style="left: {lensLeft}px; top: {lensTop}px; width: {lensSize.width}px; height: {lensSize.height}px;"
+    transition:organicZoom={{ start: lensSourceScale }}
     aria-hidden="true"
 >
     {#if plan.mode === 'single' && items[0]}
@@ -116,7 +130,8 @@
         {#key plan.previewKey}
             <div
                 class="preview-grid"
-                style:grid-template-columns={`repeat(${previewColumns}, 1fr)`}
+                style:grid-template-columns={`repeat(${previewColumns}, minmax(0, 1fr))`}
+                style:grid-template-rows={`repeat(${previewRows}, minmax(0, 1fr))`}
                 transition:fade={{ duration: reduceMotion ? 0 : 120 }}
             >
                 {#each items as item (item.image.id)}
@@ -140,14 +155,11 @@
         background: var(--surface);
         box-shadow: 0 22px 70px color-mix(in srgb, var(--bg) 72%, transparent);
         transform-origin: var(--preview-origin-x) var(--preview-origin-y);
-        transition: left 220ms cubic-bezier(0.22, 1, 0.36, 1),
-            top 220ms cubic-bezier(0.22, 1, 0.36, 1),
-            width 220ms cubic-bezier(0.22, 1, 0.36, 1),
-            height 220ms cubic-bezier(0.22, 1, 0.36, 1);
         will-change: left, top, transform, opacity;
     }
 
     .single-image {
+        position: relative;
         width: 100%;
         height: 100%;
         display: flex;
@@ -164,7 +176,14 @@
         display: block;
     }
 
+    .single-image img {
+        position: absolute;
+        inset: 0;
+    }
+
     .preview-grid {
+        position: absolute;
+        inset: 0;
         display: grid;
         width: 100%;
         height: 100%;
@@ -172,7 +191,6 @@
     }
 
     .preview-cell {
-        aspect-ratio: 1;
         overflow: hidden;
         background: var(--bg);
     }

--- a/src/lib/components/GridHoverPreview.svelte
+++ b/src/lib/components/GridHoverPreview.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
     import { convertFileSrc } from '@tauri-apps/api/core';
+    import { cubicOut } from 'svelte/easing';
+    import { fade } from 'svelte/transition';
     import type { ImageWithFile } from '$lib/api';
     import type { GridHoverPreviewPlan } from '$lib/grid-hover-preview';
     import { safeAssetPreviewPath } from '$lib/view-utils';
@@ -7,47 +9,124 @@
     interface Props {
         plan: GridHoverPreviewPlan;
         items: ImageWithFile[];
-        x: number;
-        y: number;
+        anchor: { left: number; top: number; width: number; height: number };
+        sourceShape: { rows: number; cols: number };
     }
 
-    let { plan, items, x, y }: Props = $props();
-    let previewWidth = $derived(plan.mode === 'single' ? 320 : 284);
-    let left = $derived(Math.max(12, Math.min(x + 18, window.innerWidth - previewWidth - 12)));
-    let top = $derived(Math.max(12, Math.min(y + 18, window.innerHeight - (plan.mode === 'single' ? 286 : 332))));
+    let { plan, items, anchor, sourceShape }: Props = $props();
+    const viewportInset = 12;
+    const singleMaxWidth = 420;
+    const singleMaxHeight = 360;
+    const groupExtent = 300;
+    const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+    function organicZoom(_node: Element, params: { start: number }) {
+        return {
+            duration: reduceMotion ? 0 : 340,
+            easing: cubicOut,
+            css: (t: number) => {
+                const scale = params.start + (1 - params.start) * t;
+                const opacity = 0.3 + 0.7 * t;
+                const saturation = 0.84 + 0.16 * t;
+                const brightness = 0.88 + 0.12 * t;
+                return `transform: scale(${scale}); opacity: ${opacity}; filter: saturate(${saturation}) brightness(${brightness});`;
+            },
+        };
+    }
+
+    let previewColumns = $derived.by(() => {
+        if (plan.mode !== 'group') return 1;
+        if (items.length === plan.groupCount) return Math.max(1, sourceShape.cols);
+        const aspect = Math.max(1, sourceShape.cols) / Math.max(1, sourceShape.rows);
+        return Math.max(1, Math.ceil(Math.sqrt(items.length * aspect)));
+    });
+    let previewSize = $derived.by(() => {
+        if (plan.mode === 'group' || !items[0]) {
+            const aspect = Math.max(1, sourceShape.cols) / Math.max(1, sourceShape.rows);
+            const width = aspect >= 1 ? groupExtent : groupExtent * aspect;
+            const height = aspect >= 1 ? groupExtent / aspect : groupExtent;
+            return {
+                width: Math.max(1, Math.round(width)),
+                height: Math.max(1, Math.round(height)),
+            };
+        }
+        const imageWidth = Math.max(1, items[0].image.width);
+        const imageHeight = Math.max(1, items[0].image.height);
+        const scale = Math.min(singleMaxWidth / imageWidth, singleMaxHeight / imageHeight);
+        return {
+            width: Math.max(1, Math.round(imageWidth * scale)),
+            height: Math.max(1, Math.round(imageHeight * scale)),
+        };
+    });
+    let left = $derived(Math.max(
+        viewportInset,
+        Math.min(
+            anchor.left + anchor.width / 2 - previewSize.width / 2,
+            window.innerWidth - previewSize.width - viewportInset,
+        ),
+    ));
+    let top = $derived(Math.max(
+        viewportInset,
+        Math.min(
+            anchor.top + anchor.height / 2 - previewSize.height / 2,
+            window.innerHeight - previewSize.height - viewportInset,
+        ),
+    ));
+    let originX = $derived(anchor.left + anchor.width / 2 - left);
+    let originY = $derived(anchor.top + anchor.height / 2 - top);
+    let sourceScale = $derived.by(() => {
+        if (plan.mode === 'group') {
+            return Math.max(0.015, Math.min(
+                1,
+                anchor.width / previewSize.width,
+                anchor.height / previewSize.height,
+            ));
+        }
+        const item = items[0];
+        if (!item) return 0.1;
+        const aspect = Math.max(1, item.image.width) / Math.max(1, item.image.height);
+        const containedWidth = Math.min(anchor.width, anchor.height * aspect);
+        return Math.max(0.015, Math.min(1, containedWidth / previewSize.width));
+    });
 
     function previewSrc(item: ImageWithFile): string {
         const path = safeAssetPreviewPath(item, { displayPx: plan.mode === 'single' ? 320 : 88, dpr: window.devicePixelRatio || 1 });
         return path ? convertFileSrc(path) : '';
     }
 
-    function filename(item: ImageWithFile): string {
-        return item.path.split('/').filter(Boolean).pop() ?? item.image.id;
-    }
 </script>
 
 <aside
     class="hover-preview"
     class:group={plan.mode === 'group'}
-    style="left: {left}px; top: {top}px; width: {previewWidth}px;"
+    style:--preview-origin-x={`${originX}px`}
+    style:--preview-origin-y={`${originY}px`}
+    style="left: {left}px; top: {top}px; width: {previewSize.width}px; height: {previewSize.height}px;"
+    transition:organicZoom={{ start: sourceScale }}
     aria-hidden="true"
 >
     {#if plan.mode === 'single' && items[0]}
         {@const src = previewSrc(items[0])}
         <div class="single-image">
-            {#if src}<img {src} alt="" />{/if}
+            {#key items[0].image.id}
+                {#if src}<img {src} alt="" transition:fade={{ duration: reduceMotion ? 0 : 120 }} />{/if}
+            {/key}
         </div>
-        <div class="caption">{filename(items[0])}</div>
     {:else}
-        <div class="preview-grid">
-            {#each items as item (item.image.id)}
-                {@const src = previewSrc(item)}
-                <div class="preview-cell">
-                    {#if src}<img {src} alt="" />{/if}
-                </div>
-            {/each}
-        </div>
-        <div class="caption">{plan.groupCount} images around pointer</div>
+        {#key plan.previewKey}
+            <div
+                class="preview-grid"
+                style:grid-template-columns={`repeat(${previewColumns}, 1fr)`}
+                transition:fade={{ duration: reduceMotion ? 0 : 120 }}
+            >
+                {#each items as item (item.image.id)}
+                    {@const src = previewSrc(item)}
+                    <div class="preview-cell">
+                        {#if src}<img {src} alt="" />{/if}
+                    </div>
+                {/each}
+            </div>
+        {/key}
     {/if}
 </aside>
 
@@ -56,26 +135,25 @@
         position: fixed;
         z-index: 320;
         pointer-events: none;
-        padding: 8px;
-        border: 1px solid var(--border);
-        border-radius: calc(var(--radius) * 2);
-        background: color-mix(in srgb, var(--surface) 94%, transparent);
-        box-shadow: 0 16px 48px color-mix(in srgb, var(--bg) 78%, transparent), 0 0 0 1px color-mix(in srgb, var(--blue) 12%, transparent);
-        backdrop-filter: blur(14px);
-        transform-origin: 18px 18px;
-        transition: left 180ms cubic-bezier(0.22, 1, 0.36, 1), top 180ms cubic-bezier(0.22, 1, 0.36, 1);
-        animation: preview-arrive 220ms cubic-bezier(0.16, 1, 0.3, 1);
+        overflow: hidden;
+        border-radius: calc(var(--radius) * 1.5);
+        background: var(--surface);
+        box-shadow: 0 22px 70px color-mix(in srgb, var(--bg) 72%, transparent);
+        transform-origin: var(--preview-origin-x) var(--preview-origin-y);
+        transition: left 220ms cubic-bezier(0.22, 1, 0.36, 1),
+            top 220ms cubic-bezier(0.22, 1, 0.36, 1),
+            width 220ms cubic-bezier(0.22, 1, 0.36, 1),
+            height 220ms cubic-bezier(0.22, 1, 0.36, 1);
         will-change: left, top, transform, opacity;
     }
 
     .single-image {
         width: 100%;
-        height: 232px;
+        height: 100%;
         display: flex;
         align-items: center;
         justify-content: center;
         overflow: hidden;
-        border-radius: var(--radius);
         background: var(--bg);
     }
 
@@ -88,14 +166,14 @@
 
     .preview-grid {
         display: grid;
-        grid-template-columns: repeat(3, 1fr);
-        gap: 3px;
+        width: 100%;
+        height: 100%;
+        gap: 2px;
     }
 
     .preview-cell {
         aspect-ratio: 1;
         overflow: hidden;
-        border-radius: var(--radius);
         background: var(--bg);
     }
 
@@ -103,22 +181,4 @@
         object-fit: cover;
     }
 
-    .caption {
-        margin-top: 7px;
-        overflow: hidden;
-        color: var(--text-secondary);
-        font-size: 10px;
-        line-height: 14px;
-        text-overflow: ellipsis;
-        white-space: nowrap;
-    }
-
-    @keyframes preview-arrive {
-        from { opacity: 0; transform: translateY(7px) scale(0.94); }
-        to { opacity: 1; transform: translateY(0) scale(1); }
-    }
-
-    @media (prefers-reduced-motion: reduce) {
-        .hover-preview { animation-duration: 1ms; }
-    }
 </style>

--- a/src/lib/components/GridHoverPreview.svelte
+++ b/src/lib/components/GridHoverPreview.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
     import { convertFileSrc } from '@tauri-apps/api/core';
     import { untrack } from 'svelte';
-    import { cubicOut } from 'svelte/easing';
     import { fade } from 'svelte/transition';
     import type { ImageWithFile } from '$lib/api';
     import type { GridHoverPreviewPlan } from '$lib/grid-hover-preview';
@@ -20,20 +19,6 @@
     const singleMaxHeight = 360;
     const groupExtent = 300;
     const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
-
-    function organicZoom(_node: Element, params: { start: number }) {
-        return {
-            duration: reduceMotion ? 0 : 340,
-            easing: cubicOut,
-            css: (t: number) => {
-                const scale = params.start + (1 - params.start) * t;
-                const opacity = 0.3 + 0.7 * t;
-                const saturation = 0.84 + 0.16 * t;
-                const brightness = 0.88 + 0.12 * t;
-                return `transform: scale(${scale}); opacity: ${opacity}; filter: saturate(${saturation}) brightness(${brightness});`;
-            },
-        };
-    }
 
     function previewColumnsForCurrentSource(): number {
         if (plan.mode !== 'group') return 1;
@@ -61,22 +46,21 @@
         };
     }
 
-    function sourceScaleForCurrentSource(
-        size: { width: number; height: number },
+    function sourceRectForCurrentSource(
         sourceAnchor: { left: number; top: number; width: number; height: number },
-    ): number {
-        if (plan.mode === 'group') {
-            return Math.max(0.015, Math.min(
-                1,
-                sourceAnchor.width / size.width,
-                sourceAnchor.height / size.height,
-            ));
-        }
+    ): { left: number; top: number; width: number; height: number } {
+        if (plan.mode === 'group') return sourceAnchor;
         const item = items[0];
-        if (!item) return 0.1;
+        if (!item) return sourceAnchor;
         const aspect = Math.max(1, item.image.width) / Math.max(1, item.image.height);
-        const containedWidth = Math.min(sourceAnchor.width, sourceAnchor.height * aspect);
-        return Math.max(0.015, Math.min(1, containedWidth / size.width));
+        const width = Math.min(sourceAnchor.width, sourceAnchor.height * aspect);
+        const height = Math.min(sourceAnchor.height, sourceAnchor.width / aspect);
+        return {
+            left: sourceAnchor.left + (sourceAnchor.width - width) / 2,
+            top: sourceAnchor.top + (sourceAnchor.height - height) / 2,
+            width,
+            height,
+        };
     }
 
     // A hover session gets one stable lens. Content changes inside it, but its
@@ -99,9 +83,11 @@
             window.innerHeight - lensSize.height - viewportInset,
         ),
     );
-    const lensOriginX = initialAnchor.left + initialAnchor.width / 2 - lensLeft;
-    const lensOriginY = initialAnchor.top + initialAnchor.height / 2 - lensTop;
-    const lensSourceScale = sourceScaleForCurrentSource(lensSize, initialAnchor);
+    const sourceRect = sourceRectForCurrentSource(initialAnchor);
+    const lensSourceX = sourceRect.left - lensLeft;
+    const lensSourceY = sourceRect.top - lensTop;
+    const lensSourceScaleX = sourceRect.width / lensSize.width;
+    const lensSourceScaleY = sourceRect.height / lensSize.height;
 
     function previewSrc(item: ImageWithFile): string {
         const path = safeAssetPreviewPath(item, { displayPx: plan.mode === 'single' ? 320 : 88, dpr: window.devicePixelRatio || 1 });
@@ -113,10 +99,11 @@
 <aside
     class="hover-preview"
     class:group={plan.mode === 'group'}
-    style:--preview-origin-x={`${lensOriginX}px`}
-    style:--preview-origin-y={`${lensOriginY}px`}
+    style:--preview-source-x={`${lensSourceX}px`}
+    style:--preview-source-y={`${lensSourceY}px`}
+    style:--preview-source-scale-x={lensSourceScaleX}
+    style:--preview-source-scale-y={lensSourceScaleY}
     style="left: {lensLeft}px; top: {lensTop}px; width: {lensSize.width}px; height: {lensSize.height}px;"
-    transition:organicZoom={{ start: lensSourceScale }}
     aria-hidden="true"
 >
     {#if plan.mode === 'single' && items[0]}
@@ -154,8 +141,33 @@
         border-radius: calc(var(--radius) * 1.5);
         background: var(--surface);
         box-shadow: 0 22px 70px color-mix(in srgb, var(--bg) 72%, transparent);
-        transform-origin: var(--preview-origin-x) var(--preview-origin-y);
-        will-change: left, top, transform, opacity;
+        transform-origin: top left;
+        animation: preview-enter 380ms cubic-bezier(0.16, 1, 0.3, 1) both;
+        will-change: transform, opacity, filter;
+    }
+
+    @keyframes preview-enter {
+        0% {
+            transform: translate(var(--preview-source-x), var(--preview-source-y)) scale(var(--preview-source-scale-x), var(--preview-source-scale-y));
+            opacity: 0.2;
+            filter: saturate(0.82) brightness(0.86);
+            box-shadow: 0 2px 8px color-mix(in srgb, var(--bg) 42%, transparent);
+        }
+        62% {
+            opacity: 0.96;
+        }
+        100% {
+            transform: translate(0, 0) scale(1, 1);
+            opacity: 1;
+            filter: saturate(1) brightness(1);
+            box-shadow: 0 22px 70px color-mix(in srgb, var(--bg) 72%, transparent);
+        }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+        .hover-preview {
+            animation: none;
+        }
     }
 
     .single-image {

--- a/src/lib/components/GridOverviewCanvas.svelte
+++ b/src/lib/components/GridOverviewCanvas.svelte
@@ -1,0 +1,157 @@
+<script lang="ts">
+    import { convertFileSrc } from '@tauri-apps/api/core';
+    import type { ImageWithFile } from '$lib/api';
+    import { shouldDecodeGridOverviewThumbnails } from '$lib/grid-overview';
+    import { safeAssetPreviewPath } from '$lib/view-utils';
+
+    interface Props {
+        items: ImageWithFile[];
+        width: number;
+        height: number;
+        scrollTop: number;
+        size: number;
+        gap: number;
+        cols: number;
+        focusedIndex: number;
+        selectedIds: Set<string>;
+        onclick: (event: MouseEvent) => void;
+        ondblclick: (event: MouseEvent) => void;
+    }
+
+    let {
+        items,
+        width,
+        height,
+        scrollTop,
+        size,
+        gap,
+        cols,
+        focusedIndex,
+        selectedIds,
+        onclick,
+        ondblclick,
+    }: Props = $props();
+
+    let canvas: HTMLCanvasElement;
+    let renderGeneration = 0;
+
+    function token(styles: CSSStyleDeclaration, name: string): string {
+        return styles.getPropertyValue(name).trim();
+    }
+
+    function imageColor(index: number, palette: string[]): string {
+        const id = items[index]?.image.id ?? String(index);
+        let hash = 0;
+        for (let i = 0; i < id.length; i += 1) hash = ((hash << 5) - hash + id.charCodeAt(i)) | 0;
+        return palette[Math.abs(hash) % palette.length];
+    }
+
+    $effect(() => {
+        if (!canvas || width <= 0 || height <= 0 || cols <= 0 || size <= 0) return;
+        const generation = ++renderGeneration;
+        const dpr = Math.min(window.devicePixelRatio || 1, 1.5);
+        canvas.width = Math.max(1, Math.round(width * dpr));
+        canvas.height = Math.max(1, Math.round(height * dpr));
+        const ctx = canvas.getContext('2d', { alpha: false });
+        if (!ctx) return;
+        ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+        ctx.imageSmoothingEnabled = size >= 8;
+
+        const styles = getComputedStyle(canvas);
+        const background = token(styles, '--bg');
+        const palette = [
+            token(styles, '--surface'),
+            token(styles, '--border'),
+            token(styles, '--text-secondary'),
+            token(styles, '--blue'),
+            token(styles, '--purple'),
+        ];
+        const selectedColor = token(styles, '--green');
+        const focusedColor = token(styles, '--blue');
+        ctx.fillStyle = background;
+        ctx.fillRect(0, 0, width, height);
+
+        const cellSize = size + gap;
+        const firstRow = Math.max(0, Math.floor(scrollTop / cellSize));
+        const lastRow = Math.min(Math.ceil(items.length / cols), Math.ceil((scrollTop + height) / cellSize) + 1);
+        const pending: Array<{ index: number; x: number; y: number; src: string }> = [];
+        const decodeThumbnails = shouldDecodeGridOverviewThumbnails(size);
+
+        for (let row = firstRow; row < lastRow; row += 1) {
+            for (let col = 0; col < cols; col += 1) {
+                const index = row * cols + col;
+                const item = items[index];
+                if (!item) break;
+                const x = col * cellSize;
+                const y = row * cellSize - scrollTop;
+                ctx.fillStyle = selectedIds.has(item.image.id)
+                    ? selectedColor
+                    : index === focusedIndex
+                        ? focusedColor
+                        : imageColor(index, palette);
+                ctx.fillRect(x, y, size, size);
+
+                if (decodeThumbnails) {
+                    const path = safeAssetPreviewPath(item, { displayPx: size, dpr: 1 });
+                    if (path) pending.push({ index, x, y, src: convertFileSrc(path) });
+                }
+            }
+        }
+
+        // Decode progressively with a small concurrency window. The canvas itself is the
+        // cache, so even a six-figure overview never mounts six figures of DOM nodes.
+        let cursor = 0;
+        const workers = Math.min(12, pending.length);
+        const drawNext = () => {
+            if (generation !== renderGeneration) return;
+            const next = pending[cursor++];
+            if (!next) return;
+            const img = new Image();
+            img.decoding = 'async';
+            img.onload = () => {
+                if (generation === renderGeneration) {
+                    ctx.drawImage(img, next.x, next.y, size, size);
+                    const item = items[next.index];
+                    if (item && selectedIds.has(item.image.id)) {
+                        ctx.strokeStyle = selectedColor;
+                        ctx.lineWidth = Math.max(1, Math.min(2, size / 3));
+                        ctx.strokeRect(next.x + 0.5, next.y + 0.5, Math.max(0, size - 1), Math.max(0, size - 1));
+                    }
+                }
+                drawNext();
+            };
+            img.onerror = drawNext;
+            img.src = next.src;
+        };
+        for (let i = 0; i < workers; i += 1) drawNext();
+
+        return () => {
+            renderGeneration += 1;
+        };
+    });
+</script>
+
+<canvas
+    bind:this={canvas}
+    class="overview-canvas"
+    style="top: {scrollTop}px; width: {width}px; height: {height}px;"
+    aria-label="Canvas overview of {items.length} images"
+    tabindex="0"
+    {onclick}
+    {ondblclick}
+></canvas>
+
+<style>
+    .overview-canvas {
+        position: absolute;
+        left: 0;
+        display: block;
+        cursor: crosshair;
+        outline: none;
+        touch-action: pan-y;
+    }
+
+    .overview-canvas:focus-visible {
+        box-shadow: inset 0 0 0 1px var(--blue);
+    }
+</style>

--- a/src/lib/components/TabBar.svelte
+++ b/src/lib/components/TabBar.svelte
@@ -10,6 +10,9 @@
     import { visibleViewTabs } from '$lib/view-tabs';
     import { tabRegistry } from '$lib/plugins/tab-registry';
     import {
+        nudgeThumbnailSize,
+        THUMBNAIL_ZOOM_MAX,
+        THUMBNAIL_ZOOM_MIN,
         thumbnailSizeFromZoomPosition,
         zoomPositionFromThumbnailSize,
     } from '$lib/thumbnail-zoom';
@@ -32,6 +35,10 @@
         const val = thumbnailSizeFromZoomPosition(position);
         zoomPosition = position;
         setGridThumbnailSize(val);
+    }
+
+    function stepGridZoom(direction: -1 | 1) {
+        setGridThumbnailSize(nudgeThumbnailSize($thumbnailSize, direction));
     }
 
     function setCanvasZoom(e: Event) {
@@ -104,7 +111,7 @@
     <div class="tabbar-right">
         {#if $viewMode === 'grid'}
             <div class="slider-group">
-                <span class="slider-icon">▪▪</span>
+                <button class="slider-icon" type="button" aria-label="Zoom thumbnails out" title="Zoom out" disabled={$thumbnailSize <= THUMBNAIL_ZOOM_MIN} onclick={() => stepGridZoom(-1)}>▪▪</button>
                 <div class="slider-track">
                     <input
                         type="range"
@@ -116,11 +123,11 @@
                         aria-label="Thumbnail size"
                     />
                 </div>
-                <span class="slider-icon">▪</span>
+                <button class="slider-icon" type="button" aria-label="Zoom thumbnails in" title="Zoom in" disabled={$thumbnailSize >= THUMBNAIL_ZOOM_MAX} onclick={() => stepGridZoom(1)}>▪</button>
             </div>
         {:else if $viewMode === 'canvas'}
             <div class="slider-group">
-                <span class="slider-icon">-</span>
+                <span class="slider-marker">-</span>
                 <div class="slider-track">
                     <input
                         type="range"
@@ -132,7 +139,7 @@
                         aria-label="Canvas zoom"
                     />
                 </div>
-                <span class="slider-icon">+</span>
+                <span class="slider-marker">+</span>
             </div>
         {/if}
     </div>
@@ -312,10 +319,46 @@
         gap: 6px;
     }
     .slider-icon {
+        display: grid;
+        place-items: center;
+        min-width: 18px;
+        height: 22px;
+        padding: 0 3px;
+        border: 0;
+        border-radius: var(--radius);
+        background: transparent;
         color: var(--text-secondary);
+        font-family: var(--font);
         font-size: 8px;
         opacity: 0.5;
         letter-spacing: 1px;
+        cursor: pointer;
+        transition: color 120ms, opacity 120ms, background 120ms, transform 80ms;
+    }
+    .slider-marker {
+        color: var(--text-secondary);
+        font-size: 8px;
+        opacity: 0.5;
+    }
+    .slider-icon:hover {
+        color: var(--text);
+        background: color-mix(in srgb, var(--blue) 10%, transparent);
+        opacity: 1;
+    }
+    .slider-icon:active {
+        transform: scale(0.88);
+    }
+    .slider-icon:disabled {
+        opacity: 0.18;
+        cursor: default;
+    }
+    .slider-icon:disabled:hover {
+        color: var(--text-secondary);
+        background: transparent;
+    }
+    .slider-icon:focus-visible {
+        outline: 1px solid var(--blue);
+        outline-offset: 1px;
     }
     .slider-track {
         width: 80px;
@@ -348,6 +391,9 @@
         .tab,
         .tab-label,
         .tab-label-popover {
+            transition: none;
+        }
+        .slider-icon {
             transition: none;
         }
     }

--- a/src/lib/components/TabBar.svelte
+++ b/src/lib/components/TabBar.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import { openPreviewDisplay } from '$lib/api';
-    import { viewMode, thumbnailSize, canvasZoom, navigateTo, requestCanvasZoom, showToast } from '$lib/stores';
+    import { viewMode, thumbnailSize, canvasZoom, navigateTo, requestCanvasZoom, setGridThumbnailSize, showToast } from '$lib/stores';
     import type { ViewMode } from '$lib/stores';
     import {
         canvasZoomFromPosition,
@@ -31,7 +31,7 @@
         const position = parseFloat((e.target as HTMLInputElement).value);
         const val = thumbnailSizeFromZoomPosition(position);
         zoomPosition = position;
-        thumbnailSize.set(val);
+        setGridThumbnailSize(val);
     }
 
     function setCanvasZoom(e: Event) {

--- a/src/lib/components/Thumbnail.svelte
+++ b/src/lib/components/Thumbnail.svelte
@@ -141,6 +141,7 @@
 
 <div
     class="thumb {borderClass}"
+    class:micro={size < 40}
     style="width: {size}px; height: {size}px;"
     role="gridcell"
     tabindex={focused ? 0 : -1}
@@ -238,6 +239,17 @@
     .thumb.focused.selected {
         border-color: var(--blue);
         box-shadow: 0 0 0 1px var(--green);
+    }
+    .thumb.micro {
+        border-width: 1px;
+    }
+    .thumb.micro .rating,
+    .thumb.micro .source-tag,
+    .thumb.micro .pdf-badge,
+    .thumb.micro .badge,
+    .thumb.micro .missing-badge,
+    .thumb.micro .fallback-text {
+        display: none;
     }
     img {
         max-width: 100%;

--- a/src/lib/grid-gesture-zoom.test.ts
+++ b/src/lib/grid-gesture-zoom.test.ts
@@ -22,11 +22,12 @@ describe('grid gesture zoom', () => {
 
     it('clamps gesture zoom to grid thumbnail bounds', () => {
         const presets = [
-            { name: 'compact', size: 80, gap: 2 },
+            { name: 'pixels', size: 4, gap: 0 },
             { name: 'xl', size: 400, gap: 12 },
+            { name: 'detail', size: 800, gap: 16 },
         ];
 
-        expect(gridGestureZoom({ size: 80, gap: 2, preset: 0 }, 0.1, presets).size).toBe(GRID_GESTURE_ZOOM_MIN);
+        expect(gridGestureZoom({ size: 8, gap: 0, preset: 0 }, 0.1, presets).size).toBe(GRID_GESTURE_ZOOM_MIN);
         expect(gridGestureZoom({ size: 400, gap: 12, preset: 1 }, 10, presets).size).toBe(GRID_GESTURE_ZOOM_MAX);
     });
 });

--- a/src/lib/grid-gesture-zoom.ts
+++ b/src/lib/grid-gesture-zoom.ts
@@ -1,5 +1,7 @@
-export const GRID_GESTURE_ZOOM_MIN = 80;
-export const GRID_GESTURE_ZOOM_MAX = 400;
+import { THUMBNAIL_ZOOM_MAX, THUMBNAIL_ZOOM_MIN } from './thumbnail-zoom';
+
+export const GRID_GESTURE_ZOOM_MIN = THUMBNAIL_ZOOM_MIN;
+export const GRID_GESTURE_ZOOM_MAX = THUMBNAIL_ZOOM_MAX;
 
 export interface GridGestureZoomPreset {
     name: string;

--- a/src/lib/grid-hover-preview.test.ts
+++ b/src/lib/grid-hover-preview.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import { gridIndexAtPointer, planGridHoverPreview } from './grid-hover-preview';
+
+describe('grid hover preview planning', () => {
+    it('targets the exact image under the pointer at readable thumbnail sizes', () => {
+        const plan = planGridHoverPreview({
+            pointerX: 45,
+            pointerY: 25,
+            scrollTop: 100,
+            cols: 10,
+            cellSize: 40,
+            thumbnailSize: 36,
+            totalItems: 1_000,
+        });
+
+        expect(plan).toEqual({ mode: 'single', previewKey: 'image:31', anchorIndex: 31, indices: [31], groupCount: 1 });
+    });
+
+    it('previews a bounded sample from the pointer neighbourhood in pixel overview', () => {
+        const plan = planGridHoverPreview({
+            pointerX: 17,
+            pointerY: 9,
+            scrollTop: 0,
+            cols: 100,
+            cellSize: 4,
+            thumbnailSize: 4,
+            totalItems: 100_000,
+        });
+
+        expect(plan?.mode).toBe('group');
+        expect(plan?.anchorIndex).toBe(204);
+        expect(plan?.groupCount).toBe(64);
+        expect(plan?.indices).toHaveLength(9);
+        expect(plan?.previewKey).toBe('group:0:0:8');
+
+        const sameGroup = planGridHoverPreview({
+            pointerX: 29,
+            pointerY: 25,
+            scrollTop: 0,
+            cols: 100,
+            cellSize: 4,
+            thumbnailSize: 4,
+            totalItems: 100_000,
+        });
+        expect(sameGroup?.previewKey).toBe(plan?.previewKey);
+        expect(sameGroup?.indices).toEqual(plan?.indices);
+    });
+
+    it('maps canvas pointers to scrolled grid indices and rejects empty space', () => {
+        expect(gridIndexAtPointer(17, 7, 80, 25, 8, 1_000)).toBe(252);
+        expect(gridIndexAtPointer(-1, 7, 80, 25, 8, 100)).toBeNull();
+        expect(gridIndexAtPointer(200, 7, 80, 25, 8, 100)).toBeNull();
+    });
+
+});

--- a/src/lib/grid-hover-preview.ts
+++ b/src/lib/grid-hover-preview.ts
@@ -23,6 +23,36 @@ export interface GridHoverPreviewInput extends GridPointerInput {
     thumbnailSize: number;
 }
 
+export interface GridHoverGroupBounds {
+    startRow: number;
+    startCol: number;
+    side: number;
+    rows: number;
+    cols: number;
+}
+
+export function gridHoverGroupBounds(
+    anchorIndex: number,
+    cols: number,
+    cellSize: number,
+    totalItems: number,
+): GridHoverGroupBounds {
+    const side = Math.max(2, Math.ceil(GRID_HOVER_FOOTPRINT_PX / cellSize));
+    const anchorRow = Math.floor(anchorIndex / cols);
+    const anchorCol = anchorIndex % cols;
+    const startRow = Math.floor(anchorRow / side) * side;
+    const startCol = Math.floor(anchorCol / side) * side;
+    const actualCols = Math.min(side, cols - startCol);
+    const remainingItems = Math.max(0, totalItems - (startRow * cols + startCol));
+    return {
+        startRow,
+        startCol,
+        side,
+        rows: Math.min(side, Math.ceil(remainingItems / cols)),
+        cols: Math.min(actualCols, remainingItems),
+    };
+}
+
 export function gridIndexAtPointer(
     pointerX: number,
     pointerY: number,
@@ -71,11 +101,12 @@ export function planGridHoverPreview(input: GridHoverPreviewInput): GridHoverPre
         return { mode: 'single', previewKey: `image:${anchorIndex}`, anchorIndex, indices: [anchorIndex], groupCount: 1 };
     }
 
-    const side = Math.max(2, Math.ceil(GRID_HOVER_FOOTPRINT_PX / input.cellSize));
-    const anchorRow = Math.floor(anchorIndex / input.cols);
-    const anchorCol = anchorIndex % input.cols;
-    const startRow = Math.floor(anchorRow / side) * side;
-    const startCol = Math.floor(anchorCol / side) * side;
+    const { startRow, startCol, side } = gridHoverGroupBounds(
+        anchorIndex,
+        input.cols,
+        input.cellSize,
+        input.totalItems,
+    );
     const group: number[] = [];
 
     for (let row = startRow; row < startRow + side; row += 1) {

--- a/src/lib/grid-hover-preview.ts
+++ b/src/lib/grid-hover-preview.ts
@@ -1,0 +1,96 @@
+export const GRID_SINGLE_HOVER_MIN_SIZE = 32;
+export const GRID_HOVER_FOOTPRINT_PX = 32;
+export const GRID_HOVER_SAMPLE_LIMIT = 9;
+
+export interface GridHoverPreviewPlan {
+    mode: 'single' | 'group';
+    previewKey: string;
+    anchorIndex: number;
+    indices: number[];
+    groupCount: number;
+}
+
+export interface GridPointerInput {
+    pointerX: number;
+    pointerY: number;
+    scrollTop: number;
+    cols: number;
+    cellSize: number;
+    totalItems: number;
+}
+
+export interface GridHoverPreviewInput extends GridPointerInput {
+    thumbnailSize: number;
+}
+
+export function gridIndexAtPointer(
+    pointerX: number,
+    pointerY: number,
+    scrollTop: number,
+    cols: number,
+    cellSize: number,
+    totalItems: number,
+): number | null {
+    if (
+        pointerX < 0 ||
+        pointerY < 0 ||
+        cols <= 0 ||
+        cellSize <= 0 ||
+        totalItems <= 0
+    ) return null;
+
+    const col = Math.floor(pointerX / cellSize);
+    if (col < 0 || col >= cols) return null;
+    const row = Math.floor((scrollTop + pointerY) / cellSize);
+    const index = row * cols + col;
+    return index >= 0 && index < totalItems ? index : null;
+}
+
+function boundedSample(indices: number[], limit: number): number[] {
+    if (indices.length <= limit) return indices;
+    const sampled: number[] = [];
+    for (let i = 0; i < limit; i += 1) {
+        const offset = limit === 1 ? 0 : Math.round(i * (indices.length - 1) / (limit - 1));
+        sampled.push(indices[offset]);
+    }
+    return sampled;
+}
+
+export function planGridHoverPreview(input: GridHoverPreviewInput): GridHoverPreviewPlan | null {
+    const anchorIndex = gridIndexAtPointer(
+        input.pointerX,
+        input.pointerY,
+        input.scrollTop,
+        input.cols,
+        input.cellSize,
+        input.totalItems,
+    );
+    if (anchorIndex === null) return null;
+
+    if (input.thumbnailSize >= GRID_SINGLE_HOVER_MIN_SIZE) {
+        return { mode: 'single', previewKey: `image:${anchorIndex}`, anchorIndex, indices: [anchorIndex], groupCount: 1 };
+    }
+
+    const side = Math.max(2, Math.ceil(GRID_HOVER_FOOTPRINT_PX / input.cellSize));
+    const anchorRow = Math.floor(anchorIndex / input.cols);
+    const anchorCol = anchorIndex % input.cols;
+    const startRow = Math.floor(anchorRow / side) * side;
+    const startCol = Math.floor(anchorCol / side) * side;
+    const group: number[] = [];
+
+    for (let row = startRow; row < startRow + side; row += 1) {
+        for (let col = startCol; col < Math.min(input.cols, startCol + side); col += 1) {
+            const index = row * input.cols + col;
+            if (index >= input.totalItems) break;
+            group.push(index);
+        }
+    }
+
+    return {
+        mode: 'group',
+        previewKey: `group:${startRow}:${startCol}:${side}`,
+        anchorIndex,
+        indices: boundedSample(group, GRID_HOVER_SAMPLE_LIMIT),
+        groupCount: group.length,
+    };
+}

--- a/src/lib/grid-overview.test.ts
+++ b/src/lib/grid-overview.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from 'vitest';
+import { shouldDecodeGridOverviewThumbnails } from './grid-overview';
+
+describe('grid overview rendering policy', () => {
+    it('does not bulk-decode thumbnails at full-scope pixel density', () => {
+        expect(shouldDecodeGridOverviewThumbnails(4)).toBe(false);
+        expect(shouldDecodeGridOverviewThumbnails(8)).toBe(false);
+        expect(shouldDecodeGridOverviewThumbnails(12)).toBe(false);
+        expect(shouldDecodeGridOverviewThumbnails(13)).toBe(true);
+    });
+});

--- a/src/lib/grid-overview.ts
+++ b/src/lib/grid-overview.ts
@@ -1,0 +1,10 @@
+/** Switch to a single canvas before a 4K viewport would mount thousands of image nodes. */
+export const GRID_OVERVIEW_MAX_SIZE = 64;
+
+/** At this density the full library can fit on screen, so page through the whole scope. */
+export const GRID_FULL_SCOPE_OVERVIEW_MAX_SIZE = 12;
+
+/** Extreme density is a metadata map; actual thumbnails are decoded by the hover lens. */
+export function shouldDecodeGridOverviewThumbnails(thumbnailSize: number): boolean {
+    return thumbnailSize > GRID_FULL_SCOPE_OVERVIEW_MAX_SIZE;
+}

--- a/src/lib/image-loading.ts
+++ b/src/lib/image-loading.ts
@@ -25,6 +25,7 @@ import {
 import { formatLibraryLoadError } from './library-view-state';
 
 export const IMAGE_PAGE_SIZE = 200;
+export const IMAGE_OVERVIEW_PAGE_SIZE = 5_000;
 const MAX_SCOPE_CACHE_ENTRIES = 5;
 const LIBRARY_LOAD_TIMEOUT_MS = 15_000;
 
@@ -293,7 +294,7 @@ export async function loadImagesForCurrentScope(options: ImageLoadOptions = {}) 
     }
 }
 
-export async function loadMoreImagesForCurrentScope() {
+export async function loadMoreImagesForCurrentScope(pageSize = IMAGE_PAGE_SIZE) {
     const scope = currentScope();
     const key = scopeKey(scope);
     if (key !== activeScopeKey) {
@@ -308,11 +309,12 @@ export async function loadMoreImagesForCurrentScope() {
     setLoadState();
 
     try {
-        const page = await withLibraryLoadTimeout(fetchPage(scope, offset, IMAGE_PAGE_SIZE));
+        const normalizedPageSize = Math.max(1, Math.trunc(pageSize) || IMAGE_PAGE_SIZE);
+        const page = await withLibraryLoadTimeout(fetchPage(scope, offset, normalizedPageSize));
         if (seq !== requestSeq || key !== activeScopeKey) return;
 
-        nextOffset += IMAGE_PAGE_SIZE;
-        hasMore = page.rawCount === IMAGE_PAGE_SIZE;
+        nextOffset += normalizedPageSize;
+        hasMore = page.rawCount === normalizedPageSize;
         if (page.items.length > 0) {
             images.update(existing => {
                 const seen = new Set(existing.map(img => img.image.id));

--- a/src/lib/keys.ts
+++ b/src/lib/keys.ts
@@ -8,7 +8,7 @@ import {
     navigateTo, navigateBack, searchOpen, shortcutsOpen, undoHistoryOpen, focusedImage, activeSession,
     requestTextInput, requestCollectionTarget, selectionAnchorIndex, requestLoupeActualSize, requestLoupeFitIn,
     requestLoupeZoomIn, requestLoupeZoomOut,
-    activeFolder,
+    activeFolder, setGridThumbnailSize,
 } from './stores';
 import { tabCycleOrder } from './plugins/tab-registry';
 import { computeCompareSwap, nextComparePresentationState } from './compare-utils';
@@ -23,6 +23,7 @@ import { commandForKeyboardEvent, openCommandPalette, runCommandPaletteItem } fr
 import { recordShortcutUse, VIEW_CYCLE_SHORTCUT_REMINDER_ID } from './shortcut-reminders';
 import { withDecision, withRating, type ImageDecision } from './selection-updates';
 import { pasteDestinationForContext } from './clipboard-actions';
+import { nudgeThumbnailSize } from './thumbnail-zoom';
 
 let waitingForStar = false;
 
@@ -168,12 +169,7 @@ export async function handleDecision(decision: ImageDecision, imageIndex?: numbe
 }
 
 function handleResize(delta: number) {
-    thumbnailSize.update(s => {
-        const next = s + delta;
-        if (next < 80) return 80;
-        if (next > 400) return 400;
-        return next;
-    });
+    setGridThumbnailSize(nudgeThumbnailSize(get(thumbnailSize), delta < 0 ? -1 : 1));
 }
 
 // ---- Compare helpers ----

--- a/src/lib/menu.ts
+++ b/src/lib/menu.ts
@@ -20,6 +20,7 @@ import {
     type ImageWithFile,
     type OpenWithApplication,
 } from './api';
+import { nudgeThumbnailSize } from './thumbnail-zoom';
 import {
     images,
     viewMode,
@@ -27,6 +28,7 @@ import {
     focusedImage,
     sidebarVisible,
     thumbnailSize,
+    setGridThumbnailSize,
     showLoupeHistogram,
     activeFolder,
     activeCollection,
@@ -590,14 +592,14 @@ function handleMenuAction(action: string) {
             if (get(viewMode) === 'loupe') {
                 requestLoupeZoomIn();
             } else {
-                thumbnailSize.update((s) => Math.min(s + 40, 600));
+                setGridThumbnailSize(nudgeThumbnailSize(get(thumbnailSize), 1));
             }
             break;
         case 'zoom_out':
             if (get(viewMode) === 'loupe') {
                 requestLoupeZoomOut();
             } else {
-                thumbnailSize.update((s) => Math.max(s - 40, 40));
+                setGridThumbnailSize(nudgeThumbnailSize(get(thumbnailSize), -1));
             }
             break;
         case 'actual_size':

--- a/src/lib/persistence.ts
+++ b/src/lib/persistence.ts
@@ -8,6 +8,7 @@ import {
     pinnedCollection, pinnedCollections,
     expandedFolders, sidebarSectionsCollapsed,
     resetLoupeTransform,
+    setGridThumbnailSize,
     type ViewMode, type LineageLayout, type NsfwMode, type EmbeddingViewState,
 } from './stores';
 
@@ -88,9 +89,9 @@ export function restoreAppStateBeforeImages(): PersistedState | null {
         const state: PersistedState = JSON.parse(raw);
         if (state._version !== SCHEMA_VERSION) return null;
 
-        thumbnailSize.set(state.thumbnailSize);
-        gridPreset.set(state.gridPreset);
-        gridGap.set(state.gridGap);
+        // Derive the presentation preset from size so states saved before new
+        // overview/detail presets were added do not restore a mismatched label/gap.
+        setGridThumbnailSize(state.thumbnailSize);
         sidebarVisible.set(state.sidebarVisible);
         zenMode.set(state.zenMode);
         activeFolder.set(state.activeFolder);

--- a/src/lib/stores.ts
+++ b/src/lib/stores.ts
@@ -197,14 +197,32 @@ export function cycleAgentVisualLevel() {
 }
 
 export const GRID_PRESETS = [
+    { name: 'pixels', size: 4, gap: 0 },
+    { name: 'overview', size: 12, gap: 0 },
+    { name: 'contact', size: 32, gap: 1 },
     { name: 'compact', size: 80, gap: 2 },
     { name: 'normal', size: 160, gap: 4 },
-    { name: 'large', size: 280, gap: 8 },
-    { name: 'xl', size: 400, gap: 12 },
+    { name: 'large', size: 320, gap: 8 },
+    { name: 'detail', size: 640, gap: 12 },
 ];
 
-export const gridPreset = writable<number>(1);
+export const gridPreset = writable<number>(4);
 export const gridGap = writable<number>(4);
+
+export function setGridThumbnailSize(size: number) {
+    let closest = 0;
+    let distance = Number.POSITIVE_INFINITY;
+    for (let i = 0; i < GRID_PRESETS.length; i += 1) {
+        const nextDistance = Math.abs(GRID_PRESETS[i].size - size);
+        if (nextDistance < distance) {
+            closest = i;
+            distance = nextDistance;
+        }
+    }
+    thumbnailSize.set(size);
+    gridPreset.set(closest);
+    gridGap.set(GRID_PRESETS[closest]?.gap ?? 0);
+}
 
 export const zenMode = writable<boolean>(false);
 

--- a/src/lib/thumbnail-zoom.test.ts
+++ b/src/lib/thumbnail-zoom.test.ts
@@ -3,6 +3,7 @@ import {
     THUMBNAIL_ZOOM_MAX,
     THUMBNAIL_ZOOM_MIN,
     thumbnailSizeFromZoomPosition,
+    nudgeThumbnailSize,
     zoomPositionFromThumbnailSize,
 } from './thumbnail-zoom';
 
@@ -24,10 +25,17 @@ describe('thumbnail zoom curve', () => {
     });
 
     it('round-trips existing thumbnail sizes back to slider positions', () => {
-        for (const size of [80, 160, 280, 400]) {
+        for (const size of [4, 8, 32, 80, 160, 400, 800]) {
             const position = zoomPositionFromThumbnailSize(size);
 
             expect(thumbnailSizeFromZoomPosition(position)).toBeCloseTo(size, 0);
         }
+    });
+
+    it('nudges proportionally across the extended range without crossing its bounds', () => {
+        expect(nudgeThumbnailSize(4, 1)).toBe(5);
+        expect(nudgeThumbnailSize(5, -1)).toBe(4);
+        expect(nudgeThumbnailSize(800, 1)).toBe(800);
+        expect(nudgeThumbnailSize(4, -1)).toBe(4);
     });
 });

--- a/src/lib/thumbnail-zoom.ts
+++ b/src/lib/thumbnail-zoom.ts
@@ -1,5 +1,5 @@
-export const THUMBNAIL_ZOOM_MIN = 80;
-export const THUMBNAIL_ZOOM_MAX = 400;
+export const THUMBNAIL_ZOOM_MIN = 4;
+export const THUMBNAIL_ZOOM_MAX = 800;
 
 function clamp(value: number, min: number, max: number): number {
     return Math.min(Math.max(value, min), max);
@@ -27,4 +27,12 @@ export function zoomPositionFromThumbnailSize(size: number): number {
     }
 
     return ((lo + hi) / 2) * 100;
+}
+
+export function nudgeThumbnailSize(size: number, direction: -1 | 1): number {
+    const factor = direction > 0 ? 1.25 : 0.8;
+    const next = Math.round(clamp(size * factor, THUMBNAIL_ZOOM_MIN, THUMBNAIL_ZOOM_MAX));
+    if (next === size && size > THUMBNAIL_ZOOM_MIN && direction < 0) return size - 1;
+    if (next === size && size < THUMBNAIL_ZOOM_MAX && direction > 0) return size + 1;
+    return next;
 }


### PR DESCRIPTION
## Scope\n\nExtracts only the four grid pixel-overview/hover-lens commits from the preserved 23-commit integration stack. Supersedes the grid portion of #78; it deliberately excludes detailed history, deep-link, sidebar, context-menu, research, and Beads changes.\n\n## Conflict resolution\n\nPreserves current main's 15-second library-load timeout while retaining the overview feature's normalized 5,000-item page option.\n\n## Verification\n\n- Svelte check: 0 errors/warnings\n- Focused grid/zoom tests: 10 passed\n- Full frontend: 1,189 passed (one load-related release test timeout passed immediately alone)\n- Rust fmt and clippy completed; full Rust suite passed on retry after one unrelated trash-audit test passed immediately alone\n\nRecovery tracking: imageview-htfg.7