### PR TITLE
Complete command palette navigation providers

### DIFF
--- a/src/lib/command-palette.test.ts
+++ b/src/lib/command-palette.test.ts
@@ -23,8 +23,10 @@ import {
 } from './command-palette';
 import {
     activeCollection,
+    activeCanvas,
     activeDetectedClass,
     activeFolder,
+    activeSession,
     activeSmartCollection,
     agentPanelPinned,
     agentPanelVisible,
@@ -36,12 +38,34 @@ import {
     focusedIndex,
     folders,
     images,
+    importBatchFilter,
+    importBatchImageIds,
     selectedIds,
     sessions,
     sessionCanvases,
     smartCollections,
 } from './stores';
+import { loadImagesForCurrentScope } from './image-loading';
+import { getBatchImages } from './api';
 import { clearPluginTabs, registerCoreTabs, registerPluginTab } from './plugins/tab-registry';
+
+vi.mock('./image-loading', () => ({
+    clearImageScope: vi.fn(() => {
+        activeSmartCollection.set(null);
+        activeCollection.set(null);
+        activeDetectedClass.set(null);
+        activeFolder.set(null);
+    }),
+    invalidateImageCache: vi.fn(),
+    loadAllImages: vi.fn(),
+    loadImagesForCurrentScope: vi.fn(),
+    resetImagePaging: vi.fn(),
+}));
+
+vi.mock('./api', async (importOriginal) => ({
+    ...await importOriginal<typeof import('./api')>(),
+    getBatchImages: vi.fn(),
+}));
 
 function keyEvent(key: string, modifiers: Partial<KeyboardEvent> = {}): KeyboardEvent {
     return {
@@ -340,9 +364,15 @@ describe('command palette destination providers', () => {
         sessionCanvases.set([]);
         detectedClasses.set([]);
         activeCollection.set(null);
+        activeCanvas.set(null);
         activeFolder.set(null);
+        activeSession.set(null);
         activeSmartCollection.set(null);
         activeDetectedClass.set(null);
+        importBatchFilter.set(null);
+        importBatchImageIds.set([]);
+        vi.mocked(loadImagesForCurrentScope).mockClear();
+        vi.mocked(getBatchImages).mockReset();
     }
 
     it('always offers the All Images destination', () => {
@@ -385,6 +415,97 @@ describe('command palette destination providers', () => {
         expect(person).toBeTruthy();
         expect(person?.category).toBe('Detection');
         expect(person?.subtitle).toContain('12');
+    });
+
+    it('exposes folder, manual collection, and saved smart collection destinations', () => {
+        resetDestinations();
+        folders.set([['/photos/portraits', 9]]);
+        collections.set([['collection-1', 'Portfolio', 7]]);
+        smartCollections.set([{
+            id: 'smart-1',
+            name: 'Five Stars',
+            description: 'Top picks',
+            filter_json: '{"type":"rule"}',
+            nl_query: 'five stars',
+            image_count: 5,
+        }] as never);
+
+        const items = getCommandPaletteItems('all');
+        expect(items.find(i => i.id === 'scope.folder./photos/portraits')).toMatchObject({
+            title: 'portraits', category: 'Folder', kind: 'destination',
+        });
+        expect(items.find(i => i.id === 'scope.collection.collection-1')).toMatchObject({
+            title: 'Portfolio', subtitle: '7 images', category: 'Collection', kind: 'destination',
+        });
+        expect(items.find(i => i.id === 'scope.smart.smart-1')).toMatchObject({
+            title: 'Five Stars', subtitle: '5 images', category: 'Smart Collection', kind: 'destination',
+        });
+    });
+
+    it('exposes the current import batch and clears conflicting scopes when selected', async () => {
+        resetDestinations();
+        activeCollection.set('collection-1');
+        activeFolder.set('/photos');
+        activeSession.set({ id: 'session-1' } as never);
+        activeCanvas.set({ id: 'canvas-1' } as never);
+        importBatchFilter.set('batch-42');
+        importBatchImageIds.set(['image-1', 'image-2']);
+        vi.mocked(getBatchImages).mockResolvedValue([{
+            image: { id: 'image-1' }, path: '/photos/one.png', thumbnail_path: null, selection: null,
+        }] as never);
+
+        const batch = getCommandPaletteItems('all').find(i => i.id === 'scope.import.batch-42');
+
+        expect(batch?.kind).toBe('destination');
+        expect(batch?.category).toBe('Import');
+        expect(batch?.title).toBe('Current Import');
+        expect(batch?.subtitle).toContain('2 images');
+        await batch?.run();
+        expect(get(activeCollection)).toBeNull();
+        expect(get(activeFolder)).toBeNull();
+        expect(get(activeSession)).toBeNull();
+        expect(get(activeCanvas)).toBeNull();
+        expect(get(importBatchFilter)).toBe('batch-42');
+        expect(get(images).map(item => item.image.id)).toEqual(['image-1']);
+        expect(get(importBatchImageIds)).toEqual(['image-1']);
+    });
+
+    it('clears conflicting session and import scopes before opening a collection', async () => {
+        resetDestinations();
+        collections.set([['collection-1', 'Portfolio', 7]]);
+        activeSession.set({ id: 'session-1' } as never);
+        activeCanvas.set({ id: 'canvas-1' } as never);
+        importBatchFilter.set('batch-42');
+        importBatchImageIds.set(['image-1']);
+
+        const collection = getCommandPaletteItems('all')
+            .find(i => i.id === 'scope.collection.collection-1');
+        await collection?.run();
+
+        expect(get(activeCollection)).toBe('collection-1');
+        expect(get(activeSession)).toBeNull();
+        expect(get(activeCanvas)).toBeNull();
+        expect(get(importBatchFilter)).toBeNull();
+        expect(get(importBatchImageIds)).toEqual([]);
+        expect(loadImagesForCurrentScope).toHaveBeenCalledOnce();
+    });
+
+    it('clears the transient import scope before opening a canvas', async () => {
+        resetDestinations();
+        sessionCanvases.set([{
+            id: 'canvas-1', session_id: 'session-1', name: 'Selects', canvas_type: 'manual',
+            layout_json: '{}', filter_json: null, grid_config_json: null,
+            sort_order: 0, created_at: '', updated_at: '',
+        }] as never);
+        importBatchFilter.set('batch-42');
+        importBatchImageIds.set(['image-1']);
+
+        const canvas = getCommandPaletteItems('all').find(i => i.id === 'scope.canvas.canvas-1');
+        await canvas?.run();
+
+        expect(get(activeCanvas)?.id).toBe('canvas-1');
+        expect(get(importBatchFilter)).toBeNull();
+        expect(get(importBatchImageIds)).toEqual([]);
     });
 
     it('omits destinations in command-only mode', () => {

--- a/src/lib/command-palette.ts
+++ b/src/lib/command-palette.ts
@@ -20,6 +20,8 @@ import {
     groupRankingOpen,
     focusedIndex,
     images,
+    importBatchFilter,
+    importBatchImageIds,
     requestCollectionTarget,
     requestTextInput,
     searchOpen,
@@ -48,6 +50,7 @@ import {
 } from './stores';
 import { invalidateImageCache, loadAllImages, loadImagesForCurrentScope } from './image-loading';
 import { addToCollection, analyzeImages, checkOllama, createCollection, detectNsfw, detectObjects, getAppSetting, getClientFeedback, getOllamaConfig, isNudenetAvailable, isYoloAvailable, listCanvases, listClientFeedback, listCollections, listImageIdsMissingDetection, listImageIdsMissingVision, redo, saveTextToPath, setClientFeedback, setDecision, setRating, undo, validateSessionFolder, type Canvas, type Session } from './api';
+import { activateImportBatch } from './import-batch-navigation';
 import { withDecision, withRating, type ImageDecision } from './selection-updates';
 import { createWorkflow, readWorkflows, runWorkflow, type CommandWorkflow } from './workflows';
 import { buildDeliveryCsv, type DeliveryRow } from './delivery-csv';
@@ -328,10 +331,25 @@ export function listCommandShortcuts(
     });
 }
 
-function clearNavigationScope() {
+function clearSessionScope() {
     activeSession.set(null);
     sessionCanvases.set([]);
     activeCanvas.set(null);
+}
+
+function clearImportScope() {
+    importBatchFilter.set(null);
+    importBatchImageIds.set([]);
+}
+
+function clearNavigationScope() {
+    clearSessionScope();
+    clearImportScope();
+}
+
+async function openCurrentImportBatch(batchId: string) {
+    clearSessionScope();
+    await activateImportBatch(batchId);
 }
 
 async function openAllImages() {
@@ -390,6 +408,7 @@ async function openSession(session: Session) {
     } catch {
         sessionCanvases.set([]);
     }
+    clearImportScope();
     activeSmartCollection.set(null);
     activeFolder.set(null);
     activeCollection.set(null);
@@ -399,6 +418,7 @@ async function openSession(session: Session) {
 }
 
 function openCanvas(canvas: Canvas) {
+    clearImportScope();
     activeCanvas.set(canvas);
     navigateTo('canvas');
 }
@@ -1298,6 +1318,9 @@ function destinationItems(): CommandPaletteItem[] {
     const activeSessionId = get(activeSession)?.id ?? null;
     const activeCanvasId = get(activeCanvas)?.id ?? null;
     const activeClass = get(activeDetectedClass);
+    const currentImportBatch = get(importBatchFilter);
+    const currentImportImageIds = get(importBatchImageIds);
+    const currentImportCount = currentImportImageIds.length;
 
     return [
         {
@@ -1309,6 +1332,15 @@ function destinationItems(): CommandPaletteItem[] {
             keywords: ['library', 'root'],
             run: openAllImages,
         },
+        ...(currentImportBatch ? [{
+            id: `scope.import.${currentImportBatch}`,
+            title: 'Current Import',
+            subtitle: `${currentImportCount} image${currentImportCount === 1 ? '' : 's'} · ${currentImportBatch}`,
+            category: 'Import',
+            kind: 'destination' as const,
+            keywords: ['import', 'batch', 'recent', currentImportBatch],
+            run: () => openCurrentImportBatch(currentImportBatch),
+        }] : []),
         ...get(sessions).map((session): CommandPaletteItem => ({
             id: `scope.session.${session.id}`,
             title: session.name,

--- a/src/lib/components/CommandPalette.svelte
+++ b/src/lib/components/CommandPalette.svelte
@@ -1,7 +1,10 @@
 <script lang="ts">
     import {
         activeCollection,
+        activeCanvas,
+        activeDetectedClass,
         activeFolder,
+        activeSession,
         activeSmartCollection,
         collections,
         commandPaletteMode,
@@ -9,10 +12,15 @@
         focusedImage,
         folders,
         images,
+        importBatchFilter,
+        importBatchImageIds,
         requestTextInput,
         selectedIds,
+        sessions,
+        sessionCanvases,
         shortcutsOpen,
         smartCollections,
+        detectedClasses,
         viewMode,
         type CommandPaletteMode,
     } from '$lib/stores';
@@ -96,6 +104,7 @@
         commandPaletteMode.set(mode);
         selectedIndex = 0;
         contextMenu = null;
+        refreshItems();
     }
 
     function closePalette() {
@@ -314,8 +323,16 @@
         $images;
         $selectedIds;
         $activeCollection;
+        $activeCanvas;
+        $activeDetectedClass;
         $activeFolder;
+        $activeSession;
         $activeSmartCollection;
+        $sessions;
+        $sessionCanvases;
+        $detectedClasses;
+        $importBatchFilter;
+        $importBatchImageIds;
         if ($commandPaletteOpen) refreshItems();
     });
 

--- a/src/lib/components/command-palette-destinations.behavior.test.ts
+++ b/src/lib/components/command-palette-destinations.behavior.test.ts
@@ -1,0 +1,41 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/svelte';
+import CommandPalette from './CommandPalette.svelte';
+import {
+    collections,
+    commandPaletteMode,
+    commandPaletteOpen,
+    folders,
+    sessions,
+    sessionCanvases,
+    smartCollections,
+} from '$lib/stores';
+
+describe('CommandPalette destinations', () => {
+    beforeEach(() => {
+        localStorage.clear();
+        collections.set([['collection-1', 'Portfolio', 7]]);
+        folders.set([]);
+        smartCollections.set([]);
+        sessions.set([]);
+        sessionCanvases.set([]);
+        commandPaletteMode.set('commands');
+        commandPaletteOpen.set(true);
+    });
+
+    afterEach(() => {
+        commandPaletteOpen.set(false);
+        cleanup();
+    });
+
+    it('populates destinations when switching an open command-only palette to All', async () => {
+        render(CommandPalette);
+
+        expect(screen.queryByText('Portfolio')).toBeNull();
+        await fireEvent.click(screen.getByRole('button', { name: 'All' }));
+
+        await waitFor(() => expect(screen.getByText('Portfolio')).toBeTruthy());
+    });
+});

--- a/src/lib/deeplink-integration.test.ts
+++ b/src/lib/deeplink-integration.test.ts
@@ -345,7 +345,10 @@ describe('handleParams', () => {
     });
 
     it('imports multiple paths', async () => {
-        const fakeImages = [{ path: '/a.jpg' }, { path: '/b.jpg' }];
+        const fakeImages = [
+            { image: { id: '1' }, path: '/a.jpg' },
+            { image: { id: '2' }, path: '/b.jpg' },
+        ];
         vi.mocked(importFiles).mockResolvedValue({ imported: 2, skipped: 0, image_ids: ['1', '2'], batch_id: 'b1' } as never);
         vi.mocked(getBatchImages).mockResolvedValue(fakeImages as never);
 

--- a/src/lib/deeplink.ts
+++ b/src/lib/deeplink.ts
@@ -15,8 +15,6 @@ import {
     windowLabel,
     navigateTo,
     showToast,
-    importBatchFilter,
-    importBatchImageIds,
     pinnedCollection,
     activeCollection,
     activeSmartCollection,
@@ -25,10 +23,11 @@ import {
     collections,
     type ViewMode,
 } from './stores';
-import { importFolder, importFiles, addToCollection, listCollections, getBatchImages, listFolders, listImagesByFolder, getImagesByIds, getImageByPath, drainPendingOpenParams, openDeepLinkUrls, completeDeepLinkNavigation, type ImageWithFile, type ImportResponse } from './api';
+import { importFolder, importFiles, addToCollection, listCollections, listFolders, listImagesByFolder, getImagesByIds, getImageByPath, drainPendingOpenParams, openDeepLinkUrls, completeDeepLinkNavigation, type ImageWithFile, type ImportResponse } from './api';
 import { applyClipboardMonitorCollection } from './clipboard-monitor';
-import { clearImageScope, invalidateImageCache, loadAllImages, loadImagesForCurrentScope, loadImagesUntil, resetImagePaging } from './image-loading';
+import { loadAllImages, loadImagesForCurrentScope, loadImagesUntil } from './image-loading';
 import { openSettings, type SettingsTab } from './settings-navigation';
+import { activateImportBatch } from './import-batch-navigation';
 
 interface OpenParams {
     path?: string | null;
@@ -288,14 +287,7 @@ async function handleParamsInner(params: OpenParams, ack: AckFn) {
                 });
             } else if (result.batch_id) {
                 // No active collection — filter to batch
-                const batchImgs = await getBatchImages(result.batch_id);
-                invalidateImageCache();
-                clearImageScope();
-                resetImagePaging();
-                images.set(batchImgs);
-                importBatchFilter.set(result.batch_id);
-                importBatchImageIds.set(result.image_ids);
-                focusIndex(0);
+                await activateImportBatch(result.batch_id);
             } else {
                 await loadAllImages({ force: true, invalidateCache: true });
                 focusIndex(0);

--- a/src/lib/import-batch-navigation.ts
+++ b/src/lib/import-batch-navigation.ts
@@ -1,0 +1,25 @@
+import { getBatchImages } from './api';
+import {
+    focusedImageOverride,
+    focusedIndex,
+    images,
+    importBatchFilter,
+    importBatchImageIds,
+} from './stores';
+import {
+    clearImageScope,
+    invalidateImageCache,
+    resetImagePaging,
+} from './image-loading';
+
+export async function activateImportBatch(batchId: string) {
+    const batchImages = await getBatchImages(batchId);
+    invalidateImageCache();
+    clearImageScope();
+    resetImagePaging();
+    images.set(batchImages);
+    importBatchFilter.set(batchId);
+    importBatchImageIds.set(batchImages.map(item => item.image.id));
+    focusedImageOverride.set(null);
+    focusedIndex.set(0);
+}


### PR DESCRIPTION
## Summary
- expose the active import batch alongside existing folder, collection, smart collection, session, canvas, detection, and view destinations
- centralize import-batch activation for palette and deep-link navigation, including cache, paging, image, and focus restoration
- clear conflicting transient scopes and refresh live palette destinations, including Commands-to-All mode changes
- add provider, execution, deep-link, and rendered mode-switch regression coverage

## Verification
- npm test (full suite; one e2e-runner timing flake passed on isolated rerun and full rerun)
- npm test -- --run src/lib/command-palette.test.ts src/lib/components/command-palette-destinations.behavior.test.ts src/lib/deeplink-integration.test.ts (72/72)
- npm run check (0 errors, 0 warnings; existing nested site config-loader notice)
- independent spec review: PASS
- independent standards/smell review: PASS

Closes imageview-zu0.4