### PR TITLE
Open folders from positional CLI paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Current high-level shape:
 Cull has an MCP-aligned headless CLI slice. Command names and JSON fields mirror the MCP tool model where possible:
 
 ```bash
+cull ~/renders
 cull --json get_library_stats
 cull --json import_folder --folder_path ~/renders
 cull --json import_files --file_paths ~/renders/a.png,~/renders/b.png

--- a/docs/cli-and-url-scheme.md
+++ b/docs/cli-and-url-scheme.md
@@ -35,14 +35,15 @@ cull --json call_tool export_images --params_json '{"collection_id":"<collection
 ### Invocation
 
 ```
-cull [FLAGS] [SUBCOMMAND]
+cull [FLAGS] [PATH]
+cull [FLAGS] <SUBCOMMAND>
 ```
 
-With no subcommand, launches the GUI. A bare path argument is shorthand for `open`.
+With no subcommand, Cull launches the GUI. An optional bare path opens a supported image or imports a folder directly.
 
 ```bash
 cull                        # launch GUI
-cull ~/photos               # open folder in GUI (same as: cull open ~/photos)
+cull ~/photos               # import and open folder in GUI
 cull shot.png               # open file in GUI
 ```
 

--- a/src-tauri/src/cli/mod.rs
+++ b/src-tauri/src/cli/mod.rs
@@ -8,6 +8,14 @@ mod tools;
 
 use context::HeadlessContext;
 
+pub fn resolve_launch_path(path: &std::path::Path, cwd: &std::path::Path) -> PathBuf {
+    if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        cwd.join(path)
+    }
+}
+
 #[derive(Parser, Debug, Clone)]
 #[command(name = "cull")]
 pub struct CliArgs {
@@ -42,6 +50,10 @@ pub struct CliArgs {
     /// Permit MCP HTTP to bind to a non-loopback host. Use only with scoped tokens.
     #[arg(long)]
     pub mcp_http_allow_remote: bool,
+
+    /// Open an image or import a folder in the GUI
+    #[arg(value_name = "PATH")]
+    pub launch_path: Option<PathBuf>,
 
     #[command(subcommand)]
     pub command: Option<CliCommand>,
@@ -344,6 +356,30 @@ mod tests {
     fn test_unknown_flag_errors() {
         let result = CliArgs::try_parse_from(["cull", "--bogus"]);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_positional_folder_path_is_a_gui_launch_target() {
+        let args = CliArgs::try_parse_from(["cull", "/tmp/photos"]).unwrap();
+        assert_eq!(args.launch_path, Some(PathBuf::from("/tmp/photos")));
+        assert!(args.command.is_none());
+    }
+
+    #[test]
+    fn test_option_directory_is_not_mistaken_for_a_gui_launch_target() {
+        let args = CliArgs::try_parse_from(["cull", "--app-data-dir", "/tmp/cull-data"]).unwrap();
+        assert!(args.launch_path.is_none());
+    }
+
+    #[test]
+    fn test_relative_launch_path_resolves_against_invoking_working_directory() {
+        assert_eq!(
+            resolve_launch_path(
+                PathBuf::from("photos").as_path(),
+                PathBuf::from("/caller").as_path()
+            ),
+            PathBuf::from("/caller/photos")
+        );
     }
 
     #[test]

--- a/src-tauri/src/commands/deeplink.rs
+++ b/src-tauri/src/commands/deeplink.rs
@@ -93,7 +93,11 @@ pub fn open_params_for_file_paths(file_paths: Vec<String>) -> Option<OpenParams>
         return None;
     }
 
-    let params = OpenParams {
+    validate_open_params(build_file_open_params(file_paths)).ok()
+}
+
+fn build_file_open_params(file_paths: Vec<String>) -> OpenParams {
+    OpenParams {
         path: if file_paths.len() == 1 {
             Some(file_paths[0].clone())
         } else {
@@ -118,9 +122,31 @@ pub fn open_params_for_file_paths(file_paths: Vec<String>) -> Option<OpenParams>
         drop_x: None,
         drop_y: None,
         request_id: None,
-    };
+    }
+}
 
-    validate_open_params(params).ok()
+pub fn open_params_for_launch_path(path: &std::path::Path) -> Option<OpenParams> {
+    let canonical = crate::db_core::path_policy::validate_path(
+        path.to_string_lossy().as_ref(),
+        crate::db_core::path_policy::PathMode::UserPicked,
+    )
+    .ok()?;
+
+    if canonical.is_dir() {
+        return Some(OpenParams {
+            folder: Some(canonical.to_string_lossy().into_owned()),
+            view: Some("grid".to_string()),
+            ..OpenParams::default()
+        });
+    }
+
+    if canonical.is_file() && crate::extensions::is_image_path(&canonical, false) {
+        Some(build_file_open_params(vec![canonical
+            .to_string_lossy()
+            .into_owned()]))
+    } else {
+        None
+    }
 }
 
 pub fn open_params_for_urls(urls: &[String]) -> Vec<OpenParams> {
@@ -604,6 +630,72 @@ mod tests {
         assert_eq!(params.path.as_deref(), Some(canonical.as_str()));
         assert_eq!(params.view.as_deref(), Some("loupe"));
         assert!(params.paths.is_none());
+    }
+
+    #[test]
+    fn launch_folder_builds_grid_import_params() {
+        let dir = home_tempdir("cull_launch_folder_");
+        let folder = dir.path().join("Library");
+        std::fs::create_dir(&folder).unwrap();
+
+        let params = open_params_for_launch_path(&folder).unwrap();
+
+        assert_eq!(
+            params.folder,
+            Some(
+                folder
+                    .canonicalize()
+                    .unwrap()
+                    .to_string_lossy()
+                    .into_owned()
+            )
+        );
+        assert_eq!(params.view.as_deref(), Some("grid"));
+        assert_eq!(params.drag_drop, None);
+        assert!(params.path.is_none());
+    }
+
+    #[test]
+    fn launch_path_rejects_unsupported_files() {
+        let dir = home_tempdir("cull_launch_unsupported_");
+        let text = dir.path().join("notes.txt");
+        std::fs::write(&text, b"notes").unwrap();
+
+        assert!(open_params_for_launch_path(&text).is_none());
+    }
+
+    #[test]
+    fn launch_folder_accepts_explicit_path_outside_home() {
+        let folder = tempfile::tempdir().unwrap();
+
+        let params = open_params_for_launch_path(folder.path()).unwrap();
+
+        assert_eq!(
+            params.folder,
+            Some(
+                folder
+                    .path()
+                    .canonicalize()
+                    .unwrap()
+                    .to_string_lossy()
+                    .into_owned()
+            )
+        );
+    }
+
+    #[test]
+    fn launch_image_accepts_explicit_path_outside_home() {
+        let dir = tempfile::tempdir().unwrap();
+        let image = dir.path().join("shot.png");
+        std::fs::write(&image, b"image").unwrap();
+
+        let params = open_params_for_launch_path(&image).unwrap();
+
+        assert_eq!(
+            params.path,
+            Some(image.canonicalize().unwrap().to_string_lossy().into_owned())
+        );
+        assert_eq!(params.view.as_deref(), Some("loupe"));
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -37,7 +37,7 @@ pub mod test_support {
 
 use crate::commands::deeplink::{
     emit_open_params, open_params_for_drag_drop_paths, open_params_for_drag_drop_paths_at,
-    open_params_for_file_paths, open_params_for_urls, parse_deep_link,
+    open_params_for_file_paths, open_params_for_launch_path, open_params_for_urls, parse_deep_link,
 };
 use crate::db_core::db::Database;
 use crate::db_core::detection::DetectionEngine;
@@ -216,10 +216,40 @@ fn run_stdio_bridge() {
     });
 }
 
+fn legacy_image_paths(args: &[String], parsed_launch_arg: Option<&std::path::Path>) -> Vec<String> {
+    args.iter()
+        .filter(|arg| !arg.starts_with("cull://"))
+        .map(PathBuf::from)
+        .filter(|path| parsed_launch_arg != Some(path.as_path()))
+        .filter(|path| path.is_file() && crate::extensions::is_image_path(path, false))
+        .map(|path| path.to_string_lossy().into_owned())
+        .collect()
+}
+
+#[cfg(test)]
+mod gui_launch_tests {
+    use super::*;
+
+    #[test]
+    fn parsed_positional_image_is_not_forwarded_twice_by_legacy_scan() {
+        let dir = tempfile::tempdir().unwrap();
+        let image = dir.path().join("image.png");
+        std::fs::write(&image, b"image").unwrap();
+        let args = vec!["cull".to_string(), image.to_string_lossy().into_owned()];
+
+        assert!(legacy_image_paths(&args, Some(&image)).is_empty());
+        assert_eq!(
+            legacy_image_paths(&args, None),
+            vec![image.to_string_lossy()]
+        );
+    }
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     let args = <cli::CliArgs as clap::Parser>::parse();
     let start_hidden = args.tray;
+    let launch_path = args.launch_path.clone();
 
     if let Some(code) = cli::run_headless_if_requested(&args) {
         std::process::exit(code);
@@ -236,10 +266,19 @@ pub fn run() {
         .plugin(tauri_plugin_deep_link::init())
         .plugin(tauri_plugin_updater::Builder::new().build())
         .plugin(tauri_plugin_process::init())
-        .plugin(tauri_plugin_single_instance::init(|app, args, _cwd| {
+        .plugin(tauri_plugin_single_instance::init(|app, args, cwd| {
             crate::safe_eprintln!("[single-instance] Second instance args: {:?}", args);
             reveal_main_window(app);
-            let mut file_paths = Vec::new();
+            let mut parsed_launch_arg = None;
+            if let Ok(parsed) = <cli::CliArgs as clap::Parser>::try_parse_from(args.iter()) {
+                if let Some(path) = parsed.launch_path.as_deref() {
+                    parsed_launch_arg = Some(path.to_path_buf());
+                    let resolved = cli::resolve_launch_path(path, std::path::Path::new(&cwd));
+                    if let Some(params) = open_params_for_launch_path(&resolved) {
+                        let _ = emit_open_params(app, params);
+                    }
+                }
+            }
             for arg in &args {
                 if arg.starts_with("cull://") {
                     crate::safe_eprintln!("[single-instance] Forwarding deep link: {}", arg);
@@ -247,13 +286,9 @@ pub fn run() {
                         Ok(params) => { let _ = emit_open_params(app, params); }
                         Err(e) => crate::safe_eprintln!("[single-instance] Deep link rejected: {}", e),
                     }
-                } else {
-                    let path = PathBuf::from(arg);
-                    if path.is_file() && crate::extensions::is_image_path(&path, false) {
-                        file_paths.push(path.to_string_lossy().into_owned());
-                    }
                 }
             }
+            let file_paths = legacy_image_paths(&args, parsed_launch_arg.as_deref());
             if let Some(params) = open_params_for_file_paths(file_paths) {
                 let _ = emit_open_params(app, params);
             }
@@ -428,6 +463,12 @@ pub fn run() {
                         }
                     }
                 });
+            }
+
+            if let Some(path) = launch_path.as_deref() {
+                if let Some(params) = open_params_for_launch_path(path) {
+                    let _ = emit_open_params(app.handle(), params);
+                }
             }
 
             Ok(())


### PR DESCRIPTION
## Summary
- accept a bare image or folder path when launching Cull's GUI
- buffer cold-start navigation and forward warm-start paths through the existing instance using the caller's working directory
- apply explicit user-picked path policy, reject unsupported files, and avoid duplicate legacy image forwarding
- align README and CLI reference with the implemented syntax

## Verification
- cargo test --lib (775 passed, 3 ignored)
- cargo test --lib launch_ (8/8)
- cargo fmt --all -- --check
- independent spec review: PASS
- independent standards review: PASS

Closes imageview-aes