### PR TITLE
Atomic library folder rename

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -917,6 +917,7 @@ dependencies = [
  "hyper-util",
  "image",
  "keyring",
+ "libc",
  "ndarray",
  "notify",
  "objc2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -81,6 +81,7 @@ pdfium-render = { version = "0.8.37", default-features = false, features = ["syn
 tauri = { version = "2", features = ["test"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
+libc = "0.2"
 core-foundation = "0.10"
 objc2 = "0.6"
 objc2-app-kit = { version = "0.3", features = ["NSApplication", "NSImage", "NSPasteboard", "NSPasteboardItem", "NSResponder", "NSSharingService", "NSView", "NSWindow", "NSWorkspace"] }

--- a/src-tauri/permissions/app-file-access.toml
+++ b/src-tauri/permissions/app-file-access.toml
@@ -17,6 +17,7 @@ commands.allow = [
   "regenerate_single_thumbnail",
   "regenerate_thumbnails",
   "regenerate_thumbnails_by_ids",
+  "rename_folder",
   "rename_image",
   "rescan_sources",
   "rotate_image",

--- a/src-tauri/src/commands/files.rs
+++ b/src-tauri/src/commands/files.rs
@@ -1,7 +1,7 @@
 use crate::commands::log_library_event;
 use crate::db_core::db::Database;
 use crate::AppState;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 use std::io::Cursor;
 use std::path::{Path, PathBuf};
@@ -9,6 +9,14 @@ use tauri::{AppHandle, Emitter, State, Window};
 
 const CLIPBOARD_PASTE_DATE_FORMAT_SETTING: &str = "clipboard_paste_date_format";
 const DEFAULT_CLIPBOARD_PASTE_DATE_FORMAT: &str = "%Y-%m-%d";
+const PENDING_FOLDER_RENAME_SETTING: &str = "pending_folder_rename";
+static FOLDER_RENAME_LOCK: parking_lot::Mutex<()> = parking_lot::const_mutex(());
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct PendingFolderRename {
+    source: String,
+    target: String,
+}
 
 #[derive(Debug, Clone, Serialize)]
 pub struct OpenWithApplication {
@@ -21,6 +29,14 @@ pub struct OpenWithApplication {
 pub struct PastedImageResult {
     path: String,
     image_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct RenameFolderResult {
+    old_path: String,
+    new_path: String,
+    image_count: usize,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -75,6 +91,391 @@ fn rollback_disk_move(kind: DiskMove, old_path: &Path, new_path: &Path) {
             let _ = std::fs::remove_file(new_path);
         }
     }
+}
+
+fn rewrite_folder_descendant(source: &Path, target: &Path, candidate: &str) -> Option<PathBuf> {
+    let candidate = Path::new(candidate);
+    if candidate == source {
+        return Some(target.to_path_buf());
+    }
+    let relative = candidate.strip_prefix(source).ok()?;
+    Some(target.join(relative))
+}
+
+#[cfg(target_os = "macos")]
+fn rename_directory_exclusive(source: &Path, target: &Path) -> Result<(), String> {
+    use std::ffi::CString;
+    use std::os::unix::ffi::OsStrExt;
+
+    let source = CString::new(source.as_os_str().as_bytes())
+        .map_err(|_| "Source path contains an invalid NUL byte".to_string())?;
+    let target = CString::new(target.as_os_str().as_bytes())
+        .map_err(|_| "Target path contains an invalid NUL byte".to_string())?;
+    // SAFETY: both arguments are valid, NUL-terminated path strings and remain
+    // alive for the duration of the call. RENAME_EXCL makes the no-overwrite
+    // guarantee atomic with the rename itself.
+    let result = unsafe {
+        libc::renameatx_np(
+            libc::AT_FDCWD,
+            source.as_ptr(),
+            libc::AT_FDCWD,
+            target.as_ptr(),
+            libc::RENAME_EXCL,
+        )
+    };
+    if result == 0 {
+        Ok(())
+    } else {
+        Err(std::io::Error::last_os_error().to_string())
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+fn rename_directory_exclusive(source: &Path, target: &Path) -> Result<(), String> {
+    if target.exists() {
+        return Err("Target folder already exists".to_string());
+    }
+    std::fs::rename(source, target).map_err(|error| error.to_string())
+}
+
+fn restore_watcher_roots(
+    watcher: &mut crate::watcher::FileWatcher,
+    roots: &[String],
+) -> Vec<String> {
+    roots
+        .iter()
+        .filter_map(|root| watcher.watch_folder(root).err())
+        .collect()
+}
+
+trait FolderWatchOps {
+    fn add(&mut self, root: &str) -> Result<(), String>;
+    fn remove(&mut self, root: &str) -> Result<(), String>;
+}
+
+impl FolderWatchOps for crate::watcher::FileWatcher {
+    fn add(&mut self, root: &str) -> Result<(), String> {
+        self.watch_folder(root)
+    }
+
+    fn remove(&mut self, root: &str) -> Result<(), String> {
+        self.unwatch_folder(root)
+    }
+}
+
+fn register_new_watcher_roots<W: FolderWatchOps>(
+    watcher: &mut W,
+    roots: &[String],
+) -> Result<(), String> {
+    let mut registered: Vec<String> = Vec::new();
+    for root in roots {
+        if let Err(error) = watcher.add(root) {
+            let cleanup_errors = registered
+                .iter()
+                .filter_map(|added| watcher.remove(added).err())
+                .collect::<Vec<_>>();
+            return if cleanup_errors.is_empty() {
+                Err(error)
+            } else {
+                Err(format!(
+                    "{error}; failed to remove partial watcher registrations: {}",
+                    cleanup_errors.join("; ")
+                ))
+            };
+        }
+        registered.push(root.clone());
+    }
+    Ok(())
+}
+
+fn rollback_folder_rename(
+    db: &Database,
+    watcher: &parking_lot::Mutex<crate::watcher::FileWatcher>,
+    source: &Path,
+    target: &Path,
+    old_roots: &[String],
+    new_roots: &[String],
+    disk_moved: bool,
+) -> Result<(), String> {
+    let mut failures = Vec::new();
+    let disk_restored = !disk_moved
+        || match rename_directory_exclusive(target, source) {
+            Ok(()) => true,
+            Err(error) => {
+                failures.push(format!("failed to restore folder on disk: {error}"));
+                false
+            }
+        };
+    if disk_restored {
+        if let Err(error) =
+            db.migrate_folder_paths(&target.to_string_lossy(), &source.to_string_lossy())
+        {
+            failures.push(format!("failed to restore database paths: {error}"));
+        }
+    }
+    let mut watcher = watcher.lock();
+    failures.extend(
+        restore_watcher_roots(
+            &mut watcher,
+            if disk_restored { old_roots } else { new_roots },
+        )
+        .into_iter()
+        .map(|error| format!("failed to restore watcher: {error}")),
+    );
+    if failures.is_empty() {
+        db.delete_setting(PENDING_FOLDER_RENAME_SETTING)
+            .map_err(|error| format!("failed to clear recovery journal: {error}"))
+    } else {
+        Err(failures.join("; "))
+    }
+}
+
+pub fn recover_pending_folder_rename(db: &Database) -> Result<(), String> {
+    let Some(raw) = db
+        .get_setting(PENDING_FOLDER_RENAME_SETTING)
+        .map_err(|error| error.to_string())?
+    else {
+        return Ok(());
+    };
+    let pending: PendingFolderRename = serde_json::from_str(&raw)
+        .map_err(|error| format!("invalid folder rename journal: {error}"))?;
+    let source = Path::new(&pending.source);
+    let target = Path::new(&pending.target);
+    match (source.exists(), target.exists()) {
+        (true, false) => {
+            db.migrate_folder_paths(&pending.target, &pending.source)
+                .map_err(|error| format!("failed to restore database paths: {error}"))?;
+        }
+        // Journal reservation and the forward DB migration commit in one SQLite
+        // transaction, so a surviving journal proves the DB is already forward.
+        (false, true) => {}
+        (true, true) => {
+            return Err(
+                "folder rename recovery found both source and target; refusing to choose"
+                    .to_string(),
+            )
+        }
+        (false, false) => {
+            return Err("folder rename recovery found neither source nor target".to_string())
+        }
+    }
+    db.delete_setting(PENDING_FOLDER_RENAME_SETTING)
+        .map_err(|error| format!("failed to clear folder rename journal: {error}"))
+}
+
+fn clear_folder_move_intents(
+    watcher: &parking_lot::Mutex<crate::watcher::FileWatcher>,
+    source: &Path,
+    target: &Path,
+    files: &[(String, String)],
+) {
+    let watcher = watcher.lock();
+    for (_, old_path) in files {
+        if let Some(new_path) = rewrite_folder_descendant(source, target, old_path) {
+            watcher.clear_move_intent(Path::new(old_path), &new_path);
+        }
+    }
+}
+
+fn rename_folder_on_disk_and_db(
+    db: &Database,
+    watcher: &parking_lot::Mutex<crate::watcher::FileWatcher>,
+    source: &Path,
+    new_name: &str,
+) -> Result<RenameFolderResult, String> {
+    let _operation_guard = FOLDER_RENAME_LOCK.lock();
+    if new_name.is_empty()
+        || new_name == "."
+        || new_name == ".."
+        || new_name.starts_with('.')
+        || new_name.contains('/')
+        || new_name.contains('\\')
+    {
+        return Err("Invalid folder name".to_string());
+    }
+    if !source.is_absolute() || !source.is_dir() {
+        return Err("Source folder does not exist".to_string());
+    }
+    if source.components().any(|component| {
+        matches!(
+            component,
+            std::path::Component::CurDir | std::path::Component::ParentDir
+        )
+    }) {
+        return Err("Source folder path must be normalized".to_string());
+    }
+    if std::fs::symlink_metadata(source)
+        .map_err(|error| format!("Failed to inspect source folder: {error}"))?
+        .file_type()
+        .is_symlink()
+    {
+        return Err("Source folder cannot be a symbolic link".to_string());
+    }
+    let parent = source
+        .parent()
+        .ok_or_else(|| "Cannot rename a filesystem root".to_string())?;
+    let target = parent.join(new_name);
+    if target == source {
+        return Ok(RenameFolderResult {
+            old_path: source.to_string_lossy().to_string(),
+            new_path: source.to_string_lossy().to_string(),
+            image_count: 0,
+        });
+    }
+    if target.exists() {
+        return Err(format!("Folder '{}' already exists", new_name));
+    }
+
+    let roots = db.list_library_roots().map_err(|error| error.to_string())?;
+    let canonical_source = source
+        .canonicalize()
+        .map_err(|error| format!("Failed to resolve source folder: {error}"))?;
+    let source_is_in_library = roots.iter().any(|root| {
+        Path::new(root)
+            .canonicalize()
+            .map(|canonical_root| canonical_source.starts_with(canonical_root))
+            .unwrap_or(false)
+    });
+    let moving_roots = roots
+        .iter()
+        .filter(|root| Path::new(root).starts_with(source))
+        .cloned()
+        .collect::<Vec<_>>();
+    let safe_managed_parent = !moving_roots.is_empty()
+        && std::fs::read_dir(source)
+            .map(|entries| {
+                entries.into_iter().all(|entry| {
+                    entry
+                        .map(|entry| {
+                            let path = entry.path();
+                            entry
+                                .file_type()
+                                .map(|kind| kind.is_dir() && !kind.is_symlink())
+                                .unwrap_or(false)
+                                && moving_roots.iter().any(|root| Path::new(root) == path)
+                        })
+                        .unwrap_or(false)
+                })
+            })
+            .unwrap_or(false);
+    if !source_is_in_library && !safe_managed_parent {
+        return Err("Source folder is not safely managed by the library".to_string());
+    }
+    let next_roots = moving_roots
+        .iter()
+        .filter_map(|root| rewrite_folder_descendant(source, &target, root))
+        .map(|path| path.to_string_lossy().to_string())
+        .collect::<Vec<_>>();
+    let files = db
+        .list_image_files_under_path(&source.to_string_lossy())
+        .map_err(|error| error.to_string())?;
+
+    {
+        let mut watcher = watcher.lock();
+        let mut unwatched = Vec::new();
+        for root in &moving_roots {
+            if let Err(error) = watcher.unwatch_folder(root) {
+                let restore_errors = restore_watcher_roots(&mut watcher, &unwatched);
+                if restore_errors.is_empty() {
+                    return Err(error);
+                }
+                return Err(format!(
+                    "{error}; failed to restore watcher: {}",
+                    restore_errors.join("; ")
+                ));
+            }
+            unwatched.push(root.clone());
+        }
+    }
+
+    let pending = PendingFolderRename {
+        source: source.to_string_lossy().to_string(),
+        target: target.to_string_lossy().to_string(),
+    };
+    let journal = serde_json::to_string(&pending).map_err(|error| error.to_string())?;
+    let migration = match db.migrate_folder_paths_with_journal(
+        &source.to_string_lossy(),
+        &target.to_string_lossy(),
+        PENDING_FOLDER_RENAME_SETTING,
+        &journal,
+    ) {
+        Ok(migration) => migration,
+        Err(error) => {
+            let restore_errors = restore_watcher_roots(&mut watcher.lock(), &moving_roots);
+            let suffix = if restore_errors.is_empty() {
+                String::new()
+            } else {
+                format!("; failed to restore watcher: {}", restore_errors.join("; "))
+            };
+            return Err(format!(
+                "Database path migration/journal reservation failed: {error}{suffix}"
+            ));
+        }
+    };
+
+    {
+        let watcher = watcher.lock();
+        for (file_id, old_path) in &files {
+            if let Some(new_path) = rewrite_folder_descendant(source, &target, old_path) {
+                watcher.register_move_intent(PathBuf::from(old_path), new_path, file_id.clone());
+            }
+        }
+    }
+
+    if let Err(error) = rename_directory_exclusive(source, &target) {
+        clear_folder_move_intents(watcher, source, &target, &files);
+        let rollback = rollback_folder_rename(
+            db,
+            watcher,
+            source,
+            &target,
+            &moving_roots,
+            &next_roots,
+            false,
+        );
+        return Err(match rollback {
+            Ok(()) => format!("Failed to rename folder; database restored: {error}"),
+            Err(rollback_error) => {
+                format!("Failed to rename folder ({error}); rollback also failed: {rollback_error}")
+            }
+        });
+    }
+
+    {
+        let mut watcher_guard = watcher.lock();
+        if let Err(error) = register_new_watcher_roots(&mut *watcher_guard, &next_roots) {
+            drop(watcher_guard);
+            let rollback = rollback_folder_rename(
+                db,
+                watcher,
+                source,
+                &target,
+                &moving_roots,
+                &next_roots,
+                true,
+            );
+            clear_folder_move_intents(watcher, source, &target, &files);
+            return Err(match rollback {
+                Ok(()) => format!("Failed to watch renamed folder; rename restored: {error}"),
+                Err(rollback_error) => format!(
+                    "Failed to watch renamed folder ({error}); rollback also failed: {rollback_error}"
+                ),
+            });
+        }
+    }
+
+    if let Err(error) = db.delete_setting(PENDING_FOLDER_RENAME_SETTING) {
+        crate::safe_eprintln!(
+            "[folder-rename] Rename committed; recovery journal cleanup will retry at startup: {}",
+            error
+        );
+    }
+
+    Ok(RenameFolderResult {
+        old_path: source.to_string_lossy().to_string(),
+        new_path: target.to_string_lossy().to_string(),
+        image_count: migration.image_files,
+    })
 }
 
 fn mime_type_for_path(path: &Path) -> &'static str {
@@ -757,6 +1158,35 @@ pub async fn create_subfolder(
 }
 
 #[tauri::command]
+pub async fn rename_folder(
+    app: AppHandle,
+    state: State<'_, AppState>,
+    folder: String,
+    new_name: String,
+) -> Result<RenameFolderResult, String> {
+    let result = rename_folder_on_disk_and_db(
+        &state.db,
+        &state.file_watcher,
+        Path::new(&folder),
+        &new_name,
+    )?;
+    let _ = app.emit("folders:changed", ());
+    let _ = app.emit("images:changed", ());
+    log_library_event(
+        &state,
+        "folder_renamed",
+        Some("folder"),
+        Some(result.new_path.clone()),
+        serde_json::json!({
+            "old_path": result.old_path,
+            "new_path": result.new_path,
+            "image_count": result.image_count,
+        }),
+    );
+    Ok(result)
+}
+
+#[tauri::command]
 pub async fn share_images(
     app: AppHandle,
     window: Window,
@@ -1048,6 +1478,28 @@ mod tests {
     use image::{ImageBuffer, Rgba};
     use std::io::Write;
 
+    #[derive(Default)]
+    struct FailingWatchOps {
+        added: Vec<String>,
+        removed: Vec<String>,
+        fail_on: String,
+    }
+
+    impl FolderWatchOps for FailingWatchOps {
+        fn add(&mut self, root: &str) -> Result<(), String> {
+            if root == self.fail_on {
+                return Err(format!("cannot watch {root}"));
+            }
+            self.added.push(root.to_string());
+            Ok(())
+        }
+
+        fn remove(&mut self, root: &str) -> Result<(), String> {
+            self.removed.push(root.to_string());
+            Ok(())
+        }
+    }
+
     /// Security regression guard for SECURITY.md's asset-protocol boundary:
     /// the `asset:` scope is configured statically in tauri.conf.json
     /// (thumbnails / generated only). No code may widen it at runtime, which
@@ -1167,6 +1619,329 @@ mod tests {
 
         assert_eq!(std::fs::read(&source).unwrap(), b"image");
         assert!(!dest.exists());
+    }
+
+    #[test]
+    fn rename_folder_moves_disk_and_database_paths_together() {
+        let tmp = tempfile::tempdir().unwrap();
+        let source = tmp.path().join("source");
+        let nested = source.join("nested");
+        let app_data = tmp.path().join("app-data");
+        std::fs::create_dir_all(&nested).unwrap();
+        std::fs::create_dir_all(&app_data).unwrap();
+        let image_path = nested.join("image.png");
+        ImageBuffer::from_pixel(2, 2, Rgba([10u8, 20, 30, 255]))
+            .save(&image_path)
+            .unwrap();
+        let db = Database::open(std::path::Path::new(":memory:")).unwrap();
+        let image_id = crate::db_core::import::import_file(&db, &image_path, &app_data)
+            .unwrap()
+            .unwrap();
+        db.set_decision(&image_id, "accept").unwrap();
+        db.add_library_root(&source.to_string_lossy()).unwrap();
+        let watcher = parking_lot::Mutex::new(crate::watcher::FileWatcher::new());
+
+        let result = rename_folder_on_disk_and_db(&db, &watcher, &source, "renamed").unwrap();
+
+        let renamed_image = tmp.path().join("renamed/nested/image.png");
+        assert!(!source.exists());
+        assert!(renamed_image.exists());
+        assert_eq!(
+            result.new_path,
+            tmp.path().join("renamed").to_string_lossy()
+        );
+        assert!(db
+            .get_image_file_by_path(&renamed_image.to_string_lossy())
+            .unwrap()
+            .is_some());
+        assert_eq!(
+            db.get_selection_for_image(&image_id)
+                .unwrap()
+                .unwrap()
+                .decision,
+            "accept"
+        );
+        assert_eq!(
+            db.list_library_roots().unwrap(),
+            vec![tmp.path().join("renamed").to_string_lossy().to_string()]
+        );
+    }
+
+    #[test]
+    fn rename_folder_leaves_disk_untouched_when_database_paths_collide() {
+        let tmp = tempfile::tempdir().unwrap();
+        let source = tmp.path().join("source");
+        std::fs::create_dir(&source).unwrap();
+        let source_file = source.join("image.png");
+        std::fs::write(&source_file, b"source").unwrap();
+        let db = Database::open(std::path::Path::new(":memory:")).unwrap();
+        let inside = crate::db_core::models::Image {
+            id: "inside".to_string(),
+            sha256_hash: "inside-hash".to_string(),
+            width: 1,
+            height: 1,
+            format: "png".to_string(),
+            file_size: 6,
+            created_at: "2026-01-01".to_string(),
+            imported_at: "2026-01-01".to_string(),
+            ai_prompt: None,
+            raw_metadata: None,
+        };
+        let collision = crate::db_core::models::Image {
+            id: "collision".to_string(),
+            sha256_hash: "collision-hash".to_string(),
+            ..inside.clone()
+        };
+        db.insert_image(&inside).unwrap();
+        db.insert_image(&collision).unwrap();
+        db.insert_image_file(&crate::db_core::models::ImageFile {
+            id: "f-inside".to_string(),
+            image_id: "inside".to_string(),
+            path: source_file.to_string_lossy().to_string(),
+            last_seen_at: "2026-01-01".to_string(),
+            missing_at: None,
+            last_seen_size: None,
+            last_seen_mtime: None,
+        })
+        .unwrap();
+        db.insert_image_file(&crate::db_core::models::ImageFile {
+            id: "f-collision".to_string(),
+            image_id: "collision".to_string(),
+            path: tmp
+                .path()
+                .join("renamed/image.png")
+                .to_string_lossy()
+                .to_string(),
+            last_seen_at: "2026-01-01".to_string(),
+            missing_at: None,
+            last_seen_size: None,
+            last_seen_mtime: None,
+        })
+        .unwrap();
+        db.add_library_root(&source.to_string_lossy()).unwrap();
+        let watcher = parking_lot::Mutex::new(crate::watcher::FileWatcher::new());
+
+        let error = rename_folder_on_disk_and_db(&db, &watcher, &source, "renamed").unwrap_err();
+
+        assert!(error.contains("target subtree"));
+        assert!(source.exists());
+        assert!(source_file.exists());
+        assert!(!tmp.path().join("renamed").exists());
+        assert!(db
+            .get_image_file_by_path(&source_file.to_string_lossy())
+            .unwrap()
+            .is_some());
+    }
+
+    #[test]
+    fn pending_folder_rename_recovery_restores_database_when_disk_did_not_move() {
+        let tmp = tempfile::tempdir().unwrap();
+        let source = tmp.path().join("source");
+        let target = tmp.path().join("target");
+        std::fs::create_dir(&source).unwrap();
+        let db = Database::open(std::path::Path::new(":memory:")).unwrap();
+        db.add_library_root(&target.to_string_lossy()).unwrap();
+        db.set_setting(
+            PENDING_FOLDER_RENAME_SETTING,
+            &serde_json::to_string(&PendingFolderRename {
+                source: source.to_string_lossy().to_string(),
+                target: target.to_string_lossy().to_string(),
+            })
+            .unwrap(),
+        )
+        .unwrap();
+
+        recover_pending_folder_rename(&db).unwrap();
+
+        assert_eq!(
+            db.list_library_roots().unwrap(),
+            vec![source.to_string_lossy()]
+        );
+        assert!(db
+            .get_setting(PENDING_FOLDER_RENAME_SETTING)
+            .unwrap()
+            .is_none());
+    }
+
+    #[test]
+    fn pending_folder_rename_recovery_accepts_committed_database_when_disk_moved() {
+        let tmp = tempfile::tempdir().unwrap();
+        let source = tmp.path().join("source");
+        let target = tmp.path().join("target");
+        std::fs::create_dir(&target).unwrap();
+        let db = Database::open(std::path::Path::new(":memory:")).unwrap();
+        db.add_library_root(&target.to_string_lossy()).unwrap();
+        db.set_setting(
+            PENDING_FOLDER_RENAME_SETTING,
+            &serde_json::to_string(&PendingFolderRename {
+                source: source.to_string_lossy().to_string(),
+                target: target.to_string_lossy().to_string(),
+            })
+            .unwrap(),
+        )
+        .unwrap();
+
+        recover_pending_folder_rename(&db).unwrap();
+
+        assert_eq!(
+            db.list_library_roots().unwrap(),
+            vec![target.to_string_lossy()]
+        );
+        assert!(db
+            .get_setting(PENDING_FOLDER_RENAME_SETTING)
+            .unwrap()
+            .is_none());
+    }
+
+    #[test]
+    fn exclusive_directory_rename_never_replaces_an_existing_target() {
+        let tmp = tempfile::tempdir().unwrap();
+        let source = tmp.path().join("source");
+        let target = tmp.path().join("target");
+        std::fs::create_dir(&source).unwrap();
+        std::fs::create_dir(&target).unwrap();
+        std::fs::write(source.join("source.txt"), b"source").unwrap();
+        std::fs::write(target.join("unrelated.txt"), b"unrelated").unwrap();
+
+        assert!(rename_directory_exclusive(&source, &target).is_err());
+        assert_eq!(std::fs::read(source.join("source.txt")).unwrap(), b"source");
+        assert_eq!(
+            std::fs::read(target.join("unrelated.txt")).unwrap(),
+            b"unrelated"
+        );
+    }
+
+    #[test]
+    fn watcher_registration_failure_removes_every_partial_new_root() {
+        let roots = vec!["/new/one".to_string(), "/new/two".to_string()];
+        let mut watcher = FailingWatchOps {
+            fail_on: "/new/two".to_string(),
+            ..Default::default()
+        };
+
+        let error = register_new_watcher_roots(&mut watcher, &roots).unwrap_err();
+
+        assert!(error.contains("cannot watch /new/two"));
+        assert_eq!(watcher.added, vec!["/new/one"]);
+        assert_eq!(watcher.removed, vec!["/new/one"]);
+    }
+
+    #[test]
+    fn stale_recovery_journal_is_never_overwritten_by_a_new_rename() {
+        let tmp = tempfile::tempdir().unwrap();
+        let source = tmp.path().join("source");
+        std::fs::create_dir(&source).unwrap();
+        let db = Database::open(std::path::Path::new(":memory:")).unwrap();
+        db.add_library_root(&source.to_string_lossy()).unwrap();
+        let stale = r#"{"source":"/old/source","target":"/old/target"}"#;
+        db.set_setting(PENDING_FOLDER_RENAME_SETTING, stale)
+            .unwrap();
+        let watcher = parking_lot::Mutex::new(crate::watcher::FileWatcher::new());
+
+        let error = rename_folder_on_disk_and_db(&db, &watcher, &source, "renamed").unwrap_err();
+
+        assert!(error.contains("requires recovery"));
+        assert_eq!(
+            db.get_setting(PENDING_FOLDER_RENAME_SETTING)
+                .unwrap()
+                .as_deref(),
+            Some(stale)
+        );
+        assert!(source.exists());
+        assert!(!tmp.path().join("renamed").exists());
+    }
+
+    #[test]
+    fn rollback_keeps_forward_database_paths_when_disk_cannot_be_restored() {
+        let tmp = tempfile::tempdir().unwrap();
+        let source = tmp.path().join("source");
+        let target = tmp.path().join("target");
+        std::fs::create_dir(&source).unwrap();
+        std::fs::create_dir(&target).unwrap();
+        std::fs::write(source.join("unrelated.txt"), b"unrelated").unwrap();
+        std::fs::write(target.join("moved.txt"), b"moved").unwrap();
+        let db = Database::open(std::path::Path::new(":memory:")).unwrap();
+        db.add_library_root(&target.to_string_lossy()).unwrap();
+        db.set_setting(PENDING_FOLDER_RENAME_SETTING, "pending")
+            .unwrap();
+        let watcher = parking_lot::Mutex::new(crate::watcher::FileWatcher::new());
+
+        let error = rollback_folder_rename(
+            &db,
+            &watcher,
+            &source,
+            &target,
+            &[source.to_string_lossy().to_string()],
+            &[target.to_string_lossy().to_string()],
+            true,
+        )
+        .unwrap_err();
+
+        assert!(error.contains("failed to restore folder on disk"));
+        assert_eq!(
+            db.list_library_roots().unwrap(),
+            vec![target.to_string_lossy()]
+        );
+        assert!(db
+            .get_setting(PENDING_FOLDER_RENAME_SETTING)
+            .unwrap()
+            .is_some());
+        assert_eq!(
+            std::fs::read(source.join("unrelated.txt")).unwrap(),
+            b"unrelated"
+        );
+        assert_eq!(std::fs::read(target.join("moved.txt")).unwrap(), b"moved");
+    }
+
+    #[test]
+    fn rename_allows_a_parent_containing_only_managed_library_roots() {
+        let tmp = tempfile::tempdir().unwrap();
+        let group = tmp.path().join("group");
+        let first = group.join("first");
+        let second = group.join("second");
+        std::fs::create_dir_all(&first).unwrap();
+        std::fs::create_dir(&second).unwrap();
+        let db = Database::open(std::path::Path::new(":memory:")).unwrap();
+        db.add_library_root(&first.to_string_lossy()).unwrap();
+        db.add_library_root(&second.to_string_lossy()).unwrap();
+        let watcher = parking_lot::Mutex::new(crate::watcher::FileWatcher::new());
+
+        rename_folder_on_disk_and_db(&db, &watcher, &group, "renamed").unwrap();
+
+        assert!(!group.exists());
+        let renamed = tmp.path().join("renamed");
+        assert!(renamed.join("first").exists());
+        assert!(renamed.join("second").exists());
+        assert_eq!(
+            db.list_library_roots().unwrap(),
+            vec![
+                renamed.join("first").to_string_lossy().to_string(),
+                renamed.join("second").to_string_lossy().to_string(),
+            ]
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn rename_folder_rejects_symlink_escape_from_library_root() {
+        use std::os::unix::fs::symlink;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().join("library");
+        let external = tmp.path().join("external");
+        std::fs::create_dir(&root).unwrap();
+        std::fs::create_dir(&external).unwrap();
+        let escaped = root.join("linked-folder");
+        symlink(&external, &escaped).unwrap();
+        let db = Database::open(std::path::Path::new(":memory:")).unwrap();
+        db.add_library_root(&root.to_string_lossy()).unwrap();
+        let watcher = parking_lot::Mutex::new(crate::watcher::FileWatcher::new());
+
+        let error = rename_folder_on_disk_and_db(&db, &watcher, &escaped, "renamed").unwrap_err();
+
+        assert!(error.contains("symbolic link"));
+        assert!(external.exists());
+        assert!(!root.join("renamed").exists());
     }
 
     #[test]

--- a/src-tauri/src/db_core/db.rs
+++ b/src-tauri/src/db_core/db.rs
@@ -3501,6 +3501,164 @@ mod file_watcher_tests {
         assert!(roots.is_empty());
     }
 
+    #[test]
+    fn test_migrate_folder_paths_updates_descendants_and_preserves_metadata() {
+        let db = test_db();
+        insert_test_image(&db, "inside", "hash-inside");
+        insert_test_image(&db, "outside", "hash-outside");
+        db.update_image_file_path("f-inside", "/photos/old/nested/inside.png")
+            .unwrap();
+        db.update_image_file_path("f-outside", "/photos/other/outside.png")
+            .unwrap();
+        db.set_decision("inside", "accept").unwrap();
+        db.add_library_root("/photos/old").unwrap();
+        let session_id = db.create_session("Session", "/photos/old/session").unwrap();
+        let canvas_id = db.create_canvas(&session_id, "Canvas", "manual").unwrap();
+        {
+            let conn = db.conn.lock();
+            conn.execute(
+                "UPDATE canvases SET layout_json = ?1 WHERE id = ?2",
+                params![
+                    r#"{"version":1,"items":[{"id":"item","imageId":"inside","x":0,"y":0,"width":100,"height":100,"z":0,"hidden":false,"label":null,"groupId":null,"source":{"contentHash":"hash-inside","lastKnownPath":"/photos/old/nested/inside.png"}}]}"#,
+                    canvas_id
+                ],
+            )
+            .unwrap();
+            conn.execute(
+                "INSERT INTO generation_runs (id, settings_json, source_type, source_path, imported_at) VALUES ('run', '{}', 'sidecar', '/photos/old/nested/inside.json', '2026-01-01')",
+                [],
+            )
+            .unwrap();
+        }
+
+        let result = db
+            .migrate_folder_paths("/photos/old", "/photos/renamed")
+            .unwrap();
+
+        assert_eq!(result.image_files, 1);
+        assert_eq!(result.library_roots, 1);
+        assert_eq!(result.sessions, 1);
+        assert_eq!(result.canvases, 1);
+        assert_eq!(result.generation_runs, 1);
+        assert!(db
+            .get_image_file_by_path("/photos/renamed/nested/inside.png")
+            .unwrap()
+            .is_some());
+        assert!(db
+            .get_image_file_by_path("/photos/other/outside.png")
+            .unwrap()
+            .is_some());
+        assert_eq!(
+            db.get_selection_for_image("inside")
+                .unwrap()
+                .unwrap()
+                .decision,
+            "accept"
+        );
+        assert_eq!(
+            db.get_session(&session_id).unwrap().folder_path,
+            "/photos/renamed/session"
+        );
+        assert!(db
+            .get_canvas(&canvas_id)
+            .unwrap()
+            .unwrap()
+            .layout_json
+            .contains("/photos/renamed/nested/inside.png"));
+        let conn = db.conn.lock();
+        let generation_source: String = conn
+            .query_row(
+                "SELECT source_path FROM generation_runs WHERE id = 'run'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(generation_source, "/photos/renamed/nested/inside.json");
+    }
+
+    #[test]
+    fn test_migrate_folder_paths_rejects_collisions_without_partial_updates() {
+        let db = test_db();
+        insert_test_image(&db, "inside", "hash-inside");
+        insert_test_image(&db, "collision", "hash-collision");
+        db.update_image_file_path("f-inside", "/photos/old/inside.png")
+            .unwrap();
+        db.update_image_file_path("f-collision", "/photos/new/inside.png")
+            .unwrap();
+        db.add_library_root("/photos/old").unwrap();
+
+        let error = db
+            .migrate_folder_paths("/photos/old", "/photos/new")
+            .unwrap_err();
+
+        assert!(error.to_string().contains("target subtree"));
+        assert!(db
+            .get_image_file_by_path("/photos/old/inside.png")
+            .unwrap()
+            .is_some());
+        assert!(db
+            .list_library_roots()
+            .unwrap()
+            .contains(&"/photos/old".to_string()));
+    }
+
+    #[test]
+    fn test_migrate_folder_paths_preserves_missing_and_last_seen_metadata() {
+        let db = test_db();
+        insert_test_image(&db, "inside", "hash-inside");
+        db.update_image_file_path("f-inside", "/photos/old/inside.png")
+            .unwrap();
+        {
+            let conn = db.conn.lock();
+            conn.execute(
+                "UPDATE image_files SET last_seen_at = '2025-01-02', missing_at = '2025-02-03' WHERE id = 'f-inside'",
+                [],
+            )
+            .unwrap();
+        }
+
+        db.migrate_folder_paths("/photos/old", "/photos/new")
+            .unwrap();
+
+        let file = db
+            .get_image_file_by_path("/photos/new/inside.png")
+            .unwrap()
+            .unwrap();
+        assert_eq!(file.last_seen_at, "2025-01-02");
+        assert_eq!(file.missing_at.as_deref(), Some("2025-02-03"));
+    }
+
+    #[test]
+    fn test_folder_migration_journal_and_paths_commit_atomically() {
+        let db = test_db();
+        insert_test_image(&db, "source", "hash-source");
+        insert_test_image(&db, "target", "hash-target");
+        db.update_image_file_path("f-source", "/photos/source/image.png")
+            .unwrap();
+        db.update_image_file_path("f-target", "/photos/target/unrelated.png")
+            .unwrap();
+
+        let error = db
+            .migrate_folder_paths_with_journal(
+                "/photos/source",
+                "/photos/target",
+                "pending_folder_rename",
+                r#"{"source":"/photos/source","target":"/photos/target"}"#,
+            )
+            .unwrap_err();
+
+        assert!(error.to_string().contains("target subtree"));
+        assert!(db.get_setting("pending_folder_rename").unwrap().is_none());
+        assert!(db
+            .get_image_file_by_path("/photos/source/image.png")
+            .unwrap()
+            .is_some());
+        assert!(db
+            .get_image_file_by_path("/photos/target/unrelated.png")
+            .unwrap()
+            .is_some());
+    }
+
     // -- get_image_file_by_path --
 
     #[test]

--- a/src-tauri/src/db_core/queries/images.rs
+++ b/src-tauri/src/db_core/queries/images.rs
@@ -9,9 +9,282 @@ use crate::db_core::db::{
 use crate::db_core::db::Database;
 use crate::db_core::models::*;
 use crate::db_core::visibility::RejectedVisibility;
-use rusqlite::{params, OptionalExtension, Result};
+use rusqlite::{params, OptionalExtension, Result, Transaction};
+use std::collections::HashSet;
+use std::path::{Component, Path};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FolderPathMigration {
+    pub image_files: usize,
+    pub library_roots: usize,
+    pub sessions: usize,
+    pub canvases: usize,
+    pub generation_runs: usize,
+}
+
+fn invalid_path(message: impl Into<String>) -> rusqlite::Error {
+    rusqlite::Error::InvalidParameterName(message.into())
+}
+
+fn validate_folder_migration_path(path: &str, label: &str) -> Result<()> {
+    let path = Path::new(path);
+    if !path.is_absolute()
+        || path.parent().is_none()
+        || path
+            .components()
+            .any(|component| matches!(component, Component::CurDir | Component::ParentDir))
+    {
+        return Err(invalid_path(format!("invalid {label} folder path")));
+    }
+    Ok(())
+}
+
+fn rewrite_descendant_path(source: &Path, target: &Path, candidate: &str) -> Option<String> {
+    let candidate = Path::new(candidate);
+    if candidate == source {
+        return Some(target.to_string_lossy().to_string());
+    }
+    let relative = candidate.strip_prefix(source).ok()?;
+    Some(target.join(relative).to_string_lossy().to_string())
+}
+
+fn migrate_path_column(
+    tx: &Transaction<'_>,
+    select_sql: &str,
+    update_sql: &str,
+    source: &Path,
+    target: &Path,
+    reject_collisions: bool,
+) -> Result<usize> {
+    let rows = {
+        let mut stmt = tx.prepare(select_sql)?;
+        let collected = stmt
+            .query_map([], |row| {
+                Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+            })?
+            .collect::<Result<Vec<_>>>()?;
+        collected
+    };
+    let moving_ids = rows
+        .iter()
+        .filter(|(_, path)| rewrite_descendant_path(source, target, path).is_some())
+        .map(|(id, _)| id.clone())
+        .collect::<HashSet<_>>();
+    let existing_paths = rows
+        .iter()
+        .filter(|(id, _)| !moving_ids.contains(id))
+        .map(|(_, path)| path.clone())
+        .collect::<HashSet<_>>();
+    if reject_collisions
+        && existing_paths
+            .iter()
+            .any(|path| rewrite_descendant_path(target, target, path).is_some())
+    {
+        return Err(invalid_path(format!(
+            "folder rename target subtree already has persisted paths at {}",
+            target.display()
+        )));
+    }
+    let mut proposed_paths = HashSet::new();
+    let mut changed = 0;
+    for (id, path) in rows {
+        let Some(next_path) = rewrite_descendant_path(source, target, &path) else {
+            continue;
+        };
+        if reject_collisions
+            && (existing_paths.contains(&next_path) || !proposed_paths.insert(next_path.clone()))
+        {
+            return Err(invalid_path(format!(
+                "folder rename path collision at {next_path}"
+            )));
+        }
+        tx.execute(update_sql, params![id, next_path])?;
+        changed += 1;
+    }
+    Ok(changed)
+}
+
+fn rewrite_canvas_paths(value: &mut serde_json::Value, source: &Path, target: &Path) -> bool {
+    match value {
+        serde_json::Value::Array(values) => values.iter_mut().fold(false, |changed, value| {
+            rewrite_canvas_paths(value, source, target) || changed
+        }),
+        serde_json::Value::Object(values) => {
+            values.iter_mut().fold(false, |changed, (key, value)| {
+                let path_changed = if key == "lastKnownPath" {
+                    value
+                        .as_str()
+                        .and_then(|path| rewrite_descendant_path(source, target, path))
+                        .map(|path| {
+                            *value = serde_json::Value::String(path);
+                            true
+                        })
+                        .unwrap_or(false)
+                } else {
+                    rewrite_canvas_paths(value, source, target)
+                };
+                path_changed || changed
+            })
+        }
+        _ => false,
+    }
+}
+
+fn canvas_contains_path_under(value: &serde_json::Value, root: &Path) -> bool {
+    match value {
+        serde_json::Value::Array(values) => values
+            .iter()
+            .any(|value| canvas_contains_path_under(value, root)),
+        serde_json::Value::Object(values) => values.iter().any(|(key, value)| {
+            (key == "lastKnownPath"
+                && value
+                    .as_str()
+                    .is_some_and(|path| rewrite_descendant_path(root, root, path).is_some()))
+                || canvas_contains_path_under(value, root)
+        }),
+        _ => false,
+    }
+}
+
+fn migrate_folder_paths_in_transaction(
+    tx: &Transaction<'_>,
+    source_path: &Path,
+    target_path: &Path,
+) -> Result<FolderPathMigration> {
+    let image_files = migrate_path_column(
+        tx,
+        "SELECT id, path FROM image_files",
+        "UPDATE image_files SET path = ?2 WHERE id = ?1",
+        source_path,
+        target_path,
+        true,
+    )?;
+    migrate_path_column(
+        tx,
+        "SELECT id, path FROM media_files",
+        "UPDATE media_files SET path = ?2 WHERE id = ?1",
+        source_path,
+        target_path,
+        true,
+    )?;
+    let library_roots = migrate_path_column(
+        tx,
+        "SELECT id, path FROM library_roots",
+        "UPDATE library_roots SET path = ?2 WHERE id = ?1",
+        source_path,
+        target_path,
+        true,
+    )?;
+    let sessions = migrate_path_column(
+        tx,
+        "SELECT id, folder_path FROM projects WHERE folder_path IS NOT NULL",
+        "UPDATE projects SET folder_path = ?2 WHERE id = ?1",
+        source_path,
+        target_path,
+        true,
+    )?;
+    let generation_runs = migrate_path_column(
+        tx,
+        "SELECT id, source_path FROM generation_runs WHERE source_path IS NOT NULL",
+        "UPDATE generation_runs SET source_path = ?2 WHERE id = ?1",
+        source_path,
+        target_path,
+        true,
+    )?;
+
+    let canvas_rows = {
+        let mut stmt = tx.prepare("SELECT id, layout_json FROM canvases")?;
+        let collected = stmt
+            .query_map([], |row| {
+                Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+            })?
+            .collect::<Result<Vec<_>>>()?;
+        collected
+    };
+    let mut canvases = 0;
+    for (id, layout_json) in canvas_rows {
+        let mut layout =
+            serde_json::from_str::<serde_json::Value>(&layout_json).map_err(|error| {
+                invalid_path(format!(
+                    "invalid canvas layout during folder rename: {error}"
+                ))
+            })?;
+        if canvas_contains_path_under(&layout, target_path) {
+            return Err(invalid_path(format!(
+                "folder rename target subtree already has persisted canvas paths at {}",
+                target_path.display()
+            )));
+        }
+        if rewrite_canvas_paths(&mut layout, source_path, target_path) {
+            tx.execute(
+                "UPDATE canvases SET layout_json = ?2, updated_at = datetime('now') WHERE id = ?1",
+                params![
+                    id,
+                    serde_json::to_string(&layout)
+                        .map_err(|error| invalid_path(error.to_string()))?
+                ],
+            )?;
+            canvases += 1;
+        }
+    }
+
+    Ok(FolderPathMigration {
+        image_files,
+        library_roots,
+        sessions,
+        canvases,
+        generation_runs,
+    })
+}
 
 impl Database {
+    pub fn migrate_folder_paths(&self, source: &str, target: &str) -> Result<FolderPathMigration> {
+        validate_folder_migration_path(source, "source")?;
+        validate_folder_migration_path(target, "target")?;
+        if source == target {
+            return Err(invalid_path("source and target folders must differ"));
+        }
+        let source_path = Path::new(source);
+        let target_path = Path::new(target);
+        if target_path.starts_with(source_path) {
+            return Err(invalid_path("target folder cannot be inside source folder"));
+        }
+
+        let mut conn = self.conn.lock();
+        let tx = conn.transaction()?;
+        let migration = migrate_folder_paths_in_transaction(&tx, source_path, target_path)?;
+        tx.commit()?;
+        Ok(migration)
+    }
+
+    pub fn migrate_folder_paths_with_journal(
+        &self,
+        source: &str,
+        target: &str,
+        journal_key: &str,
+        journal_value: &str,
+    ) -> Result<FolderPathMigration> {
+        validate_folder_migration_path(source, "source")?;
+        validate_folder_migration_path(target, "target")?;
+        let source_path = Path::new(source);
+        let target_path = Path::new(target);
+        if source == target || target_path.starts_with(source_path) {
+            return Err(invalid_path("invalid folder rename relationship"));
+        }
+        let mut conn = self.conn.lock();
+        let tx = conn.transaction()?;
+        if tx.execute(
+            "INSERT OR IGNORE INTO app_settings (key, value) VALUES (?1, ?2)",
+            params![journal_key, journal_value],
+        )? != 1
+        {
+            return Err(invalid_path("another folder rename requires recovery"));
+        }
+        let migration = migrate_folder_paths_in_transaction(&tx, source_path, target_path)?;
+        tx.commit()?;
+        Ok(migration)
+    }
+
     pub fn insert_image(&self, image: &Image) -> Result<()> {
         let conn = self.conn.lock();
         conn.execute(

--- a/src-tauri/src/db_core/queries/misc.rs
+++ b/src-tauri/src/db_core/queries/misc.rs
@@ -28,6 +28,12 @@ impl Database {
         Ok(())
     }
 
+    pub fn delete_setting(&self, key: &str) -> Result<()> {
+        let conn = self.conn.lock();
+        conn.execute("DELETE FROM app_settings WHERE key = ?1", params![key])?;
+        Ok(())
+    }
+
     pub fn set_client_feedback(
         &self,
         image_id: &str,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -319,6 +319,16 @@ pub fn run() {
                     return Err(format!("database open failed: {}", e).into());
                 }
             };
+            if let Err(error) = commands::files::recover_pending_folder_rename(&db) {
+                let msg = format!(
+                    "Cull found an incomplete folder rename and could not finish recovery safely:\n{error}\n\nStartup has stopped before watchers or background services began. Inspect the source and target folders before reopening Cull."
+                );
+                app.dialog()
+                    .message(msg)
+                    .title("Folder Rename Recovery Required")
+                    .blocking_show();
+                return Err(format!("folder rename recovery failed: {error}").into());
+            }
 
             let model_dir = app_data_dir.join("models");
             let embedding_engine = Mutex::new(EmbeddingEngine::new(&model_dir));
@@ -693,6 +703,7 @@ pub fn run() {
             commands::files::paste_image_from_clipboard,
             commands::files::move_image,
             commands::files::rename_image,
+            commands::files::rename_folder,
             commands::files::create_subfolder,
             commands::files::share_images,
             commands::files::open_images_with_application,

--- a/src-tauri/src/watcher.rs
+++ b/src-tauri/src/watcher.rs
@@ -94,6 +94,11 @@ impl FileWatcher {
         );
     }
 
+    pub fn clear_move_intent(&self, old_path: &std::path::Path, new_path: &std::path::Path) {
+        self.intent_registry.remove(old_path);
+        self.intent_registry.remove(new_path);
+    }
+
     pub fn start(
         &mut self,
         db: Database,

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1751,6 +1751,18 @@ export async function createSubfolder(parentPath: string, name: string): Promise
     return result;
 }
 
+export interface RenameFolderResult {
+    oldPath: string;
+    newPath: string;
+    imageCount: number;
+}
+
+export async function renameFolder(folder: string, newName: string): Promise<RenameFolderResult> {
+    const result = await invoke<RenameFolderResult>('rename_folder', { folder, newName });
+    emitSessionEventsRefresh();
+    return result;
+}
+
 export async function shareImages(imageIds: string[]): Promise<void> {
     return invoke<void>('share_images', { imageIds });
 }

--- a/src/lib/canvas-save-coordinator.test.ts
+++ b/src/lib/canvas-save-coordinator.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it, vi } from 'vitest';
+import { registerCanvasPathMigrationParticipant, withCanvasPathMigrationBarrier } from './canvas-save-coordinator';
+
+describe('canvas save coordinator', () => {
+    it('holds the active canvas barrier around the migration and unregisters it safely', async () => {
+        const calls: string[] = [];
+        const unregister = registerCanvasPathMigrationParticipant(
+            async () => { calls.push('flush'); },
+            active => calls.push(active ? 'active' : 'inactive'),
+        );
+
+        await withCanvasPathMigrationBarrier(async () => { calls.push('operation'); });
+        expect(calls).toEqual(['active', 'flush', 'operation', 'inactive']);
+
+        unregister();
+        await withCanvasPathMigrationBarrier(async () => { calls.push('unregistered'); });
+        expect(calls.at(-1)).toBe('unregistered');
+    });
+
+    it('fails closed and never starts migration when the strict canvas save fails', async () => {
+        const operation = vi.fn(async () => undefined);
+        const active: boolean[] = [];
+
+        const unregister = registerCanvasPathMigrationParticipant(
+            async () => { throw new Error('save failed'); },
+            value => active.push(value),
+        );
+
+        await expect(withCanvasPathMigrationBarrier(operation)).rejects.toThrow('save failed');
+
+        expect(operation).not.toHaveBeenCalled();
+        expect(active).toEqual([true, false]);
+        unregister();
+    });
+
+    it('serializes overlapping migrations so their barriers never overlap', async () => {
+        let releaseFirst!: () => void;
+        const firstGate = new Promise<void>(resolve => { releaseFirst = resolve; });
+        const calls: string[] = [];
+
+        const first = withCanvasPathMigrationBarrier(async () => {
+            calls.push('first-start');
+            await firstGate;
+            calls.push('first-end');
+        });
+        const second = withCanvasPathMigrationBarrier(async () => {
+            calls.push('second-start');
+            calls.push('second-end');
+        });
+        await vi.waitFor(() => expect(calls).toEqual(['first-start']));
+
+        releaseFirst();
+        await Promise.all([first, second]);
+        expect(calls).toEqual(['first-start', 'first-end', 'second-start', 'second-end']);
+    });
+
+    it('waits for retiring canvases even after a replacement registers', async () => {
+        let releaseOld!: () => void;
+        const oldSave = new Promise<void>(resolve => { releaseOld = resolve; });
+        const calls: string[] = [];
+        const unregisterOld = registerCanvasPathMigrationParticipant(
+            async () => { calls.push('old-flush'); await oldSave; },
+            active => calls.push(`old-${active}`),
+        );
+        const unregisterNew = registerCanvasPathMigrationParticipant(
+            async () => { calls.push('new-flush'); },
+            active => calls.push(`new-${active}`),
+        );
+
+        const migration = withCanvasPathMigrationBarrier(async () => { calls.push('operation'); });
+        await vi.waitFor(() => {
+            expect(calls).toContain('old-flush');
+            expect(calls).toContain('new-flush');
+        });
+        expect(calls).not.toContain('operation');
+        releaseOld();
+        await migration;
+        expect(calls.indexOf('operation')).toBeGreaterThan(calls.indexOf('old-flush'));
+        expect(calls.indexOf('operation')).toBeGreaterThan(calls.indexOf('new-flush'));
+        unregisterOld();
+        unregisterNew();
+    });
+
+    it('makes a canvas mounted during migration inherit the active state', async () => {
+        let release!: () => void;
+        const gate = new Promise<void>(resolve => { release = resolve; });
+        let operationStarted = false;
+        const migration = withCanvasPathMigrationBarrier(() => {
+            operationStarted = true;
+            return gate;
+        });
+        await vi.waitFor(() => expect(operationStarted).toBe(true));
+        const active: boolean[] = [];
+        const unregister = registerCanvasPathMigrationParticipant(async () => undefined, value => active.push(value));
+
+        expect(active).toEqual([true]);
+        release();
+        await migration;
+        expect(active).toEqual([true, false]);
+        unregister();
+    });
+});

--- a/src/lib/canvas-save-coordinator.ts
+++ b/src/lib/canvas-save-coordinator.ts
@@ -1,0 +1,40 @@
+interface CanvasPathMigrationParticipant {
+    flushStrict: () => Promise<void>;
+    setActive: (active: boolean) => void;
+}
+
+const participants = new Set<CanvasPathMigrationParticipant>();
+let migrationQueue: Promise<void> = Promise.resolve();
+let migrationActive = false;
+
+export function registerCanvasPathMigrationParticipant(
+    flushStrict: () => Promise<void>,
+    setActive: (active: boolean) => void,
+): () => void {
+    const participant = { flushStrict, setActive };
+    participants.add(participant);
+    if (migrationActive) setActive(true);
+    return () => {
+        participants.delete(participant);
+        setActive(false);
+    };
+}
+
+export async function withCanvasPathMigrationBarrier<T>(operation: () => Promise<T>): Promise<T> {
+    const run = async () => {
+        migrationActive = true;
+        participants.forEach(participant => participant.setActive(true));
+        try {
+            await Promise.all(
+                Array.from(participants, participant => participant.flushStrict()),
+            );
+            return await operation();
+        } finally {
+            migrationActive = false;
+            participants.forEach(participant => participant.setActive(false));
+        }
+    };
+    const queued = migrationQueue.then(run, run);
+    migrationQueue = queued.then(() => undefined, () => undefined);
+    return queued;
+}

--- a/src/lib/components/Canvas.svelte
+++ b/src/lib/components/Canvas.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import { onDestroy, onMount } from 'svelte';
+    import { onMount } from 'svelte';
     import { convertFileSrc } from '@tauri-apps/api/core';
     import {
         activeCanvas,
@@ -40,6 +40,7 @@
     } from '$lib/canvas-view-model';
     import type { CanvasCrop } from '$lib/canvas-document';
     import { safeAssetPreviewPath } from '$lib/view-utils';
+    import { registerCanvasPathMigrationParticipant } from '$lib/canvas-save-coordinator';
     import {
         computeVisibleCanvasItems,
         capCanvasItems,
@@ -96,6 +97,7 @@
     let saveTimer: ReturnType<typeof setTimeout> | null = null;
     let pendingCanvasSaves = new Map<string, PendingCanvasSave>();
     let saveInFlight: Promise<void> | null = null;
+    let pathMigrationInProgress = $state(false);
 
     // Viewport culling + render cap (P2): only mount items intersecting the viewport.
     const dpr = typeof window !== 'undefined' ? (window.devicePixelRatio || 1) : 1;
@@ -124,11 +126,14 @@
         return capCanvasItems(culled, CANVAS_RENDER_CAP);
     });
 
-    onDestroy(() => {
-        void flushPendingCanvasSaves();
-    });
-
     onMount(() => {
+        const unregisterSaveFlusher = registerCanvasPathMigrationParticipant(
+            async () => {
+                await flushPendingCanvasSaves(true);
+                if (pendingCanvasSaves.size > 0) throw new Error('Canvas changes are not saved');
+            },
+            active => pathMigrationInProgress = active,
+        );
         const handleCanvasImportDrop = (event: Event) => {
             const detail = event instanceof CustomEvent ? detailFromCanvasImportDrop(event) : null;
             if (!detail || detail.images.length === 0) {
@@ -154,6 +159,11 @@
             window.removeEventListener('pagehide', flushForPageLifecycle);
             window.removeEventListener('beforeunload', flushForPageLifecycle);
             document.removeEventListener('visibilitychange', flushWhenHidden);
+            // Keep the coordinator barrier registered until every in-flight
+            // old-path save settles, so navigation cannot reopen the race.
+            void flushPendingCanvasSaves(true)
+                .catch(() => undefined)
+                .finally(unregisterSaveFlusher);
         };
     });
 
@@ -232,14 +242,14 @@
         }, delay);
     }
 
-    async function flushPendingCanvasSaves(): Promise<void> {
+    async function flushPendingCanvasSaves(throwOnError = false): Promise<void> {
         if (saveTimer) {
             clearTimeout(saveTimer);
             saveTimer = null;
         }
         if (saveInFlight) {
             await saveInFlight;
-            if (pendingCanvasSaves.size > 0) return flushPendingCanvasSaves();
+            if (pendingCanvasSaves.size > 0) return flushPendingCanvasSaves(throwOnError);
             return;
         }
 
@@ -259,6 +269,7 @@
                         pendingCanvasSaves.set(save.canvasId, save);
                     }
                     showToast('Canvas save failed', { detail: String(e), type: 'error', duration: 10000 });
+                    if (throwOnError) throw e;
                 }
             }
         })();
@@ -731,6 +742,8 @@
     tabindex="0"
     class:space-pan={spacePanActive}
     class:panning={panning}
+    inert={pathMigrationInProgress}
+    aria-busy={pathMigrationInProgress}
 >
     {#if visibleCanvas.droppedCount > 0}
         <div class="canvas-cap-banner" aria-live="polite">

--- a/src/lib/components/Sidebar.svelte
+++ b/src/lib/components/Sidebar.svelte
@@ -3,7 +3,7 @@
     import { open } from '@tauri-apps/plugin-dialog';
     import { listen, type UnlistenFn } from '@tauri-apps/api/event';
     import { totalCount, folders, activeFolder, minSizeFilter, collections, activeCollection, activeDetectedClass, detectedClasses as detectedClassesStore, collectMode, collectModeTarget, smartCollections, activeSmartCollection, showToast, pinnedCollection, pinnedCollections, showMissing, showRejected, requestTextInput, requestConfirm, clipboardMonitorStatus, exportFolderOpen } from '$lib/stores';
-    import { importFolder as apiImportFolder, getImageCount, listFolders, deleteFolder as apiDeleteFolder, listCollections, createCollection, renameCollectionApi, deleteCollectionApi, listCollectionImages, listSmartCollections, countByDetectedClass, listDetectedClasses, regenerateThumbnails, rescanSources, getClipboardMonitorStatus, startClipboardMonitor, stopClipboardMonitor, setClipboardMonitorCaptureExistingOnStart, moveClipboardCaptureFolder, publishClipboardCollection } from '$lib/api';
+    import { importFolder as apiImportFolder, getImageCount, listFolders, deleteFolder as apiDeleteFolder, renameFolder as apiRenameFolder, listCollections, createCollection, renameCollectionApi, deleteCollectionApi, listCollectionImages, listSmartCollections, countByDetectedClass, listDetectedClasses, regenerateThumbnails, rescanSources, getClipboardMonitorStatus, startClipboardMonitor, stopClipboardMonitor, setClipboardMonitorCaptureExistingOnStart, moveClipboardCaptureFolder, publishClipboardCollection } from '$lib/api';
     import { loadImagesForCurrentScope } from '$lib/image-loading';
     import type { ClipboardMonitorStatus, ClipboardPublishResult, ImageWithFile, SmartCollection } from '$lib/api';
     import { applyClipboardMonitorCollection } from '$lib/clipboard-monitor';
@@ -45,6 +45,13 @@
         x: number;
         y: number;
     } | null>(null);
+    let folderContextMenu = $state<{
+        path: string;
+        name: string;
+        isGroup: boolean;
+        x: number;
+        y: number;
+    } | null>(null);
     let collectionPreviewTimer: ReturnType<typeof setTimeout> | null = null;
     let collectionPreviewRequest = 0;
     let browseCountsRequest = 0;
@@ -66,8 +73,10 @@
         }
     }
     import SessionSwitcher from './SessionSwitcher.svelte';
-    import { activeCanvas, activeSession, navigateTo, sessionCanvases, expandedFolders, sidebarSectionsCollapsed, sidebarFilter } from '$lib/stores';
+    import { activeCanvas, activeSession, navigateTo, sessions, sessionCanvases, expandedFolders, sidebarSectionsCollapsed, sidebarFilter } from '$lib/stores';
     import { createCanvas, type Canvas } from '$lib/api';
+    import { reconcileRenamedCanvas, reconcileRenamedSession, renamedFolderPath } from '$lib/folder-rename-state';
+    import { withCanvasPathMigrationBarrier } from '$lib/canvas-save-coordinator';
 
     // "All Images" is only the active scope when nothing else narrows it —
     // including a detected-class filter, which used to leave both All Images
@@ -272,6 +281,7 @@
         event.preventDefault();
         event.stopPropagation();
         hideCollectionPreview(collectionId);
+        folderContextMenu = null;
         collectionContextMenu = {
             collectionId,
             name,
@@ -283,6 +293,23 @@
 
     function closeCollectionContextMenu() {
         collectionContextMenu = null;
+    }
+
+    function openFolderContextMenu(event: MouseEvent, path: string, name: string, isGroup: boolean) {
+        event.preventDefault();
+        event.stopPropagation();
+        closeCollectionContextMenu();
+        folderContextMenu = {
+            path,
+            name,
+            isGroup,
+            x: Math.min(event.clientX, window.innerWidth - 208),
+            y: Math.min(event.clientY, window.innerHeight - 128),
+        };
+    }
+
+    function closeFolderContextMenu() {
+        folderContextMenu = null;
     }
 
     onDestroy(() => {
@@ -538,6 +565,44 @@
         }
     }
 
+    async function handleRenameFolder(folder: string, currentName: string) {
+        closeFolderContextMenu();
+        const name = await requestTextInput({
+            title: 'Rename Folder',
+            label: 'Folder name',
+            initialValue: currentName,
+            placeholder: 'Folder name',
+            confirmLabel: 'Rename',
+        });
+        if (!name || !name.trim() || name.trim() === currentName) return;
+        try {
+            const result = await withCanvasPathMigrationBarrier(async () => {
+                const result = await apiRenameFolder(folder, name.trim());
+                activeFolder.update(path => path ? renamedFolderPath(path, result.oldPath, result.newPath) : null);
+                expandedFolders.update(paths => new Set(
+                    [...paths].map(path => renamedFolderPath(path, result.oldPath, result.newPath))
+                ));
+                sessions.update(items => items.map(session => reconcileRenamedSession(session, result.oldPath, result.newPath)));
+                activeSession.update(session => session ? reconcileRenamedSession(session, result.oldPath, result.newPath) : null);
+                sessionCanvases.update(canvases => canvases.map(canvas => reconcileRenamedCanvas(canvas, result.oldPath, result.newPath)));
+                activeCanvas.update(canvas => canvas ? reconcileRenamedCanvas(canvas, result.oldPath, result.newPath) : null);
+                return result;
+            });
+            await refreshBrowseCounts($showRejected);
+            if (get(activeFolder)) {
+                await loadImagesForCurrentScope({ force: true, invalidateCache: true });
+            }
+            showToast('Folder renamed', {
+                detail: `${result.oldPath} → ${result.newPath}`,
+                type: 'success',
+                duration: 5000,
+            });
+        } catch (e) {
+            console.error('Failed to rename folder:', e);
+            showToast('Failed to rename folder', { detail: String(e), type: 'error', duration: 8000 });
+        }
+    }
+
     async function handleToggleClipboardMonitor() {
         const wasRunning = clipboardStatus?.running ?? false;
         try {
@@ -759,8 +824,8 @@
 </script>
 
 <svelte:window
-    onclick={closeCollectionContextMenu}
-    onkeydown={(e) => { if (e.key === 'Escape') { closeCollectionContextMenu(); hideCollectionPreview(); } }}
+    onclick={() => { closeCollectionContextMenu(); closeFolderContextMenu(); }}
+    onkeydown={(e) => { if (e.key === 'Escape') { closeCollectionContextMenu(); closeFolderContextMenu(); hideCollectionPreview(); } }}
 />
 
 <aside class="sidebar" aria-label="Library sidebar">
@@ -866,6 +931,7 @@
                         data-tree-row={i}
                         tabindex={i === treeTabIndex ? 0 : -1}
                         onfocusin={() => treeFocusIndex = i}
+                        oncontextmenu={(e) => openFolderContextMenu(e, folder.fullPath, folder.name, folder.isGroup)}
                     >
                         {#if folder.hasChildren}
                             <button
@@ -1144,6 +1210,22 @@
             </button>
             <button type="button" role="menuitem" onclick={() => copyCollectionId(collectionContextMenu!.collectionId)}>Copy Collection ID</button>
             <button type="button" role="menuitem" class="danger" onclick={(e) => handleDeleteCollection(e, collectionContextMenu!.collectionId, collectionContextMenu!.name)}>Delete Collection...</button>
+        </div>
+    {/if}
+
+    {#if folderContextMenu}
+        <div
+            class="collection-context-menu folder-context-menu"
+            style="left: {folderContextMenu.x}px; top: {folderContextMenu.y}px;"
+            role="menu"
+            tabindex="-1"
+        >
+            <div class="context-menu-header">{folderContextMenu.name}</div>
+            <button type="button" role="menuitem" onclick={() => { selectFolder(folderContextMenu!.path); closeFolderContextMenu(); }}>Open Folder</button>
+            <button type="button" role="menuitem" onclick={() => handleRenameFolder(folderContextMenu!.path, folderName(folderContextMenu!.path))}>Rename...</button>
+            {#if !folderContextMenu.isGroup}
+                <button type="button" role="menuitem" class="danger" onclick={(e) => { const path = folderContextMenu!.path; closeFolderContextMenu(); handleDeleteFolder(e, path); }}>Remove from Library...</button>
+            {/if}
         </div>
     {/if}
 

--- a/src/lib/components/sidebar-folder-rename-contract.test.ts
+++ b/src/lib/components/sidebar-folder-rename-contract.test.ts
@@ -1,0 +1,21 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const read = (path: string) => readFileSync(join(process.cwd(), path), 'utf8');
+
+describe('atomic sidebar folder rename contract', () => {
+    it('registers one typed backend command and exposes it only from real folder rows', () => {
+        const api = read('src/lib/api.ts');
+        const rust = read('src-tauri/src/lib.rs');
+        const sidebar = read('src/lib/components/Sidebar.svelte');
+
+        expect(api).toContain("invoke<RenameFolderResult>('rename_folder', { folder, newName })");
+        expect(rust).toContain('commands::files::rename_folder');
+        expect(sidebar).toContain('openFolderContextMenu(e, folder.fullPath, folder.name, folder.isGroup)');
+        expect(sidebar).toContain("title: 'Rename Folder'");
+        expect(sidebar).toContain('handleRenameFolder(folderContextMenu!.path, folderName(folderContextMenu!.path))');
+        expect(sidebar).toContain('await apiRenameFolder(folder, name.trim())');
+        expect(sidebar).toContain('renamedFolderPath(path, result.oldPath, result.newPath)');
+    });
+});

--- a/src/lib/folder-rename-state.test.ts
+++ b/src/lib/folder-rename-state.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import type { Canvas, Session } from '$lib/api';
+import { reconcileRenamedCanvas, reconcileRenamedSession, renamedFolderPath } from './folder-rename-state';
+
+const session: Session = {
+    id: 'session', name: 'Session', description: null, folder_path: '/library/old/session',
+    settings_json: null, created_at: '2026-08-08', image_count: 1,
+};
+const canvas: Canvas = {
+    id: 'canvas', session_id: 'session', name: 'Canvas', canvas_type: 'manual',
+    layout_json: JSON.stringify({ items: [{ source: { lastKnownPath: '/library/old/image.png' } }], label: '/library/old/unchanged' }),
+    filter_json: null, grid_config_json: null, sort_order: 0, created_at: '2026-08-08', updated_at: '2026-08-08',
+};
+
+describe('folder rename live-state reconciliation', () => {
+    it('rewrites only exact and descendant paths', () => {
+        expect(renamedFolderPath('/library/old', '/library/old', '/library/new')).toBe('/library/new');
+        expect(renamedFolderPath('/library/oldish/a', '/library/old', '/library/new')).toBe('/library/oldish/a');
+    });
+
+    it('keeps session and active canvas state aligned with persisted paths', () => {
+        expect(reconcileRenamedSession(session, '/library/old', '/library/new').folder_path).toBe('/library/new/session');
+        const updated = reconcileRenamedCanvas(canvas, '/library/old', '/library/new');
+        expect(JSON.parse(updated.layout_json)).toEqual({
+            items: [{ source: { lastKnownPath: '/library/new/image.png' } }],
+            label: '/library/old/unchanged',
+        });
+    });
+});

--- a/src/lib/folder-rename-state.ts
+++ b/src/lib/folder-rename-state.ts
@@ -1,0 +1,33 @@
+import type { Canvas, Session } from '$lib/api';
+
+export function renamedFolderPath(path: string, oldPath: string, newPath: string): string {
+    if (path === oldPath) return newPath;
+    return path.startsWith(`${oldPath}/`) ? `${newPath}${path.slice(oldPath.length)}` : path;
+}
+
+export function reconcileRenamedSession(session: Session, oldPath: string, newPath: string): Session {
+    return { ...session, folder_path: renamedFolderPath(session.folder_path, oldPath, newPath) };
+}
+
+export function reconcileRenamedCanvas(canvas: Canvas, oldPath: string, newPath: string): Canvas {
+    try {
+        const layout = JSON.parse(canvas.layout_json) as unknown;
+        const rewrite = (value: unknown): void => {
+            if (Array.isArray(value)) {
+                value.forEach(rewrite);
+            } else if (value && typeof value === 'object') {
+                for (const [key, child] of Object.entries(value)) {
+                    if (key === 'lastKnownPath' && typeof child === 'string') {
+                        (value as Record<string, unknown>)[key] = renamedFolderPath(child, oldPath, newPath);
+                    } else {
+                        rewrite(child);
+                    }
+                }
+            }
+        };
+        rewrite(layout);
+        return { ...canvas, layout_json: JSON.stringify(layout) };
+    } catch {
+        return canvas;
+    }
+}

--- a/src/lib/tauri-mock.ts
+++ b/src/lib/tauri-mock.ts
@@ -77,6 +77,12 @@ function makeMockImage(i: number) {
 
 let mockImages = Array.from({ length: 20 }, (_, i) => makeMockImage(i));
 let lastTrashedImages: ReturnType<typeof makeMockImage>[] = [];
+let mockFolderPath = '/mock/folder-rename';
+
+function useFolderRenameFixture(): boolean {
+  if (typeof window === 'undefined') return false;
+  return new URLSearchParams(window.location.search).get('folderRename') === '1';
+}
 
 function mockImageFixtureIndex(item: ReturnType<typeof makeMockImage>): number {
   return Number(item.image.id.replace('img-', ''));
@@ -819,8 +825,16 @@ const MOCK_HANDLERS: Record<string, (...args: any[]) => any> = {
     },
   ],
   list_similarity_group_images: () => Array.from({ length: 4 }, (_, i) => makeMockImage(i)),
-  list_folders: () => [],
+  list_folders: () => useFolderRenameFixture() ? [[mockFolderPath, 2]] : [],
   delete_folder: () => 0,
+  rename_folder: (_: any, args: { folder: string; newName: string }) => {
+    if (!useFolderRenameFixture() || args.folder !== mockFolderPath) {
+      throw new Error('Folder not found');
+    }
+    const oldPath = mockFolderPath;
+    mockFolderPath = `${oldPath.slice(0, oldPath.lastIndexOf('/'))}/${args.newName}`;
+    return { oldPath, newPath: mockFolderPath, imageCount: 2 };
+  },
   list_collections: () => mockCollections,
   create_collection: (_: any, args: { name: string }) => {
     const id = `col-${nextId++}`;
@@ -833,7 +847,7 @@ const MOCK_HANDLERS: Record<string, (...args: any[]) => any> = {
     const index = mockCollections.findIndex(([id]) => id === args.collectionId);
     if (index >= 0) mockCollections.splice(index, 1);
   },
-  list_images_by_folder: () => [],
+  list_images_by_folder: () => useFolderRenameFixture() ? mockImages.slice(0, 2) : [],
   list_images_filtered: () => [],
   list_collection_images: (_: any, args: { collectionId: string }) =>
     args.collectionId === 'col_clipboard_mock' ? [makeMockImage(0), makeMockImage(1)] : [],

--- a/tests/e2e/smoke.py
+++ b/tests/e2e/smoke.py
@@ -147,6 +147,23 @@ def ensure_nsfw_mode(page: Page, mode: str) -> None:
     raise AssertionError(f"could not reach {expected}")
 
 
+def test_sidebar_folder_rename(page: Page) -> None:
+    """S28b — folder context rename updates the sidebar through one backend action."""
+    wait_for_app(page, f"{URL}?folderRename=1")
+    row = page.locator('.folder-row').filter(has_text='folder-rename')
+    expect(row).to_be_visible()
+    row.click(button='right')
+    rename = page.get_by_role('menuitem', name='Rename...')
+    expect(rename).to_be_visible()
+    rename.click()
+    dialog = page.get_by_role('dialog', name='Rename Folder')
+    expect(dialog).to_be_visible()
+    dialog.locator('#text-input-dialog-input').fill('renamed')
+    dialog.get_by_role('button', name='Rename').click()
+    expect(page.locator('.folder-row').filter(has_text='renamed')).to_be_visible()
+    expect(page.get_by_text('Folder renamed', exact=True)).to_be_visible()
+
+
 def set_search_value(page: Page, value: str) -> None:
     page.locator(".command-input").evaluate(
         """(el, value) => {
@@ -1353,6 +1370,7 @@ def main() -> int:
         smoke.step("S03c loupe arrow navigation", lambda: test_loupe_arrow_navigation(page))
         smoke.step("S03d loupe double-click return", lambda: test_loupe_dblclick_return(page))
         smoke.step("S28a sidebar toggle Cmd+B", lambda: test_sidebar_toggle(page))
+        smoke.step("S28b atomic folder rename", lambda: test_sidebar_folder_rename(page))
         smoke.step("S29a zen mode", lambda: test_zen_mode(page))
         smoke.step("S19a command palette open/close", lambda: test_command_palette_open_close(page))
         smoke.step("S19b command palette navigate and execute", lambda: test_command_palette_navigate_and_execute(page))


### PR DESCRIPTION
Summary:
- Add atomic, crash-recoverable library-folder rename across disk, SQLite paths, watcher roots, sessions, and canvas documents.
- Validate managed roots and symlink boundaries, use no-replace filesystem moves, and roll back safely on watcher or disk failures.
- Add a serialized canvas-save barrier plus Sidebar rename UI and state reconciliation.
- Cover database migration, recovery, watcher rollback, frontend coordination, and browser smoke behavior.

Verification:
- npm run preflight -- full: 1,230 frontend tests; 792 Rust tests passed, 3 ignored.
- npm run build.
- Manual E2E smoke S28b: atomic folder rename passed.
- Independent specification review: PASS.
- Independent standards/correctness review: PASS.

Beads: imageview-10s0.13.