### PR TITLE
Add sidebar context action menus

### DIFF
--- a/src/lib/audit-ui-contract.test.ts
+++ b/src/lib/audit-ui-contract.test.ts
@@ -99,7 +99,7 @@ describe('impeccable audit UI contracts', () => {
     });
 
     it('clarifies destructive, privacy-sensitive, and publishing copy', () => {
-        expect(sidebar).toContain('Remove folder from library');
+        expect(sidebar).toContain('Remove Folder from Library');
         // Model setup must not imply an in-app auto-download (bd imageview-dkz.19
         // replaced the 'Install model manually' dead-end with a setup-guide link).
         expect(aiSettings).toContain('setup guide');

--- a/src/lib/components/ActionMenu.svelte
+++ b/src/lib/components/ActionMenu.svelte
@@ -1,0 +1,389 @@
+<script module lang="ts">
+    export interface ActionMenuItem {
+        id: string;
+        label: string;
+        action?: () => void | Promise<void>;
+        children?: ActionMenuItem[];
+        disabled?: boolean;
+        danger?: boolean;
+        hidden?: boolean;
+        separatorBefore?: boolean;
+    }
+</script>
+
+<script lang="ts">
+    import { onMount, tick } from 'svelte';
+    import { clampFloatingPosition, placeAdjacentSubmenu } from '$lib/floating-position';
+    import { claimContextMenu } from '$lib/context-menu-coordinator';
+
+    interface Props {
+        title?: string;
+        x: number;
+        y: number;
+        items: ActionMenuItem[];
+        opener?: HTMLElement | null;
+        onclose: () => void;
+    }
+
+    let { title, x, y, items, opener = null, onclose }: Props = $props();
+
+    const fallbackOpener = typeof document !== 'undefined'
+        && document.activeElement instanceof HTMLElement
+        && document.activeElement !== document.body
+        ? document.activeElement
+        : null;
+
+    let menuEl = $state<HTMLDivElement>();
+    let submenuEl = $state<HTMLDivElement>();
+    let menuX = $state(0);
+    let menuY = $state(0);
+    let menuReady = $state(false);
+    let openSubmenuId = $state<string | null>(null);
+    let submenuPlacement = $state('');
+    let initialFocusSet = false;
+    let focusRequest = 0;
+    let placementRequest = 0;
+
+    let visibleItems = $derived(items.filter(item => !item.hidden));
+
+    function rootItems(): HTMLButtonElement[] {
+        return menuEl
+            ? Array.from(menuEl.querySelectorAll<HTMLButtonElement>('button[data-action-root]:not(:disabled)'))
+            : [];
+    }
+
+    function submenuItems(): HTMLButtonElement[] {
+        return submenuEl
+            ? Array.from(submenuEl.querySelectorAll<HTMLButtonElement>('button[data-action-child]:not(:disabled)'))
+            : [];
+    }
+
+    function focusedIndex(elements: HTMLElement[]): number {
+        const index = elements.indexOf(document.activeElement as HTMLElement);
+        return index < 0 ? 0 : index;
+    }
+
+    async function requestFocus(scope: 'root' | 'submenu', index: number) {
+        const request = ++focusRequest;
+        await tick();
+        if (request !== focusRequest) return;
+        const elements = scope === 'root' ? rootItems() : submenuItems();
+        if (elements.length === 0) return;
+        const wrapped = ((index % elements.length) + elements.length) % elements.length;
+        elements[wrapped]?.focus({ preventScroll: true });
+    }
+
+    async function placeMenu() {
+        const request = ++placementRequest;
+        menuReady = false;
+        menuX = x;
+        menuY = y;
+        await tick();
+        if (request !== placementRequest || !menuEl) return;
+        const rect = menuEl.getBoundingClientRect();
+        const next = clampFloatingPosition(
+            { x, y },
+            { width: rect.width, height: rect.height },
+            { width: window.innerWidth, height: window.innerHeight },
+        );
+        menuX = next.x;
+        menuY = next.y;
+        menuReady = true;
+        if (!initialFocusSet) {
+            initialFocusSet = true;
+            await requestFocus('root', 0);
+        }
+    }
+
+    async function placeSubmenu() {
+        await tick();
+        if (!submenuEl) return;
+        const parent = submenuEl.closest<HTMLElement>('.submenu-parent');
+        if (!parent) return;
+        const parentRect = parent.getBoundingClientRect();
+        const submenuRect = submenuEl.getBoundingClientRect();
+        const placement = placeAdjacentSubmenu(
+            {
+                x: parentRect.left,
+                y: parentRect.top,
+                width: parentRect.width,
+                height: parentRect.height,
+            },
+            { width: submenuRect.width, height: submenuRect.height },
+            { width: window.innerWidth, height: window.innerHeight },
+            460,
+        );
+        submenuPlacement = [
+            `--submenu-left: ${placement.left}px`,
+            `--submenu-top: ${placement.top}px`,
+            `--submenu-max-height: ${placement.maxHeight}px`,
+        ].join('; ');
+    }
+
+    $effect(() => {
+        if (!menuEl) return;
+        void placeMenu();
+    });
+
+    $effect(() => {
+        if (!openSubmenuId) return;
+        submenuEl;
+        void placeSubmenu();
+    });
+
+    function restoreOpenerFocus() {
+        const focusTarget = opener ?? fallbackOpener;
+        if (!focusTarget?.isConnected) return;
+        const active = document.activeElement;
+        const owned = !!menuEl && active instanceof Node && menuEl.contains(active);
+        if (active !== document.body && active !== menuEl && !owned) return;
+        focusTarget.focus({ preventScroll: true });
+    }
+
+    onMount(() => {
+        const releaseMenuClaim = claimContextMenu(onclose);
+        function closeFromOutside(event: MouseEvent) {
+            if (event.defaultPrevented) return;
+            if (menuEl && !menuEl.contains(event.target as Node)) onclose();
+        }
+        function reposition() {
+            void placeMenu();
+            void placeSubmenu();
+        }
+        function closeFromEarlyEscape(event: KeyboardEvent) {
+            if (event.key !== 'Escape') return;
+            if (menuEl && event.target instanceof Node && menuEl.contains(event.target)) return;
+            event.preventDefault();
+            event.stopPropagation();
+            onclose();
+        }
+        const listenerTimer = window.setTimeout(() => {
+            window.addEventListener('click', closeFromOutside);
+            window.addEventListener('contextmenu', closeFromOutside);
+        });
+        window.addEventListener('keydown', closeFromEarlyEscape, true);
+        window.addEventListener('resize', reposition);
+        return () => {
+            releaseMenuClaim();
+            window.clearTimeout(listenerTimer);
+            window.removeEventListener('click', closeFromOutside);
+            window.removeEventListener('contextmenu', closeFromOutside);
+            window.removeEventListener('keydown', closeFromEarlyEscape, true);
+            window.removeEventListener('resize', reposition);
+            focusRequest += 1;
+            restoreOpenerFocus();
+        };
+    });
+
+    async function openSubmenu(item: ActionMenuItem, focusFirst = false) {
+        if (!item.children?.some(child => !child.hidden && !child.disabled)) return;
+        openSubmenuId = item.id;
+        await placeSubmenu();
+        if (focusFirst) await requestFocus('submenu', 0);
+    }
+
+    async function activate(item: ActionMenuItem) {
+        if (item.disabled) return;
+        if (item.children?.length) {
+            await openSubmenu(item, true);
+            return;
+        }
+        onclose();
+        await item.action?.();
+    }
+
+    function parentRootIndex(): number {
+        const roots = rootItems();
+        const parent = roots.findIndex(button => button.dataset.actionId === openSubmenuId);
+        return parent < 0 ? 0 : parent;
+    }
+
+    async function closeSubmenuAndRestoreParent() {
+        const index = parentRootIndex();
+        openSubmenuId = null;
+        submenuPlacement = '';
+        await requestFocus('root', index);
+    }
+
+    function handleKeydown(event: KeyboardEvent) {
+        const inSubmenu = !!submenuEl
+            && event.target instanceof Node
+            && submenuEl.contains(event.target);
+        const elements = inSubmenu ? submenuItems() : rootItems();
+        if (elements.length === 0) return;
+        const index = focusedIndex(elements);
+
+        if (event.key === 'ArrowDown') {
+            event.preventDefault();
+            event.stopPropagation();
+            void requestFocus(inSubmenu ? 'submenu' : 'root', index + 1);
+        } else if (event.key === 'ArrowUp') {
+            event.preventDefault();
+            event.stopPropagation();
+            void requestFocus(inSubmenu ? 'submenu' : 'root', index - 1);
+        } else if (event.key === 'Home') {
+            event.preventDefault();
+            event.stopPropagation();
+            void requestFocus(inSubmenu ? 'submenu' : 'root', 0);
+        } else if (event.key === 'End') {
+            event.preventDefault();
+            event.stopPropagation();
+            void requestFocus(inSubmenu ? 'submenu' : 'root', elements.length - 1);
+        } else if (event.key === 'ArrowRight' && !inSubmenu) {
+            const item = visibleItems.find(candidate => candidate.id === elements[index]?.dataset.actionId);
+            if (item?.children?.length) {
+                event.preventDefault();
+                event.stopPropagation();
+                void openSubmenu(item, true);
+            }
+        } else if (event.key === 'ArrowLeft' && inSubmenu) {
+            event.preventDefault();
+            event.stopPropagation();
+            void closeSubmenuAndRestoreParent();
+        } else if (event.key === 'Escape') {
+            event.preventDefault();
+            event.stopPropagation();
+            if (inSubmenu || openSubmenuId) void closeSubmenuAndRestoreParent();
+            else onclose();
+        } else if ((event.key === 'Enter' || event.key === ' ') && event.target instanceof HTMLButtonElement) {
+            event.preventDefault();
+            event.stopPropagation();
+            event.target.click();
+        }
+    }
+</script>
+
+<div
+    class="action-menu"
+    style="left: {menuX}px; top: {menuY}px; visibility: {menuReady ? 'visible' : 'hidden'};"
+    role="menu"
+    aria-label={title ? `${title} actions` : 'Actions'}
+    tabindex="-1"
+    bind:this={menuEl}
+    onkeydown={handleKeydown}
+>
+    {#if title}<div class="menu-header">{title}</div>{/if}
+    {#each visibleItems as item}
+        {#if item.separatorBefore}<div class="separator" role="separator"></div>{/if}
+        <!-- svelte-ignore a11y_no_static_element_interactions -->
+        <div
+            class:submenu-parent={item.children?.length}
+            onmouseenter={() => { if (item.children?.length) void openSubmenu(item); }}
+            onmouseleave={() => { if (openSubmenuId === item.id && !(document.activeElement instanceof Node && submenuEl?.contains(document.activeElement))) openSubmenuId = null; }}
+        >
+            <button
+                type="button"
+                class="action-menu-item"
+                class:danger={item.danger}
+                class:has-submenu={item.children?.length}
+                role="menuitem"
+                data-action-root
+                data-action-id={item.id}
+                aria-haspopup={item.children?.length ? 'menu' : undefined}
+                aria-expanded={item.children?.length ? openSubmenuId === item.id : undefined}
+                disabled={item.disabled}
+                tabindex="-1"
+                onclick={() => activate(item)}
+            >
+                <span>{item.label}</span>
+                {#if item.children?.length}<span class="arrow" aria-hidden="true">▸</span>{/if}
+            </button>
+            {#if item.children?.length && openSubmenuId === item.id}
+                <div
+                    class="action-submenu"
+                    role="menu"
+                    aria-label={`${item.label} submenu`}
+                    bind:this={submenuEl}
+                    style={submenuPlacement}
+                >
+                    {#each item.children.filter(child => !child.hidden) as child}
+                        {#if child.separatorBefore}<div class="separator" role="separator"></div>{/if}
+                        <button
+                            type="button"
+                            class="action-menu-item"
+                            class:danger={child.danger}
+                            role="menuitem"
+                            data-action-child
+                            disabled={child.disabled}
+                            tabindex="-1"
+                            onclick={() => activate(child)}
+                        >{child.label}</button>
+                    {/each}
+                </div>
+            {/if}
+        </div>
+    {/each}
+</div>
+
+<style>
+    .action-menu,
+    .action-submenu {
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--radius);
+        box-shadow: 0 12px 32px color-mix(in srgb, var(--bg) 80%, transparent);
+        min-width: 220px;
+        padding: 4px;
+        z-index: var(--z-context-menu);
+    }
+    .action-menu {
+        position: fixed;
+    }
+    .submenu-parent {
+        position: relative;
+    }
+    .action-submenu {
+        left: var(--submenu-left, calc(100% - 1px));
+        max-height: var(--submenu-max-height, 460px);
+        overflow-y: auto;
+        position: absolute;
+        top: var(--submenu-top, -4px);
+    }
+    .menu-header {
+        color: var(--text-secondary);
+        font-size: 10px;
+        overflow: hidden;
+        padding: 6px 8px;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+    .action-menu-item {
+        align-items: center;
+        background: none;
+        border: none;
+        border-radius: var(--radius);
+        color: var(--text);
+        cursor: pointer;
+        display: flex;
+        font-family: inherit;
+        font-size: 12px;
+        gap: 16px;
+        justify-content: space-between;
+        min-height: 28px;
+        padding: 6px 8px;
+        text-align: left;
+        width: 100%;
+    }
+    .action-menu-item:hover:not(:disabled),
+    .action-menu-item:focus-visible {
+        background: var(--border);
+        outline: none;
+    }
+    .action-menu-item:disabled {
+        color: var(--text-secondary);
+        cursor: default;
+        opacity: 0.55;
+    }
+    .action-menu-item.danger {
+        color: var(--red);
+    }
+    .arrow {
+        color: var(--text-secondary);
+        margin-left: auto;
+    }
+    .separator {
+        background: var(--border);
+        height: 1px;
+        margin: 4px;
+    }
+</style>

--- a/src/lib/components/ActionMenu.test-harness.svelte
+++ b/src/lib/components/ActionMenu.test-harness.svelte
@@ -1,0 +1,40 @@
+<script lang="ts">
+    import ActionMenu, { type ActionMenuItem } from './ActionMenu.svelte';
+
+    let {
+        onclose,
+        onopen,
+        onalpha,
+        onbeta,
+        ondelete,
+        opener = null,
+        targetKey = 'initial',
+    }: {
+        onclose: () => void;
+        onopen: () => void;
+        onalpha: () => void;
+        onbeta: () => void;
+        ondelete: () => void;
+        opener?: HTMLElement | null;
+        targetKey?: string;
+    } = $props();
+
+    const items: ActionMenuItem[] = [
+        { id: 'open', label: 'Open', action: () => onopen() },
+        {
+            id: 'add',
+            label: 'Add to Collection',
+            children: [
+                { id: 'alpha', label: 'Alpha', action: () => onalpha() },
+                { id: 'disabled', label: 'Unavailable', disabled: true, action: () => {} },
+                { id: 'beta', label: 'Beta', action: () => onbeta() },
+            ],
+        },
+        { id: 'delete', label: 'Delete…', danger: true, separatorBefore: true, action: () => ondelete() },
+    ];
+</script>
+
+<button type="button">Menu opener</button>
+{#key targetKey}
+    <ActionMenu title="Example" x={40} y={40} {items} {opener} {onclose} />
+{/key}

--- a/src/lib/components/ContextMenu.svelte
+++ b/src/lib/components/ContextMenu.svelte
@@ -13,6 +13,7 @@
     import { requestTrashImages } from '$lib/trash-actions';
     import { commandShortcutHints, eventMatchesShortcut } from '$lib/command-palette';
     import { copyImageWithToast } from '$lib/image-copy-action';
+    import { claimContextMenu } from '$lib/context-menu-coordinator';
 
     interface Props {
         image: ImageWithFile;
@@ -164,6 +165,7 @@
     });
 
     onMount(() => {
+        const releaseMenuClaim = claimContextMenu(onclose);
         function handleClickOutside(e: MouseEvent) {
             if (menuEl && !menuEl.contains(e.target as Node)) onclose();
         }
@@ -185,6 +187,7 @@
             window.addEventListener('resize', handleResize);
         });
         return () => {
+            releaseMenuClaim();
             window.removeEventListener('click', handleClickOutside);
             window.removeEventListener('contextmenu', handleClickOutside);
             window.removeEventListener('keydown', handleWindowKeydown, true);

--- a/src/lib/components/Sidebar.svelte
+++ b/src/lib/components/Sidebar.svelte
@@ -3,11 +3,12 @@
     import { open } from '@tauri-apps/plugin-dialog';
     import { listen, type UnlistenFn } from '@tauri-apps/api/event';
     import { totalCount, folders, activeFolder, minSizeFilter, collections, activeCollection, activeDetectedClass, detectedClasses as detectedClassesStore, collectMode, collectModeTarget, smartCollections, activeSmartCollection, showToast, pinnedCollection, pinnedCollections, showMissing, showRejected, requestTextInput, requestConfirm, clipboardMonitorStatus, exportFolderOpen } from '$lib/stores';
-    import { importFolder as apiImportFolder, getImageCount, listFolders, deleteFolder as apiDeleteFolder, renameFolder as apiRenameFolder, listCollections, createCollection, renameCollectionApi, deleteCollectionApi, listCollectionImages, listSmartCollections, countByDetectedClass, listDetectedClasses, regenerateThumbnails, rescanSources, getClipboardMonitorStatus, startClipboardMonitor, stopClipboardMonitor, setClipboardMonitorCaptureExistingOnStart, moveClipboardCaptureFolder, publishClipboardCollection } from '$lib/api';
+    import { importFolder as apiImportFolder, getImageCount, listFolders, deleteFolder as apiDeleteFolder, renameFolder as apiRenameFolder, listCollections, createCollection, createCollectionWithImages, renameCollectionApi, deleteCollectionApi, listCollectionImages, listSmartCollections, updateSmartCollectionApi, deleteSmartCollectionApi, countByDetectedClass, listDetectedClasses, regenerateThumbnails, rescanSources, getClipboardMonitorStatus, startClipboardMonitor, stopClipboardMonitor, setClipboardMonitorCaptureExistingOnStart, moveClipboardCaptureFolder, publishClipboardCollection } from '$lib/api';
     import { loadImagesForCurrentScope } from '$lib/image-loading';
-    import type { ClipboardMonitorStatus, ClipboardPublishResult, ImageWithFile, SmartCollection } from '$lib/api';
+    import type { ClipboardMonitorStatus, ClipboardPublishResult, FilterNode, ImageWithFile, SmartCollection } from '$lib/api';
     import { applyClipboardMonitorCollection } from '$lib/clipboard-monitor';
     import { safeAssetPreviewPath } from '$lib/view-utils';
+    import { revealItemInDir } from '@tauri-apps/plugin-opener';
     import { onDestroy, onMount } from 'svelte';
     import { get } from 'svelte/store';
 
@@ -38,20 +39,13 @@
         x: number;
         y: number;
     } | null>(null);
-    let collectionContextMenu = $state<{
-        collectionId: string;
-        name: string;
-        count: number;
-        x: number;
-        y: number;
-    } | null>(null);
-    let folderContextMenu = $state<{
-        path: string;
-        name: string;
-        isGroup: boolean;
-        x: number;
-        y: number;
-    } | null>(null);
+    type SidebarContextTarget =
+        | { kind: 'folder'; folder: string; name: string; renamable: boolean; removable: boolean; x: number; y: number; opener: HTMLElement | null }
+        | { kind: 'collection'; collectionId: string; name: string; count: number; x: number; y: number; opener: HTMLElement | null }
+        | { kind: 'smart'; collection: SmartCollection; x: number; y: number; opener: HTMLElement | null };
+    let sidebarContextMenu = $state<SidebarContextTarget | null>(null);
+    let smartCollectionEditor = $state<SmartCollection | null>(null);
+    let smartCollectionDraft = $state<FilterNode | null>(null);
     let collectionPreviewTimer: ReturnType<typeof setTimeout> | null = null;
     let collectionPreviewRequest = 0;
     let browseCountsRequest = 0;
@@ -77,6 +71,10 @@
     import { createCanvas, type Canvas } from '$lib/api';
     import { reconcileRenamedCanvas, reconcileRenamedSession, renamedFolderPath } from '$lib/folder-rename-state';
     import { withCanvasPathMigrationBarrier } from '$lib/canvas-save-coordinator';
+    import ActionMenu from './ActionMenu.svelte';
+    import ModalDialog from './ModalDialog.svelte';
+    import RuleBuilder from './RuleBuilder.svelte';
+    import { buildCollectionContextActions, buildFolderContextActions, buildSmartCollectionContextActions } from '$lib/sidebar-context-actions';
 
     // "All Images" is only the active scope when nothing else narrows it —
     // including a detected-class filter, which used to leave both All Images
@@ -160,6 +158,21 @@
         const i = Math.min(treeFocusIndex, rows.length - 1);
         const row = rows[i];
 
+        if (isContextMenuKey(event)) {
+            const treeItem = event.target instanceof HTMLElement
+                ? event.target.closest<HTMLElement>('[data-tree-row]')
+                : null;
+            openFolderContextMenu(
+                event,
+                row.fullPath,
+                row.name,
+                row.fullPath !== '/',
+                !row.isGroup && row.fullPath !== '/',
+                treeItem,
+            );
+            return;
+        }
+
         switch (event.key) {
             case 'Enter':
             case ' ':
@@ -209,7 +222,7 @@
             case 'Delete':
                 if (!row.isGroup) {
                     event.preventDefault();
-                    void handleDeleteFolder(event, row.fullPath);
+                    void handleDeleteFolder(row.fullPath);
                 }
                 break;
         }
@@ -221,11 +234,12 @@
         isSectionCollapsed($sidebarSectionsCollapsed, 'clipboard') && !clipboardStatus?.running
     );
 
-    // Smart collections seed ~22 presets. Hiding the empty ones keeps the list
-    // proportional to the library instead of to the seed table.
+    // Smart collections seed ~22 presets. Hide empty built-ins to keep the list
+    // proportional to the library, but retain user collections so their rules
+    // can still be edited when they currently match nothing.
     let visibleSmartCollections = $derived(
         $smartCollections.filter(sc =>
-            (sc.image_count ?? 0) > 0 &&
+            ((sc.image_count ?? 0) > 0 || !sc.is_preset) &&
             sc.id !== recentImportsCollection?.id &&
             matchesSidebarFilter(sc.name, $sidebarFilter)
         )
@@ -277,39 +291,54 @@
         }
     }
 
-    function openCollectionContextMenu(event: MouseEvent, collectionId: string, name: string, count: number) {
+    function contextPoint(event: MouseEvent | KeyboardEvent, anchor?: HTMLElement | null): { x: number; y: number } {
+        if (event instanceof MouseEvent && event.type === 'contextmenu') {
+            return { x: event.clientX, y: event.clientY };
+        }
+        const target = anchor ?? event.currentTarget as HTMLElement | null;
+        const rect = target?.getBoundingClientRect();
+        return rect
+            ? { x: rect.left + Math.min(32, rect.width / 2), y: rect.top + Math.min(24, rect.height) }
+            : { x: 16, y: 16 };
+    }
+
+    function isContextMenuKey(event: KeyboardEvent): boolean {
+        return event.key === 'ContextMenu' || (event.shiftKey && event.key === 'F10');
+    }
+
+    function openCollectionContextMenu(event: MouseEvent | KeyboardEvent, collectionId: string, name: string, count: number) {
         event.preventDefault();
         event.stopPropagation();
         hideCollectionPreview(collectionId);
-        folderContextMenu = null;
-        collectionContextMenu = {
-            collectionId,
-            name,
-            count,
-            x: Math.min(event.clientX, window.innerWidth - 208),
-            y: Math.min(event.clientY, window.innerHeight - 224),
+        sidebarContextMenu = {
+            kind: 'collection', collectionId, name, count,
+            ...contextPoint(event),
+            opener: event.currentTarget as HTMLElement | null,
         };
     }
 
-    function closeCollectionContextMenu() {
-        collectionContextMenu = null;
-    }
-
-    function openFolderContextMenu(event: MouseEvent, path: string, name: string, isGroup: boolean) {
+    function openFolderContextMenu(event: MouseEvent | KeyboardEvent, folder: string, name: string, renamable: boolean, removable: boolean, anchor?: HTMLElement | null) {
         event.preventDefault();
         event.stopPropagation();
-        closeCollectionContextMenu();
-        folderContextMenu = {
-            path,
-            name,
-            isGroup,
-            x: Math.min(event.clientX, window.innerWidth - 208),
-            y: Math.min(event.clientY, window.innerHeight - 128),
+        sidebarContextMenu = {
+            kind: 'folder', folder, name, renamable, removable,
+            ...contextPoint(event, anchor),
+            opener: anchor ?? event.currentTarget as HTMLElement | null,
         };
     }
 
-    function closeFolderContextMenu() {
-        folderContextMenu = null;
+    function openSmartCollectionContextMenu(event: MouseEvent | KeyboardEvent, collection: SmartCollection) {
+        event.preventDefault();
+        event.stopPropagation();
+        sidebarContextMenu = {
+            kind: 'smart', collection,
+            ...contextPoint(event),
+            opener: event.currentTarget as HTMLElement | null,
+        };
+    }
+
+    function closeSidebarContextMenu() {
+        sidebarContextMenu = null;
     }
 
     onDestroy(() => {
@@ -406,7 +435,7 @@
     }
 
     async function handleRenameCollection(collectionId: string, currentName: string) {
-        closeCollectionContextMenu();
+        closeSidebarContextMenu();
         const name = await requestTextInput({
             title: 'Rename Collection',
             label: 'Collection name',
@@ -426,13 +455,68 @@
     }
 
     async function handleExportCollection(collectionId: string) {
-        closeCollectionContextMenu();
+        closeSidebarContextMenu();
         await selectCollection(collectionId);
         exportFolderOpen.set(true);
     }
 
+    async function listAllCollectionImageIds(collectionId: string): Promise<string[]> {
+        const pageSize = 500;
+        const ids: string[] = [];
+        for (let offset = 0; ; offset += pageSize) {
+            const page = await listCollectionImages(collectionId, pageSize, offset, true);
+            ids.push(...page.map(item => item.image.id));
+            if (page.length < pageSize) break;
+        }
+        return [...new Set(ids)];
+    }
+
+    async function duplicateCollection(collectionId: string, currentName: string) {
+        const name = await requestTextInput({
+            title: 'Duplicate Collection',
+            label: 'New collection name',
+            initialValue: `${currentName} Copy`,
+            confirmLabel: 'Duplicate',
+        });
+        if (!name?.trim()) return;
+        let ids: string[];
+        try {
+            ids = await listAllCollectionImageIds(collectionId);
+            await createCollectionWithImages(name.trim(), ids);
+        } catch (e) {
+            showToast('Could not duplicate collection', { detail: String(e), type: 'error', duration: 10000 });
+            return;
+        }
+        showToast(`Duplicated “${currentName}”`, {
+            detail: `${ids.length} image${ids.length === 1 ? '' : 's'}`,
+            type: 'success',
+        });
+        try {
+            collections.set(await listCollections($showRejected));
+        } catch (e) {
+            showToast('Collection duplicated, but the sidebar could not refresh', {
+                detail: String(e), type: 'warning', duration: 10000,
+            });
+        }
+    }
+
+    async function publishCollection(collectionId: string) {
+        try {
+            const result = await publishClipboardCollection(collectionId);
+            clipboardPublishResult = result;
+            try {
+                await navigator.clipboard.writeText(result.url);
+                showToast('Collection published; link copied', { detail: result.url, type: 'success', duration: 10000 });
+            } catch (e) {
+                showToast('Collection published', { detail: `${result.url} · Copy failed: ${e}`, type: 'warning', duration: 10000 });
+            }
+        } catch (e) {
+            showToast('Could not publish collection', { detail: String(e), type: 'error', duration: 10000 });
+        }
+    }
+
     async function copyCollectionId(collectionId: string) {
-        closeCollectionContextMenu();
+        closeSidebarContextMenu();
         try {
             await navigator.clipboard.writeText(collectionId);
             showToast('Collection ID copied', { type: 'success', duration: 2500 });
@@ -442,7 +526,7 @@
     }
 
     function setCollectTarget(collectionId: string, name: string) {
-        closeCollectionContextMenu();
+        closeSidebarContextMenu();
         collectMode.set(true);
         collectModeTarget.set(collectionId);
         showToast('Collect mode enabled', { detail: name, type: 'info', duration: 5000 });
@@ -513,9 +597,8 @@
         }
     }
 
-    async function handleDeleteCollection(event: Event, collectionId: string, collectionName: string) {
-        event.stopPropagation();
-        closeCollectionContextMenu();
+    async function handleDeleteCollection(collectionId: string, collectionName: string) {
+        closeSidebarContextMenu();
         const confirmed = await requestConfirm({
             title: 'Delete Collection',
             description: `Delete collection "${collectionName}"? Images stay in the library.`,
@@ -543,8 +626,8 @@
         }
     }
 
-    async function handleDeleteFolder(event: Event, folder: string) {
-        event.stopPropagation();
+    async function handleDeleteFolder(folder: string) {
+        closeSidebarContextMenu();
         const name = folderName(folder);
         const confirmed = await requestConfirm({
             title: 'Remove Folder from Library',
@@ -566,7 +649,7 @@
     }
 
     async function handleRenameFolder(folder: string, currentName: string) {
-        closeFolderContextMenu();
+        closeSidebarContextMenu();
         const name = await requestTextInput({
             title: 'Rename Folder',
             label: 'Folder name',
@@ -600,6 +683,116 @@
         } catch (e) {
             console.error('Failed to rename folder:', e);
             showToast('Failed to rename folder', { detail: String(e), type: 'error', duration: 8000 });
+        }
+    }
+
+    async function revealFolder(folder: string) {
+        try {
+            await revealItemInDir(folder);
+        } catch (e) {
+            showToast('Could not reveal folder in Finder', { detail: String(e), type: 'error', duration: 8000 });
+        }
+    }
+
+    async function rescanFolder(folder: string) {
+        if (importing) return;
+        importing = true;
+        importCurrent = 0;
+        importTotal = 0;
+        try {
+            const result = await apiImportFolder(folder);
+            const summary = `Rescanned “${folderName(folder)}”: ${result.imported} imported, ${result.skipped} unchanged`;
+            setLastResult(result.errors.length > 0 ? `${summary}, ${result.errors.length} errors` : summary, result.errors.length > 0 ? 'error' : 'success');
+            await refreshImages();
+        } catch (e) {
+            setLastResult(`Rescan failed: ${e}`, 'error');
+        } finally {
+            importing = false;
+        }
+    }
+
+    async function beginEditSmartCollection(id: string) {
+        const collection = get(smartCollections).find(item => item.id === id);
+        if (!collection?.filter_json || collection.is_preset) return;
+        try {
+            smartCollectionDraft = JSON.parse(collection.filter_json) as FilterNode;
+            smartCollectionEditor = collection;
+        } catch (e) {
+            showToast('Smart collection rules could not be opened', { detail: String(e), type: 'error', duration: 8000 });
+        }
+    }
+
+    function closeSmartCollectionEditor() {
+        smartCollectionEditor = null;
+        smartCollectionDraft = null;
+    }
+
+    async function saveSmartCollectionRules() {
+        const collection = smartCollectionEditor;
+        const draft = smartCollectionDraft;
+        if (!collection || !draft) return;
+        try {
+            await updateSmartCollectionApi(
+                collection.id,
+                collection.name,
+                JSON.stringify(draft),
+                collection.nl_query ?? undefined,
+            );
+        } catch (e) {
+            showToast('Could not update smart collection', { detail: String(e), type: 'error', duration: 10000 });
+            return;
+        }
+        closeSmartCollectionEditor();
+        try {
+            const updated = await listSmartCollections($showRejected);
+            smartCollections.set(updated);
+            const nextActive = updated.find(item => item.id === collection.id) ?? null;
+            if (get(activeSmartCollection)?.id === collection.id && nextActive) {
+                activeSmartCollection.set(nextActive);
+                await loadImagesForCurrentScope({ force: true, invalidateCache: true });
+            }
+            showToast('Smart collection rules updated', { type: 'success' });
+        } catch (e) {
+            showToast('Smart collection updated, but the view could not refresh', {
+                detail: String(e), type: 'warning', duration: 10000,
+            });
+        }
+    }
+
+    async function deleteSmartCollection(id: string, name: string) {
+        const confirmed = await requestConfirm({
+            title: 'Delete Smart Collection',
+            description: `Delete smart collection “${name}”? Images stay in the library.`,
+            confirmLabel: 'Delete',
+            danger: true,
+        });
+        if (!confirmed) return;
+        try {
+            await deleteSmartCollectionApi(id);
+        } catch (e) {
+            showToast('Could not delete smart collection', { detail: String(e), type: 'error', duration: 10000 });
+            return;
+        }
+        const refreshErrors: string[] = [];
+        if (get(activeSmartCollection)?.id === id) {
+            activeSmartCollection.set(null);
+            try {
+                await loadImagesForCurrentScope({ force: true, invalidateCache: true });
+            } catch (e) {
+                refreshErrors.push(String(e));
+            }
+        }
+        try {
+            smartCollections.set(await listSmartCollections($showRejected));
+        } catch (e) {
+            refreshErrors.push(String(e));
+        }
+        if (refreshErrors.length === 0) {
+            showToast('Smart collection deleted', { type: 'success' });
+        } else {
+            showToast('Smart collection deleted, but the view could not refresh', {
+                detail: refreshErrors.join(' · '), type: 'warning', duration: 10000,
+            });
         }
     }
 
@@ -829,12 +1022,54 @@
             folders.set(f);
         } catch (_) {}
     }
-</script>
 
-<svelte:window
-    onclick={() => { closeCollectionContextMenu(); closeFolderContextMenu(); }}
-    onkeydown={(e) => { if (e.key === 'Escape') { closeCollectionContextMenu(); closeFolderContextMenu(); hideCollectionPreview(); } }}
-/>
+    let sidebarContextItems = $derived.by(() => {
+        const target = sidebarContextMenu;
+        if (!target) return [];
+        if (target.kind === 'folder') {
+            return buildFolderContextActions({
+                folder: target.folder,
+                name: folderName(target.folder),
+                renamable: target.renamable,
+                removable: target.removable,
+                onOpen: selectFolder,
+                onReveal: revealFolder,
+                onRename: handleRenameFolder,
+                onRescan: rescanFolder,
+                onRemove: handleDeleteFolder,
+            });
+        }
+        if (target.kind === 'collection') {
+            return buildCollectionContextActions({
+                collectionId: target.collectionId,
+                name: target.name,
+                count: target.count,
+                pinned: $pinnedCollections.includes(target.collectionId),
+                onOpen: selectCollection,
+                onRename: handleRenameCollection,
+                onDuplicate: duplicateCollection,
+                onExport: handleExportCollection,
+                onPublish: publishCollection,
+                onCollect: setCollectTarget,
+                onTogglePin: togglePinnedCollection,
+                onCopyId: copyCollectionId,
+                onDelete: handleDeleteCollection,
+            });
+        }
+        const collection = target.collection;
+        return buildSmartCollectionContextActions({
+            id: collection.id,
+            name: collection.name,
+            isPreset: collection.is_preset,
+            onOpen: async (id) => {
+                const next = get(smartCollections).find(item => item.id === id);
+                if (next) await selectSmartCollection(next);
+            },
+            onEdit: beginEditSmartCollection,
+            onDelete: deleteSmartCollection,
+        });
+    });
+</script>
 
 <aside class="sidebar" aria-label="Library sidebar">
     <div class="sidebar-scroll">
@@ -939,7 +1174,7 @@
                         data-tree-row={i}
                         tabindex={i === treeTabIndex ? 0 : -1}
                         onfocusin={() => treeFocusIndex = i}
-                        oncontextmenu={(e) => openFolderContextMenu(e, folder.fullPath, folder.name, folder.isGroup)}
+                        oncontextmenu={(e) => openFolderContextMenu(e, folder.fullPath, folder.name, folder.fullPath !== '/', !folder.isGroup && folder.fullPath !== '/')}
                     >
                         {#if folder.hasChildren}
                             <button
@@ -969,15 +1204,14 @@
                                     : `${folder.count} directly in this folder, ${folder.subtreeCount} including subfolders`}
                             >{formatFolderCount(folder.count, folder.subtreeCount)}</span>
                         </button>
-                        {#if !folder.isGroup}
-                            <button
-                                class="delete-btn"
-                                tabindex="-1"
-                                onclick={(e: Event) => handleDeleteFolder(e, folder.fullPath)}
-                                title="Remove folder from library"
-                                aria-label={`Remove folder from library: ${folder.name}`}
-                            >&times;</button>
-                        {/if}
+                        <button
+                            class="menu-btn"
+                            tabindex="-1"
+                            onclick={(event) => openFolderContextMenu(event, folder.fullPath, folder.name, folder.fullPath !== '/', !folder.isGroup && folder.fullPath !== '/')}
+                            title="Folder actions"
+                            aria-label={`Folder actions: ${folder.name}`}
+                            aria-haspopup="menu"
+                        >…</button>
                     </div>
                 {/each}
                 {#if visibleFolders.length === 0}
@@ -1016,6 +1250,7 @@
                     <button
                         class="section-item"
                         onclick={() => selectCollection(id)}
+                        onkeydown={(event) => { if (isContextMenuKey(event)) openCollectionContextMenu(event, id, name, count); }}
                         aria-current={$activeCollection === id ? 'true' : undefined}
                     >
                         <span class="icon">&#9671;</span>
@@ -1033,11 +1268,12 @@
                         <span class="generated-pin" aria-hidden="true"></span>
                     </button>
                     <button
-                        class="delete-btn"
-                        onclick={(e: Event) => handleDeleteCollection(e, id, name)}
-                        title="Delete collection"
-                        aria-label={`Delete collection: ${name}`}
-                    >&times;</button>
+                        class="menu-btn"
+                        onclick={(event) => openCollectionContextMenu(event, id, name, count)}
+                        title="Collection actions"
+                        aria-label={`Collection actions: ${name}`}
+                        aria-haspopup="menu"
+                    >…</button>
                 </div>
             {/each}
         {/if}
@@ -1060,6 +1296,8 @@
                 <button class="section-item"
                     class:active={$activeSmartCollection?.id === sc.id}
                     onclick={() => selectSmartCollection(sc)}
+                    oncontextmenu={(event) => openSmartCollectionContextMenu(event, sc)}
+                    onkeydown={(event) => { if (isContextMenuKey(event)) openSmartCollectionContextMenu(event, sc); }}
                     aria-current={$activeSmartCollection?.id === sc.id ? 'true' : undefined}>
                     <span class="icon">&#9733;</span>
                     <span class="item-label">{sc.name}</span>
@@ -1201,40 +1439,21 @@
         </div>
     {/if}
 
-    {#if collectionContextMenu}
-        <div
-            class="collection-context-menu"
-            style="left: {collectionContextMenu.x}px; top: {collectionContextMenu.y}px;"
-            role="menu"
-            tabindex="-1"
-        >
-            <div class="context-menu-header">{collectionContextMenu.name}</div>
-            <button type="button" role="menuitem" onclick={() => { selectCollection(collectionContextMenu!.collectionId); closeCollectionContextMenu(); }}>Open Collection</button>
-            <button type="button" role="menuitem" onclick={() => handleRenameCollection(collectionContextMenu!.collectionId, collectionContextMenu!.name)}>Rename...</button>
-            <button type="button" role="menuitem" onclick={() => handleExportCollection(collectionContextMenu!.collectionId)} disabled={collectionContextMenu.count === 0}>Export to Folder...</button>
-            <button type="button" role="menuitem" onclick={() => setCollectTarget(collectionContextMenu!.collectionId, collectionContextMenu!.name)}>Use for Collect Mode</button>
-            <button type="button" role="menuitem" onclick={() => togglePinnedCollection(collectionContextMenu!.collectionId)}>
-                {$pinnedCollections.includes(collectionContextMenu.collectionId) ? 'Unpin Collection' : 'Pin Collection'}
-            </button>
-            <button type="button" role="menuitem" onclick={() => copyCollectionId(collectionContextMenu!.collectionId)}>Copy Collection ID</button>
-            <button type="button" role="menuitem" class="danger" onclick={(e) => handleDeleteCollection(e, collectionContextMenu!.collectionId, collectionContextMenu!.name)}>Delete Collection...</button>
-        </div>
-    {/if}
-
-    {#if folderContextMenu}
-        <div
-            class="collection-context-menu folder-context-menu"
-            style="left: {folderContextMenu.x}px; top: {folderContextMenu.y}px;"
-            role="menu"
-            tabindex="-1"
-        >
-            <div class="context-menu-header">{folderContextMenu.name}</div>
-            <button type="button" role="menuitem" onclick={() => { selectFolder(folderContextMenu!.path); closeFolderContextMenu(); }}>Open Folder</button>
-            <button type="button" role="menuitem" onclick={() => handleRenameFolder(folderContextMenu!.path, folderName(folderContextMenu!.path))}>Rename...</button>
-            {#if !folderContextMenu.isGroup}
-                <button type="button" role="menuitem" class="danger" onclick={(e) => { const path = folderContextMenu!.path; closeFolderContextMenu(); handleDeleteFolder(e, path); }}>Remove from Library...</button>
-            {/if}
-        </div>
+    {#if sidebarContextMenu}
+        {#key sidebarContextMenu.kind === 'folder'
+            ? `folder:${sidebarContextMenu.folder}`
+            : sidebarContextMenu.kind === 'collection'
+                ? `collection:${sidebarContextMenu.collectionId}`
+                : `smart:${sidebarContextMenu.collection.id}`}
+            <ActionMenu
+                title={sidebarContextMenu.kind === 'smart' ? sidebarContextMenu.collection.name : sidebarContextMenu.name}
+                x={sidebarContextMenu.x}
+                y={sidebarContextMenu.y}
+                items={sidebarContextItems}
+                opener={sidebarContextMenu.opener}
+                onclose={closeSidebarContextMenu}
+            />
+        {/key}
     {/if}
 
     <div class="sidebar-footer" aria-live="polite" aria-busy={importing || regenerating || rescanning}>
@@ -1277,6 +1496,27 @@
         </div>
     </div>
 </aside>
+
+{#if smartCollectionEditor && smartCollectionDraft}
+    <ModalDialog
+        titleId="smart-collection-editor-title"
+        descriptionId="smart-collection-editor-description"
+        onclose={closeSmartCollectionEditor}
+    >
+        <div class="smart-editor-dialog">
+            <h2 id="smart-collection-editor-title">Edit {smartCollectionEditor.name}</h2>
+            <p id="smart-collection-editor-description">Adjust the rules that decide which images appear in this smart collection.</p>
+            <RuleBuilder
+                filter={smartCollectionDraft}
+                onchange={(next) => smartCollectionDraft = next}
+            />
+            <div class="smart-editor-actions">
+                <button type="button" onclick={closeSmartCollectionEditor}>Cancel</button>
+                <button type="button" class="primary" data-modal-initial-focus onclick={saveSmartCollectionRules}>Save Rules</button>
+            </div>
+        </div>
+    </ModalDialog>
+{/if}
 
 <style>
     .sidebar {
@@ -1472,33 +1712,6 @@
     .folder-row .section-item {
         flex: 1;
         min-width: 0;
-    }
-    .delete-btn {
-        align-items: center;
-        display: inline-flex;
-        height: 24px;
-        justify-content: center;
-        margin-right: 4px;
-        font-size: 14px;
-        line-height: 1;
-        color: var(--text-secondary);
-        cursor: pointer;
-        flex-shrink: 0;
-        background: none;
-        border: none;
-        opacity: 0;
-        padding: 0;
-        pointer-events: none;
-        font-family: inherit;
-        width: 24px;
-    }
-    .folder-row:hover .delete-btn,
-    .folder-row:focus-within .delete-btn {
-        opacity: 1;
-        pointer-events: auto;
-    }
-    .delete-btn:hover {
-        color: var(--red);
     }
     .folders-toggle {
         font-size: 11px;
@@ -1813,46 +2026,68 @@
         object-fit: cover;
         width: 100%;
     }
-    .collection-context-menu {
+    .menu-btn {
+        align-items: center;
+        background: none;
+        border: none;
+        color: var(--text-secondary);
+        cursor: pointer;
+        display: inline-flex;
+        flex-shrink: 0;
+        font: inherit;
+        font-size: 15px;
+        height: 24px;
+        justify-content: center;
+        line-height: 1;
+        margin-right: 4px;
+        opacity: 0;
+        padding: 0;
+        pointer-events: none;
+        width: 24px;
+    }
+    .folder-row:hover .menu-btn,
+    .folder-row:focus-within .menu-btn {
+        opacity: 1;
+        pointer-events: auto;
+    }
+    .menu-btn:hover,
+    .menu-btn:focus-visible {
+        color: var(--text);
+        outline: 1px solid var(--blue);
+    }
+    .smart-editor-dialog {
+        min-width: min(620px, 80vw);
+        padding: calc(var(--spacing) * 2);
+    }
+    .smart-editor-dialog h2 {
+        color: var(--text);
+        font-size: 16px;
+        margin: 0 0 var(--spacing);
+    }
+    .smart-editor-dialog p {
+        color: var(--text-secondary);
+        font-size: 12px;
+        line-height: 1.5;
+        margin: 0 0 calc(var(--spacing) * 2);
+    }
+    .smart-editor-actions {
+        display: flex;
+        gap: var(--spacing);
+        justify-content: flex-end;
+        margin-top: calc(var(--spacing) * 2);
+    }
+    .smart-editor-actions button {
         background: var(--surface);
         border: 1px solid var(--border);
         border-radius: var(--radius);
-        box-shadow: 0 12px 32px color-mix(in srgb, var(--bg) 80%, transparent);
-        display: grid;
-        min-width: 200px;
-        padding: 4px;
-        position: fixed;
-        z-index: var(--z-context-menu);
-    }
-    .context-menu-header {
-        color: var(--text-secondary);
-        font-size: 10px;
-        overflow: hidden;
-        padding: 6px 8px;
-        text-overflow: ellipsis;
-        white-space: nowrap;
-    }
-    .collection-context-menu button {
-        background: none;
-        border: none;
-        border-radius: var(--radius);
         color: var(--text);
         cursor: pointer;
-        font-family: inherit;
-        font-size: 12px;
-        padding: 6px 8px;
-        text-align: left;
+        font: inherit;
+        padding: 7px 12px;
     }
-    .collection-context-menu button:hover:not(:disabled),
-    .collection-context-menu button:focus-visible {
-        background: var(--border);
-    }
-    .collection-context-menu button:disabled {
-        color: var(--text-secondary);
-        cursor: default;
-    }
-    .collection-context-menu button.danger {
-        color: var(--red);
+    .smart-editor-actions button.primary {
+        border-color: var(--blue);
+        color: var(--blue);
     }
     .sr-only {
         border: 0;

--- a/src/lib/components/action-menu.behavior.test.ts
+++ b/src/lib/components/action-menu.behavior.test.ts
@@ -1,0 +1,108 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import '@testing-library/jest-dom/vitest';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import Harness from './ActionMenu.test-harness.svelte';
+
+afterEach(() => cleanup());
+
+function renderMenu() {
+    const opener = document.createElement('button');
+    opener.textContent = 'External opener';
+    document.body.append(opener);
+    opener.focus();
+    const handlers = {
+        onclose: vi.fn(),
+        onopen: vi.fn(),
+        onalpha: vi.fn(),
+        onbeta: vi.fn(),
+        ondelete: vi.fn(),
+        opener,
+        targetKey: 'initial',
+    };
+    const view = render(Harness, handlers);
+    return { handlers, opener, view };
+}
+
+describe('ActionMenu rendered behavior', () => {
+    it('focuses the first action and wraps through enabled root actions', async () => {
+        const user = userEvent.setup();
+        renderMenu();
+
+        const open = await screen.findByRole('menuitem', { name: 'Open' });
+        await waitFor(() => expect(open).toHaveFocus());
+        await user.keyboard('{ArrowUp}');
+        expect(screen.getByRole('menuitem', { name: 'Delete…' })).toHaveFocus();
+        await user.keyboard('{ArrowDown}');
+        expect(open).toHaveFocus();
+    });
+
+    it('enters and leaves a submenu without focusing disabled actions', async () => {
+        const user = userEvent.setup();
+        renderMenu();
+
+        await waitFor(() => expect(screen.getByRole('menuitem', { name: 'Open' })).toHaveFocus());
+        await user.keyboard('{ArrowDown}{ArrowRight}');
+        expect(screen.getByRole('menuitem', { name: 'Alpha' })).toHaveFocus();
+        await user.keyboard('{ArrowDown}');
+        expect(screen.getByRole('menuitem', { name: 'Beta' })).toHaveFocus();
+        await user.keyboard('{ArrowLeft}');
+        expect(screen.getByRole('menuitem', { name: /Add to Collection/ })).toHaveFocus();
+    });
+
+    it('dispatches the selected action and closes the menu', async () => {
+        const user = userEvent.setup();
+        const { handlers } = renderMenu();
+
+        await waitFor(() => expect(screen.getByRole('menuitem', { name: 'Open' })).toHaveFocus());
+        await user.keyboard('{ArrowDown}{ArrowRight}{ArrowDown}{Enter}');
+        expect(handlers.onbeta).toHaveBeenCalledOnce();
+        expect(handlers.onclose).toHaveBeenCalledOnce();
+    });
+
+    it('closes on Escape or outside click and restores opener focus after unmount', async () => {
+        const user = userEvent.setup();
+        const first = renderMenu();
+        await waitFor(() => expect(screen.getByRole('menuitem', { name: 'Open' })).toHaveFocus());
+        await user.keyboard('{Escape}');
+        expect(first.handlers.onclose).toHaveBeenCalledOnce();
+        first.view.unmount();
+        expect(first.opener).toHaveFocus();
+        first.opener.remove();
+
+        cleanup();
+        const second = renderMenu();
+        await waitFor(() => expect(screen.getByRole('menuitem', { name: 'Open' })).toHaveFocus());
+        await fireEvent.click(document.body);
+        expect(second.handlers.onclose).toHaveBeenCalledOnce();
+        second.view.unmount();
+        second.opener.remove();
+    });
+
+    it('closes on Escape before asynchronous placement moves focus into the menu', async () => {
+        const { handlers, opener, view } = renderMenu();
+        await fireEvent.keyDown(window, { key: 'Escape' });
+        expect(handlers.onclose).toHaveBeenCalledOnce();
+        view.unmount();
+        opener.remove();
+    });
+
+    it('does not close when a handled contextmenu event retargets the active menu', async () => {
+        const { handlers, opener, view } = renderMenu();
+        await waitFor(() => expect(screen.getByRole('menuitem', { name: 'Open' })).toHaveFocus());
+        const nextOpener = document.createElement('button');
+        nextOpener.textContent = 'Next opener';
+        document.body.append(nextOpener);
+        const event = new MouseEvent('contextmenu', { bubbles: true, cancelable: true });
+        event.preventDefault();
+        nextOpener.dispatchEvent(event);
+        expect(handlers.onclose).not.toHaveBeenCalled();
+        await view.rerender({ ...handlers, opener: nextOpener, targetKey: 'next' });
+        await waitFor(() => expect(screen.getByRole('menuitem', { name: 'Open' })).toHaveFocus());
+        view.unmount();
+        expect(nextOpener).toHaveFocus();
+        nextOpener.remove();
+        opener.remove();
+    });
+});

--- a/src/lib/components/sidebar-context-menu.behavior.test.ts
+++ b/src/lib/components/sidebar-context-menu.behavior.test.ts
@@ -1,0 +1,126 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import '@testing-library/jest-dom/vitest';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import { get } from 'svelte/store';
+
+vi.mock('@tauri-apps/api/core', () => ({ convertFileSrc: vi.fn((path: string) => path) }));
+vi.mock('@tauri-apps/plugin-dialog', () => ({ open: vi.fn() }));
+vi.mock('@tauri-apps/plugin-opener', () => ({ revealItemInDir: vi.fn().mockResolvedValue(undefined) }));
+vi.mock('@tauri-apps/api/event', () => ({ listen: vi.fn().mockResolvedValue(() => {}) }));
+vi.mock('$lib/image-loading', () => ({ loadImagesForCurrentScope: vi.fn().mockResolvedValue(undefined) }));
+vi.mock('$lib/clipboard-monitor', () => ({ applyClipboardMonitorCollection: vi.fn() }));
+vi.mock('$lib/view-utils', () => ({ safeAssetPreviewPath: vi.fn(() => null) }));
+vi.mock('$lib/api', () => ({
+    countByDetectedClass: vi.fn().mockResolvedValue(0),
+    createCanvas: vi.fn(),
+    createCollection: vi.fn(),
+    createCollectionWithImages: vi.fn(),
+    deleteCollectionApi: vi.fn(),
+    deleteFolder: vi.fn(),
+    deleteSmartCollectionApi: vi.fn(),
+    getClipboardMonitorStatus: vi.fn().mockResolvedValue(null),
+    getImageCount: vi.fn().mockResolvedValue(2),
+    importFolder: vi.fn().mockResolvedValue({ imported: 0, skipped: 2, errors: [], image_ids: [], cancelled: false }),
+    listCanvases: vi.fn().mockResolvedValue([]),
+    listCollections: vi.fn().mockResolvedValue([['c1', 'Portfolio', 2]]),
+    listCollectionImages: vi.fn().mockResolvedValue([]),
+    listDetectedClasses: vi.fn().mockResolvedValue([]),
+    listFolders: vi.fn().mockResolvedValue([['/mock/library', 2]]),
+    listSessions: vi.fn().mockResolvedValue([]),
+    listSmartCollections: vi.fn().mockResolvedValue([{
+        id: 'smart-1', name: 'Five Stars', description: null, collection_type: 'smart',
+        filter_json: '{"type":"rule","field":"rating","op":"eq","value":5}', nl_query: 'rating at least 5',
+        is_preset: false, sort_order: 1, created_at: '2026-01-01', image_count: 0,
+    }]),
+    moveClipboardCaptureFolder: vi.fn(),
+    publishClipboardCollection: vi.fn(),
+    regenerateThumbnails: vi.fn(),
+    renameCollectionApi: vi.fn(),
+    renameFolder: vi.fn(),
+    rescanSources: vi.fn(),
+    setClipboardMonitorCaptureExistingOnStart: vi.fn(),
+    startClipboardMonitor: vi.fn(),
+    stopClipboardMonitor: vi.fn(),
+    updateSmartCollectionApi: vi.fn(),
+    validateSessionFolder: vi.fn().mockResolvedValue(true),
+}));
+
+import Sidebar from './Sidebar.svelte';
+import { importFolder, listSmartCollections, updateSmartCollectionApi } from '$lib/api';
+import { activeCanvas, activeCollection, activeDetectedClass, activeFolder, activeSession, activeSmartCollection, sessionCanvases, toasts } from '$lib/stores';
+
+afterEach(() => cleanup());
+beforeEach(() => {
+    vi.clearAllMocks();
+    activeCanvas.set(null);
+    activeCollection.set(null);
+    activeDetectedClass.set(null);
+    activeFolder.set(null);
+    activeSession.set(null);
+    activeSmartCollection.set(null);
+    sessionCanvases.set([]);
+    toasts.set([]);
+});
+
+describe('Sidebar context menu behavior', () => {
+    it('opens the folder action menu from right-click and runs a targeted rescan', async () => {
+        const user = userEvent.setup();
+        render(Sidebar);
+
+        const folder = await screen.findByRole('treeitem', { name: /library, 2 images/i });
+        await fireEvent.contextMenu(folder, { clientX: 40, clientY: 60 });
+
+        const menu = await screen.findByRole('menu', { name: 'library actions' });
+        expect(menu).toBeVisible();
+        expect(screen.getByRole('menuitem', { name: 'Rename…' })).toBeVisible();
+        const rescan = screen.getByRole('menuitem', { name: 'Rescan Folder' });
+        await waitFor(() => expect(screen.getByRole('menuitem', { name: 'Open Folder' })).toHaveFocus());
+        await user.click(rescan);
+
+        await waitFor(() => expect(importFolder).toHaveBeenCalledWith('/mock/library'));
+        expect(screen.queryByRole('menu', { name: 'library actions' })).not.toBeInTheDocument();
+    });
+
+    it('keeps an empty user smart collection editable from the keyboard context-menu shortcut', async () => {
+        const user = userEvent.setup();
+        render(Sidebar);
+
+        const smart = await screen.findByRole('button', { name: /Five Stars/i });
+        smart.focus();
+        await fireEvent.keyDown(smart, { key: 'F10', shiftKey: true });
+
+        expect(await screen.findByRole('menuitem', { name: 'Edit Rules…' })).toBeVisible();
+        expect(screen.getByRole('menuitem', { name: 'Delete Smart Collection…' })).toBeVisible();
+
+        await user.click(screen.getByRole('menuitem', { name: 'Edit Rules…' }));
+        vi.mocked(listSmartCollections).mockRejectedValueOnce(new Error('refresh unavailable'));
+        await user.click(await screen.findByRole('button', { name: 'Save Rules' }));
+        await waitFor(() => expect(updateSmartCollectionApi).toHaveBeenCalledWith(
+            'smart-1',
+            'Five Stars',
+            expect.any(String),
+            'rating at least 5',
+        ));
+        await waitFor(() => expect(get(toasts).at(-1)).toMatchObject({
+            message: 'Smart collection updated, but the view could not refresh',
+            type: 'warning',
+        }));
+    });
+
+    it('anchors a keyboard-opened folder menu to the focused tree item', async () => {
+        render(Sidebar);
+
+        const folder = await screen.findByRole('treeitem', { name: /library, 2 images/i });
+        vi.spyOn(folder, 'getBoundingClientRect').mockReturnValue({
+            x: 280, y: 360, left: 280, top: 360, right: 440, bottom: 392,
+            width: 160, height: 32, toJSON: () => ({}),
+        });
+        folder.focus();
+        await fireEvent.keyDown(folder, { key: 'F10', shiftKey: true });
+
+        const menu = await screen.findByRole('menu', { name: 'library actions' });
+        await waitFor(() => expect(menu).toHaveStyle({ left: '312px', top: '384px' }));
+    });
+});

--- a/src/lib/components/sidebar-folder-rename-contract.test.ts
+++ b/src/lib/components/sidebar-folder-rename-contract.test.ts
@@ -12,9 +12,9 @@ describe('atomic sidebar folder rename contract', () => {
 
         expect(api).toContain("invoke<RenameFolderResult>('rename_folder', { folder, newName })");
         expect(rust).toContain('commands::files::rename_folder');
-        expect(sidebar).toContain('openFolderContextMenu(e, folder.fullPath, folder.name, folder.isGroup)');
+        expect(sidebar).toContain("onRename: handleRenameFolder");
         expect(sidebar).toContain("title: 'Rename Folder'");
-        expect(sidebar).toContain('handleRenameFolder(folderContextMenu!.path, folderName(folderContextMenu!.path))');
+        expect(sidebar).toContain("name: folderName(target.folder)");
         expect(sidebar).toContain('await apiRenameFolder(folder, name.trim())');
         expect(sidebar).toContain('renamedFolderPath(path, result.oldPath, result.newPath)');
     });

--- a/src/lib/context-menu-coordinator.test.ts
+++ b/src/lib/context-menu-coordinator.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { claimContextMenu } from './context-menu-coordinator';
+
+describe('context menu coordinator', () => {
+    it('closes the previous owner and does not let stale cleanup release the current owner', () => {
+        const first = vi.fn();
+        const second = vi.fn();
+        const releaseFirst = claimContextMenu(first);
+        const releaseSecond = claimContextMenu(second);
+        expect(first).toHaveBeenCalledOnce();
+
+        releaseFirst();
+        const third = vi.fn();
+        const releaseThird = claimContextMenu(third);
+        expect(second).toHaveBeenCalledOnce();
+        releaseSecond();
+        expect(third).not.toHaveBeenCalled();
+        releaseThird();
+    });
+
+    it('is claimed by both shared sidebar menus and the existing image menu', () => {
+        const actionMenu = readFileSync(join(process.cwd(), 'src/lib/components/ActionMenu.svelte'), 'utf8');
+        const imageMenu = readFileSync(join(process.cwd(), 'src/lib/components/ContextMenu.svelte'), 'utf8');
+
+        for (const source of [actionMenu, imageMenu]) {
+            expect(source).toContain("import { claimContextMenu } from '$lib/context-menu-coordinator'");
+            expect(source).toContain('claimContextMenu(onclose)');
+        }
+    });
+});

--- a/src/lib/context-menu-coordinator.ts
+++ b/src/lib/context-menu-coordinator.ts
@@ -1,0 +1,10 @@
+let activeClose: (() => void) | null = null;
+
+/** Ensures only one contextual menu owns focus anywhere in the app. */
+export function claimContextMenu(close: () => void): () => void {
+    activeClose?.();
+    activeClose = close;
+    return () => {
+        if (activeClose === close) activeClose = null;
+    };
+}

--- a/src/lib/sidebar-audit-contract.test.ts
+++ b/src/lib/sidebar-audit-contract.test.ts
@@ -41,7 +41,7 @@ describe('sidebar audit fixes contract', () => {
 
     it('keeps folder removal available from the keyboard tree', () => {
         expect(sidebar).toContain("case 'Delete':");
-        expect(sidebar).toContain('handleDeleteFolder(event, row.fullPath)');
+        expect(sidebar).toContain('handleDeleteFolder(row.fullPath)');
         expect(sidebar).toContain("aria-keyshortcuts={folder.isGroup ? undefined : 'Delete'}");
     });
 

--- a/src/lib/sidebar-collections-ui.test.ts
+++ b/src/lib/sidebar-collections-ui.test.ts
@@ -20,9 +20,8 @@ describe('collections sidebar UI contract', () => {
         expect(sidebar).toContain('collection-preview-popover');
         expect(sidebar).toContain('setTimeout(async () =>');
         expect(sidebar).toContain('}, 1000)');
-        expect(sidebar).toContain('collection-context-menu');
-        expect(sidebar).toContain('Rename...');
-        expect(sidebar).toContain('Export to Folder...');
-        expect(sidebar).toContain('Use for Collect Mode');
+        expect(sidebar).toContain('<ActionMenu');
+        expect(sidebar).toContain('buildCollectionContextActions');
+        expect(sidebar).toContain('oncontextmenu={(e) => openCollectionContextMenu(e, id, name, count)}');
     });
 });

--- a/src/lib/sidebar-context-actions.test.ts
+++ b/src/lib/sidebar-context-actions.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+    buildCollectionContextActions,
+    buildFolderContextActions,
+    buildSmartCollectionContextActions,
+} from './sidebar-context-actions';
+
+describe('sidebar contextual action policy', () => {
+    it('offers the supported folder actions and protects synthetic groups from mutation', async () => {
+        const handlers = {
+            onOpen: vi.fn(),
+            onReveal: vi.fn(),
+            onRename: vi.fn(),
+            onRescan: vi.fn(),
+            onRemove: vi.fn(),
+        };
+        const items = buildFolderContextActions({
+            folder: '/Pictures/Run 1',
+            name: 'Run 1',
+            renamable: true,
+            removable: true,
+            ...handlers,
+        });
+
+        expect(items.map(item => item.label)).toEqual([
+            'Open Folder',
+            'Reveal in Finder',
+            'Rename…',
+            'Rescan Folder',
+            'Remove Folder from Library…',
+        ]);
+        await items[2].action?.();
+        expect(handlers.onRename).toHaveBeenCalledWith('/Pictures/Run 1', 'Run 1');
+        expect(items.at(-1)).toMatchObject({ danger: true, separatorBefore: true });
+
+        const group = buildFolderContextActions({
+            folder: '/Pictures',
+            name: 'Pictures',
+            renamable: true,
+            removable: false,
+            ...handlers,
+        });
+        expect(group.map(item => item.label)).toEqual(['Open Folder', 'Reveal in Finder', 'Rename…']);
+    });
+
+    it('preserves collection actions and hides content actions for an empty collection', () => {
+        const handlers = {
+            onOpen: vi.fn(), onRename: vi.fn(), onDuplicate: vi.fn(), onExport: vi.fn(),
+            onPublish: vi.fn(), onCollect: vi.fn(), onTogglePin: vi.fn(), onCopyId: vi.fn(), onDelete: vi.fn(),
+        };
+        const full = buildCollectionContextActions({
+            collectionId: 'c1', name: 'Portfolio', count: 4, pinned: false, ...handlers,
+        });
+        expect(full.map(item => item.label)).toEqual([
+            'Open Collection', 'Rename…', 'Duplicate…', 'Export to Folder…', 'Publish Collection',
+            'Use for Collect Mode', 'Pin Collection', 'Copy Collection ID', 'Delete Collection…',
+        ]);
+
+        const empty = buildCollectionContextActions({
+            collectionId: 'c1', name: 'Portfolio', count: 0, pinned: true, ...handlers,
+        });
+        expect(empty.map(item => item.label)).not.toContain('Export to Folder…');
+        expect(empty.map(item => item.label)).not.toContain('Publish Collection');
+        expect(empty.map(item => item.label)).toContain('Unpin Collection');
+    });
+
+    it('protects preset smart collections while exposing edit and delete for user collections', () => {
+        const handlers = { onOpen: vi.fn(), onEdit: vi.fn(), onDelete: vi.fn() };
+        const preset = buildSmartCollectionContextActions({
+            id: 'preset', name: 'Recent Imports', isPreset: true, ...handlers,
+        });
+        expect(preset.map(item => item.label)).toEqual(['Open Smart Collection']);
+
+        const saved = buildSmartCollectionContextActions({
+            id: 'saved', name: 'Five Stars', isPreset: false, ...handlers,
+        });
+        expect(saved.map(item => item.label)).toEqual([
+            'Open Smart Collection', 'Edit Rules…', 'Delete Smart Collection…',
+        ]);
+        expect(saved.at(-1)).toMatchObject({ danger: true, separatorBefore: true });
+    });
+});

--- a/src/lib/sidebar-context-actions.ts
+++ b/src/lib/sidebar-context-actions.ts
@@ -1,0 +1,119 @@
+import type { ActionMenuItem } from './components/ActionMenu.svelte';
+
+export interface FolderContextActionOptions {
+    folder: string;
+    name: string;
+    renamable: boolean;
+    removable: boolean;
+    onOpen: (folder: string) => void | Promise<void>;
+    onReveal: (folder: string) => void | Promise<void>;
+    onRename: (folder: string, name: string) => void | Promise<void>;
+    onRescan: (folder: string) => void | Promise<void>;
+    onRemove: (folder: string) => void | Promise<void>;
+}
+
+export function buildFolderContextActions(options: FolderContextActionOptions): ActionMenuItem[] {
+    return [
+        { id: 'folder-open', label: 'Open Folder', action: () => options.onOpen(options.folder) },
+        { id: 'folder-reveal', label: 'Reveal in Finder', action: () => options.onReveal(options.folder) },
+        {
+            id: 'folder-rename',
+            label: 'Rename…',
+            action: () => options.onRename(options.folder, options.name),
+            hidden: !options.renamable,
+        },
+        {
+            id: 'folder-rescan',
+            label: 'Rescan Folder',
+            action: () => options.onRescan(options.folder),
+            hidden: !options.removable,
+        },
+        {
+            id: 'folder-remove',
+            label: 'Remove Folder from Library…',
+            action: () => options.onRemove(options.folder),
+            danger: true,
+            separatorBefore: true,
+            hidden: !options.removable,
+        },
+    ].filter(item => !item.hidden);
+}
+
+export interface CollectionContextActionOptions {
+    collectionId: string;
+    name: string;
+    count: number;
+    pinned: boolean;
+    onOpen: (collectionId: string) => void | Promise<void>;
+    onRename: (collectionId: string, name: string) => void | Promise<void>;
+    onDuplicate: (collectionId: string, name: string) => void | Promise<void>;
+    onExport: (collectionId: string) => void | Promise<void>;
+    onPublish: (collectionId: string) => void | Promise<void>;
+    onCollect: (collectionId: string, name: string) => void | Promise<void>;
+    onTogglePin: (collectionId: string) => void | Promise<void>;
+    onCopyId: (collectionId: string) => void | Promise<void>;
+    onDelete: (collectionId: string, name: string) => void | Promise<void>;
+}
+
+export function buildCollectionContextActions(options: CollectionContextActionOptions): ActionMenuItem[] {
+    return [
+        { id: 'collection-open', label: 'Open Collection', action: () => options.onOpen(options.collectionId) },
+        { id: 'collection-rename', label: 'Rename…', action: () => options.onRename(options.collectionId, options.name) },
+        { id: 'collection-duplicate', label: 'Duplicate…', action: () => options.onDuplicate(options.collectionId, options.name) },
+        {
+            id: 'collection-export',
+            label: 'Export to Folder…',
+            action: () => options.onExport(options.collectionId),
+            hidden: options.count === 0,
+        },
+        {
+            id: 'collection-publish',
+            label: 'Publish Collection',
+            action: () => options.onPublish(options.collectionId),
+            hidden: options.count === 0,
+        },
+        { id: 'collection-collect', label: 'Use for Collect Mode', action: () => options.onCollect(options.collectionId, options.name) },
+        {
+            id: 'collection-pin',
+            label: options.pinned ? 'Unpin Collection' : 'Pin Collection',
+            action: () => options.onTogglePin(options.collectionId),
+        },
+        { id: 'collection-copy-id', label: 'Copy Collection ID', action: () => options.onCopyId(options.collectionId) },
+        {
+            id: 'collection-delete',
+            label: 'Delete Collection…',
+            action: () => options.onDelete(options.collectionId, options.name),
+            danger: true,
+            separatorBefore: true,
+        },
+    ].filter(item => !item.hidden);
+}
+
+export interface SmartCollectionContextActionOptions {
+    id: string;
+    name: string;
+    isPreset: boolean;
+    onOpen: (id: string) => void | Promise<void>;
+    onEdit: (id: string) => void | Promise<void>;
+    onDelete: (id: string, name: string) => void | Promise<void>;
+}
+
+export function buildSmartCollectionContextActions(options: SmartCollectionContextActionOptions): ActionMenuItem[] {
+    return [
+        { id: 'smart-open', label: 'Open Smart Collection', action: () => options.onOpen(options.id) },
+        {
+            id: 'smart-edit',
+            label: 'Edit Rules…',
+            action: () => options.onEdit(options.id),
+            hidden: options.isPreset,
+        },
+        {
+            id: 'smart-delete',
+            label: 'Delete Smart Collection…',
+            action: () => options.onDelete(options.id, options.name),
+            danger: true,
+            separatorBefore: true,
+            hidden: options.isPreset,
+        },
+    ].filter(item => !item.hidden);
+}

--- a/tests/e2e/smoke.py
+++ b/tests/e2e/smoke.py
@@ -153,7 +153,7 @@ def test_sidebar_folder_rename(page: Page) -> None:
     row = page.locator('.folder-row').filter(has_text='folder-rename')
     expect(row).to_be_visible()
     row.click(button='right')
-    rename = page.get_by_role('menuitem', name='Rename...')
+    rename = page.get_by_role('menuitem', name='Rename…')
     expect(rename).to_be_visible()
     rename.click()
     dialog = page.get_by_role('dialog', name='Rename Folder')


### PR DESCRIPTION
## What changed

Refreshes the old preservation PR against current main after validating which parts are still needed.

- adds one keyboard-accessible, focus-restoring ActionMenu shared by sidebar surfaces
- adds folder actions: Open, Reveal, Rename, Rescan, and confirmed Remove
- adds manual collection actions: Rename, Duplicate, Export, Publish, Collect, Pin, Copy ID, and confirmed Delete
- adds editable/deletable user smart-collection actions, including empty custom collections
- coordinates the new menus with the existing image/canvas ContextMenu
- preserves current atomic folder rename, atomic collection duplication, centralized Trash, import, and session behavior

## Deliberately excluded from the old PR

The image-menu rewrite, direct Trash implementation, Recent Imports repair, import/progress API changes, session actions, lineage actions, canvas actions, and session-conversion database changes are already superseded or outside imageview-10s0.3.

## Validation

- npm run check: 0 errors, 0 warnings
- frontend: 185 files, 1334 tests passed
- full preflight: format, clippy, 869 Rust library tests plus integration targets passed
- focused context-menu tests: 17 passed
- independent Spec review: PASS
- independent Standards/correctness review: PASS
- git diff --check: clean

The manual browser suite reached the sidebar rename scenario and identified only a typography mismatch in its selector, now corrected. Its remaining failures are pre-existing mock drift in decision badges, embedding provider text, and the Trash result fixture; those paths are outside this PR.