### PR TITLE
Keep large imports responsive and cancellable

### DIFF
--- a/src-tauri/src/commands/import.rs
+++ b/src-tauri/src/commands/import.rs
@@ -1,9 +1,11 @@
 use crate::db_core::db::Database;
 use crate::db_core::models::NewSessionEvent;
+use crate::services::jobs::JobRegistry;
 use crate::AppState;
 use std::collections::HashSet;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use tauri::{AppHandle, Emitter, Manager, State};
+use tokio_util::sync::CancellationToken;
 
 #[derive(serde::Serialize)]
 pub struct ImportResponse {
@@ -12,13 +14,175 @@ pub struct ImportResponse {
     pub errors: Vec<String>,
     pub batch_id: Option<String>,
     pub image_ids: Vec<String>,
+    pub cancelled: bool,
 }
 
 #[derive(Clone, serde::Serialize)]
 struct ImportProgress {
+    job_id: String,
+    progress_id: Option<String>,
     current: u32,
     total: u32,
     filename: String,
+}
+
+struct ImportWorkResult {
+    response: ImportResponse,
+    cancelled: bool,
+}
+
+struct ImportPathSummary {
+    imported: u32,
+    skipped: u32,
+    errors: Vec<String>,
+    image_ids: Vec<String>,
+    cancelled: bool,
+}
+
+struct ImportDiscovery {
+    entries: Vec<PathBuf>,
+    cancelled: bool,
+}
+
+fn collect_cancellable_entries<I, F>(
+    candidates: I,
+    cancel: &CancellationToken,
+    mut is_supported: F,
+) -> ImportDiscovery
+where
+    I: IntoIterator<Item = PathBuf>,
+    F: FnMut(&Path) -> bool,
+{
+    let mut entries = Vec::new();
+    for path in candidates {
+        if cancel.is_cancelled() {
+            return ImportDiscovery {
+                entries,
+                cancelled: true,
+            };
+        }
+        if is_supported(&path) {
+            entries.push(path);
+        }
+    }
+    ImportDiscovery {
+        entries,
+        cancelled: false,
+    }
+}
+
+fn process_import_entries<P, F>(
+    entries: &[PathBuf],
+    cancel: &CancellationToken,
+    mut on_progress: P,
+    mut import_one: F,
+) -> ImportPathSummary
+where
+    P: FnMut(u32, u32, &Path),
+    F: FnMut(&Path) -> Result<Option<String>, String>,
+{
+    let total = entries.len() as u32;
+    let mut summary = ImportPathSummary {
+        imported: 0,
+        skipped: 0,
+        errors: Vec::new(),
+        image_ids: Vec::new(),
+        cancelled: false,
+    };
+
+    for (index, path) in entries.iter().enumerate() {
+        if cancel.is_cancelled() {
+            summary.cancelled = true;
+            break;
+        }
+
+        on_progress((index + 1) as u32, total, path);
+        match import_one(path) {
+            Ok(Some(id)) => {
+                summary.image_ids.push(id);
+                summary.imported += 1;
+            }
+            Ok(None) => summary.skipped += 1,
+            Err(_) if cancel.is_cancelled() => {
+                summary.cancelled = true;
+                break;
+            }
+            Err(error) => summary
+                .errors
+                .push(format!("{}: {}", path.display(), error)),
+        }
+        if cancel.is_cancelled() {
+            summary.cancelled = true;
+            break;
+        }
+    }
+
+    summary
+}
+
+fn emit_import_job_status(app: &AppHandle, job_id: &str, status: &str, current: u32, total: u32) {
+    let _ = app.emit(
+        "job-status-changed",
+        serde_json::json!({
+            "job_id": job_id,
+            "kind": "import",
+            "status": status,
+            "current": current,
+            "total": total,
+        }),
+    );
+}
+
+fn finish_import_job(
+    app: &AppHandle,
+    jobs: &JobRegistry,
+    job_id: &str,
+    work: &Result<ImportWorkResult, String>,
+) {
+    match work {
+        Ok(result) if result.cancelled => jobs.mark_cancelled(job_id),
+        Ok(_) => jobs.complete(job_id),
+        Err(error) => jobs.fail(job_id, error),
+    }
+    if let Some(snapshot) = jobs.get(job_id) {
+        emit_import_job_status(
+            app,
+            job_id,
+            &snapshot.status,
+            snapshot.current,
+            snapshot.total,
+        );
+    }
+}
+
+fn seal_import_job(
+    jobs: &JobRegistry,
+    job_id: &str,
+    cancel: &CancellationToken,
+    already_cancelled: bool,
+) -> bool {
+    if already_cancelled || cancel.is_cancelled() {
+        jobs.mark_cancelled(job_id);
+    } else {
+        // Completing here closes the cancellation window before audit logging
+        // and automatic child-job dispatch. Later cancel requests are rejected.
+        jobs.complete(job_id);
+    }
+    jobs.get(job_id)
+        .map(|snapshot| snapshot.status == "cancelled")
+        .unwrap_or(already_cancelled || cancel.is_cancelled())
+}
+
+fn import_audit_event_type(cancelled: bool) -> &'static str {
+    if cancelled {
+        "import_cancelled"
+    } else {
+        "import_completed"
+    }
+}
+
+async fn persist_import_job(db: Database, jobs: JobRegistry, job_id: String) {
+    let _ = tauri::async_runtime::spawn_blocking(move || jobs.persist_terminal(&job_id, &db)).await;
 }
 
 #[tauri::command]
@@ -27,59 +191,116 @@ pub async fn import_folder(
     state: State<'_, AppState>,
     folder_path: String,
     session_id: Option<String>,
+    progress_id: Option<String>,
 ) -> Result<ImportResponse, String> {
-    let db = &state.db;
-    let app_data_dir = &state.app_data_dir;
+    let db = state.db.clone();
+    let app_data_dir = state.app_data_dir.clone();
+    let jobs = state.jobs.clone();
+    let (job_id, cancel) = jobs.create_job("import", 0);
+    emit_import_job_status(&app, &job_id, "running", 0, 0);
 
+    let worker_app = app.clone();
+    let worker_jobs = jobs.clone();
+    let worker_job_id = job_id.clone();
+    let joined = tauri::async_runtime::spawn_blocking(move || {
+        import_folder_blocking(
+            worker_app,
+            db,
+            app_data_dir,
+            worker_jobs,
+            worker_job_id,
+            cancel,
+            folder_path,
+            session_id,
+            progress_id,
+        )
+    })
+    .await;
+    let work = match joined {
+        Ok(work) => work,
+        Err(error) => Err(format!("Import worker failed: {error}")),
+    };
+
+    finish_import_job(&app, &jobs, &job_id, &work);
+    persist_import_job(state.db.clone(), jobs, job_id).await;
+    work.map(|result| result.response)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn import_folder_blocking(
+    app: AppHandle,
+    db: Database,
+    app_data_dir: PathBuf,
+    jobs: JobRegistry,
+    job_id: String,
+    cancel: CancellationToken,
+    folder_path: String,
+    session_id: Option<String>,
+    progress_id: Option<String>,
+) -> Result<ImportWorkResult, String> {
     // Collect all image files first so we know the total
-    let module_raw = crate::db_core::import::is_module_raw_enabled(&state.db);
+    let module_raw = crate::db_core::import::is_module_raw_enabled(&db);
     let extensions = crate::extensions::supported_extensions(module_raw);
-    let entries: Vec<std::path::PathBuf> = walkdir::WalkDir::new(&folder_path)
+    let candidates = walkdir::WalkDir::new(&folder_path)
         .into_iter()
         .filter_map(|e| e.ok())
         .filter(|e| e.file_type().is_file())
-        .filter(|e| {
-            e.path()
-                .extension()
-                .and_then(|ext| ext.to_str())
-                .map(|ext| extensions.contains(&ext.to_lowercase().as_str()))
-                .unwrap_or(false)
-        })
-        .map(|e| e.path().to_path_buf())
-        .collect();
+        .map(|e| e.path().to_path_buf());
+    let discovery = collect_cancellable_entries(candidates, &cancel, |path| {
+        path.extension()
+            .and_then(|ext| ext.to_str())
+            .map(|ext| extensions.contains(&ext.to_lowercase().as_str()))
+            .unwrap_or(false)
+    });
+    if discovery.cancelled {
+        return Ok(ImportWorkResult {
+            response: ImportResponse {
+                imported: 0,
+                skipped: 0,
+                errors: Vec::new(),
+                batch_id: None,
+                image_ids: Vec::new(),
+                cancelled: true,
+            },
+            cancelled: true,
+        });
+    }
+    let entries = discovery.entries;
 
     let total = entries.len() as u32;
-    let mut imported = 0u32;
-    let mut skipped = 0u32;
-    let mut errors = Vec::new();
-    let mut new_image_ids: Vec<String> = Vec::new();
+    jobs.update_total(&job_id, total);
+    let summary = process_import_entries(
+        &entries,
+        &cancel,
+        |current, total, path| {
+            let filename = path
+                .file_name()
+                .map(|name| name.to_string_lossy().to_string())
+                .unwrap_or_default();
+            let _ = app.emit(
+                "import-progress",
+                ImportProgress {
+                    job_id: job_id.clone(),
+                    progress_id: progress_id.clone(),
+                    current,
+                    total,
+                    filename: filename.clone(),
+                },
+            );
+            jobs.update_progress(&job_id, current, Some(&filename));
+        },
+        |path| {
+            crate::db_core::import::import_file_cancellable(&db, path, &app_data_dir, &|| {
+                cancel.is_cancelled()
+            })
+        },
+    );
+    let imported = summary.imported;
+    let skipped = summary.skipped;
+    let errors = summary.errors;
+    let new_image_ids = summary.image_ids;
 
-    for (i, path) in entries.iter().enumerate() {
-        let filename = path
-            .file_name()
-            .map(|f| f.to_string_lossy().to_string())
-            .unwrap_or_default();
-
-        let _ = app.emit(
-            "import-progress",
-            ImportProgress {
-                current: (i + 1) as u32,
-                total,
-                filename,
-            },
-        );
-
-        match crate::db_core::import::import_file(db, path, app_data_dir) {
-            Ok(Some(id)) => {
-                new_image_ids.push(id);
-                imported += 1;
-            }
-            Ok(None) => skipped += 1,
-            Err(e) => errors.push(format!("{}: {}", path.display(), e)),
-        }
-    }
-
-    let _ = state.db.add_library_root(&folder_path);
+    let _ = db.add_library_root(&folder_path);
 
     let batch_id = if !new_image_ids.is_empty() {
         let batch = db
@@ -93,9 +314,17 @@ pub async fn import_folder(
             let _ = db.add_to_collection(active_session_id, &refs);
         }
         let _ = db.detect_lineage_for_batch(&new_image_ids);
+        Some(batch)
+    } else {
+        None
+    };
+
+    let auto_process_ids = filter_image_ids_for_auto_jobs(&db, &new_image_ids)?;
+    let cancelled = seal_import_job(&jobs, &job_id, &cancel, summary.cancelled);
+    if let Some(batch) = batch_id.as_ref() {
         let _ = db.log_session_event(&NewSessionEvent {
             session_id: session_id.clone(),
-            event_type: "import_completed".to_string(),
+            event_type: import_audit_event_type(cancelled).to_string(),
             actor_type: "user".to_string(),
             actor_id: None,
             subject_type: Some("import_batch".to_string()),
@@ -107,30 +336,29 @@ pub async fn import_folder(
                 "skipped": skipped,
                 "error_count": errors.len(),
                 "image_count": new_image_ids.len(),
+                "cancelled": cancelled,
             })
             .to_string(),
         });
-        Some(batch)
-    } else {
-        None
-    };
-
+    }
     let image_ids_out = new_image_ids.clone();
-    let auto_process_ids =
-        filter_image_ids_for_auto_jobs(&db, &new_image_ids).map_err(|e| e.to_string())?;
 
-    if !auto_process_ids.is_empty() {
+    if !cancelled && !auto_process_ids.is_empty() {
         run_post_import_quality_analysis(app.clone(), auto_process_ids.clone());
         run_post_import_detection(app.clone(), auto_process_ids);
     }
     let _ = crate::tray::refresh_tray_menu(&app);
 
-    Ok(ImportResponse {
-        imported,
-        skipped,
-        errors,
-        batch_id,
-        image_ids: image_ids_out,
+    Ok(ImportWorkResult {
+        response: ImportResponse {
+            imported,
+            skipped,
+            errors,
+            batch_id,
+            image_ids: image_ids_out,
+            cancelled,
+        },
+        cancelled,
     })
 }
 
@@ -140,40 +368,85 @@ pub async fn import_files(
     state: State<'_, AppState>,
     file_paths: Vec<String>,
     session_id: Option<String>,
+    progress_id: Option<String>,
 ) -> Result<ImportResponse, String> {
-    let db = &state.db;
-    let app_data_dir = &state.app_data_dir;
-    let mut imported = 0u32;
-    let mut skipped = 0u32;
-    let mut errors = Vec::new();
-
-    let mut new_image_ids: Vec<String> = Vec::new();
+    let db = state.db.clone();
+    let app_data_dir = state.app_data_dir.clone();
+    let jobs = state.jobs.clone();
     let total = file_paths.len() as u32;
+    let (job_id, cancel) = jobs.create_job("import", total);
+    emit_import_job_status(&app, &job_id, "running", 0, total);
 
-    for (i, path_str) in file_paths.iter().enumerate() {
-        let filename = Path::new(path_str.as_str())
-            .file_name()
-            .map(|f| f.to_string_lossy().to_string())
-            .unwrap_or_else(|| path_str.clone());
+    let worker_app = app.clone();
+    let worker_jobs = jobs.clone();
+    let worker_job_id = job_id.clone();
+    let joined = tauri::async_runtime::spawn_blocking(move || {
+        import_files_blocking(
+            worker_app,
+            db,
+            app_data_dir,
+            worker_jobs,
+            worker_job_id,
+            cancel,
+            file_paths,
+            session_id,
+            progress_id,
+        )
+    })
+    .await;
+    let work = match joined {
+        Ok(work) => work,
+        Err(error) => Err(format!("Import worker failed: {error}")),
+    };
 
-        let _ = app.emit(
-            "import-progress",
-            ImportProgress {
-                current: (i + 1) as u32,
-                total,
-                filename,
-            },
-        );
+    finish_import_job(&app, &jobs, &job_id, &work);
+    persist_import_job(state.db.clone(), jobs, job_id).await;
+    work.map(|result| result.response)
+}
 
-        match crate::db_core::import::import_file(db, Path::new(path_str.as_str()), app_data_dir) {
-            Ok(Some(id)) => {
-                new_image_ids.push(id);
-                imported += 1;
-            }
-            Ok(None) => skipped += 1,
-            Err(e) => errors.push(format!("{}: {}", path_str, e)),
-        }
-    }
+#[allow(clippy::too_many_arguments)]
+fn import_files_blocking(
+    app: AppHandle,
+    db: Database,
+    app_data_dir: PathBuf,
+    jobs: JobRegistry,
+    job_id: String,
+    cancel: CancellationToken,
+    file_paths: Vec<String>,
+    session_id: Option<String>,
+    progress_id: Option<String>,
+) -> Result<ImportWorkResult, String> {
+    let entries: Vec<PathBuf> = file_paths.into_iter().map(PathBuf::from).collect();
+    let summary = process_import_entries(
+        &entries,
+        &cancel,
+        |current, total, path| {
+            let filename = path
+                .file_name()
+                .map(|name| name.to_string_lossy().to_string())
+                .unwrap_or_else(|| path.to_string_lossy().to_string());
+            let _ = app.emit(
+                "import-progress",
+                ImportProgress {
+                    job_id: job_id.clone(),
+                    progress_id: progress_id.clone(),
+                    current,
+                    total,
+                    filename: filename.clone(),
+                },
+            );
+            jobs.update_progress(&job_id, current, Some(&filename));
+        },
+        |path| {
+            crate::db_core::import::import_file_cancellable(&db, path, &app_data_dir, &|| {
+                cancel.is_cancelled()
+            })
+        },
+    );
+    let imported = summary.imported;
+    let skipped = summary.skipped;
+    let errors = summary.errors;
+    let new_image_ids = summary.image_ids;
 
     let batch_id = if !new_image_ids.is_empty() {
         let batch = db
@@ -187,46 +460,53 @@ pub async fn import_files(
             let _ = db.add_to_collection(active_session_id, &refs);
         }
         let _ = db.detect_lineage_for_batch(&new_image_ids);
+        Some(batch)
+    } else {
+        None
+    };
+
+    let auto_process_ids = filter_image_ids_for_auto_jobs(&db, &new_image_ids)?;
+    let cancelled = seal_import_job(&jobs, &job_id, &cancel, summary.cancelled);
+    if let Some(batch) = batch_id.as_ref() {
         let _ = db.log_session_event(&NewSessionEvent {
             session_id: session_id.clone(),
-            event_type: "import_completed".to_string(),
+            event_type: import_audit_event_type(cancelled).to_string(),
             actor_type: "user".to_string(),
             actor_id: None,
             subject_type: Some("import_batch".to_string()),
             subject_id: Some(batch.clone()),
             payload_json: serde_json::json!({
                 "source": "files",
-                "file_count": file_paths.len(),
+                "file_count": entries.len(),
                 "imported": imported,
                 "skipped": skipped,
                 "error_count": errors.len(),
                 "image_count": new_image_ids.len(),
+                "cancelled": cancelled,
             })
             .to_string(),
         });
-        Some(batch)
-    } else {
-        None
-    };
-
+    }
     let image_ids_out = new_image_ids.clone();
-    let auto_process_ids =
-        filter_image_ids_for_auto_jobs(&db, &new_image_ids).map_err(|e| e.to_string())?;
 
     if !new_image_ids.is_empty() {
         let _ = crate::tray::refresh_tray_menu(&app);
-        if !auto_process_ids.is_empty() {
+        if !cancelled && !auto_process_ids.is_empty() {
             run_post_import_quality_analysis(app.clone(), auto_process_ids.clone());
             run_post_import_detection(app, auto_process_ids);
         }
     }
 
-    Ok(ImportResponse {
-        imported,
-        skipped,
-        errors,
-        batch_id,
-        image_ids: image_ids_out,
+    Ok(ImportWorkResult {
+        response: ImportResponse {
+            imported,
+            skipped,
+            errors,
+            batch_id,
+            image_ids: image_ids_out,
+            cancelled,
+        },
+        cancelled,
     })
 }
 
@@ -534,62 +814,76 @@ fn run_post_import_quality_analysis(app: AppHandle, image_ids: Vec<String>) {
 
     let app_clone = app.clone();
     crate::spawn_guarded(app_clone, "post-import-quality", move || async move {
-        let state: State<'_, AppState> = app.state();
-        let total = image_ids.len() as u32;
-        let (job_id, cancel_token) = state.jobs.create_job("quality", total);
-        let progress_job_id = job_id.clone();
-        let progress_app = app.clone();
-        let cancel_for_loop = cancel_token.clone();
+        let blocking_app = app.clone();
+        let result = tauri::async_runtime::spawn_blocking(move || {
+            let state: State<'_, AppState> = blocking_app.state();
+            let total = image_ids.len() as u32;
+            let (job_id, cancel_token) = state.jobs.create_job("quality", total);
+            let progress_job_id = job_id.clone();
+            let progress_app = blocking_app.clone();
+            let cancel_for_loop = cancel_token.clone();
 
-        let _ = app.emit(
-            "job-status-changed",
-            serde_json::json!({
-                "job_id": &job_id,
-                "kind": "quality",
-                "status": "running",
-                "current": 0,
-                "total": total,
-            }),
-        );
+            let _ = blocking_app.emit(
+                "job-status-changed",
+                serde_json::json!({
+                    "job_id": &job_id,
+                    "kind": "quality",
+                    "status": "running",
+                    "current": 0,
+                    "total": total,
+                }),
+            );
 
-        let summary = analyze_quality_for_imported_images(
-            &state.db,
-            &state.app_data_dir,
-            &image_ids,
-            |current, total| {
-                state.jobs.update_progress(&progress_job_id, current, None);
-                let _ = progress_app.emit(
-                    "quality-progress",
-                    serde_json::json!({
-                        "job_id": &progress_job_id,
-                        "current": current,
-                        "total": total,
-                        "analyzer": crate::db_core::quality::QUALITY_ANALYZER_VERSION,
-                    }),
-                );
-            },
-            move || cancel_for_loop.is_cancelled(),
-        );
+            let summary = analyze_quality_for_imported_images(
+                &state.db,
+                &state.app_data_dir,
+                &image_ids,
+                |current, total| {
+                    state.jobs.update_progress(&progress_job_id, current, None);
+                    let _ = progress_app.emit(
+                        "quality-progress",
+                        serde_json::json!({
+                            "job_id": &progress_job_id,
+                            "current": current,
+                            "total": total,
+                            "analyzer": crate::db_core::quality::QUALITY_ANALYZER_VERSION,
+                        }),
+                    );
+                },
+                move || cancel_for_loop.is_cancelled(),
+            );
 
-        let status = if summary.cancelled {
-            state.jobs.mark_cancelled(&job_id);
-            "cancelled"
-        } else {
-            state.jobs.complete(&job_id);
-            "completed"
-        };
-        state.jobs.persist_terminal(&job_id, &state.db);
-        let _ = app.emit(
-            "job-status-changed",
-            serde_json::json!({
-                "job_id": &job_id,
-                "kind": "quality",
-                "status": status,
-                "current": if summary.cancelled { summary.analyzed + summary.failed } else { total },
-                "total": total,
-                "message": format!("{} analyzed, {} skipped", summary.analyzed, summary.failed),
-            }),
-        );
+            let status = if summary.cancelled {
+                state.jobs.mark_cancelled(&job_id);
+                "cancelled"
+            } else {
+                state.jobs.complete(&job_id);
+                "completed"
+            };
+            let _ = blocking_app.emit(
+                "job-status-changed",
+                serde_json::json!({
+                    "job_id": &job_id,
+                    "kind": "quality",
+                    "status": status,
+                    "current": if summary.cancelled { summary.analyzed + summary.failed } else { total },
+                    "total": total,
+                    "message": format!("{} analyzed, {} skipped", summary.analyzed, summary.failed),
+                }),
+            );
+            state.jobs.persist_terminal(&job_id, &state.db);
+        })
+        .await;
+        if let Err(error) = result {
+            let _ = app.emit(
+                "background-task-failed",
+                serde_json::json!({
+                    "task": "post-import-quality",
+                    "message": error.to_string(),
+                    "recoverable": true,
+                }),
+            );
+        }
     });
 }
 
@@ -650,114 +944,374 @@ fn analyze_quality_for_imported_image(
 fn run_post_import_detection(app: AppHandle, image_ids: Vec<String>) {
     let app_clone = app.clone();
     crate::spawn_guarded(app_clone, "post-import-detection", move || async move {
-        let state: State<'_, AppState> = app.state();
-        let yolo_variant = crate::db_core::detection::YoloVariant::Medium;
-        let yolo_model_name = yolo_variant.model_name();
-
-        // YOLO detection (if model available)
-        let yolo_available = {
-            let engine = state.detection_engine.lock();
-            engine.is_variant_available(yolo_variant)
-        };
-
-        if yolo_available {
+        let blocking_app = app.clone();
+        let result = tauri::async_runtime::spawn_blocking(move || {
+            run_post_import_detection_blocking(blocking_app, image_ids)
+        })
+        .await;
+        if let Err(error) = result {
             let _ = app.emit(
-                "auto-detection-start",
+                "background-task-failed",
                 serde_json::json!({
-                    "model": yolo_model_name, "count": image_ids.len()
+                    "task": "post-import-detection",
+                    "message": error.to_string(),
+                    "recoverable": true,
                 }),
             );
-
-            {
-                let mut engine = state.detection_engine.lock();
-                if engine.session.is_none() {
-                    let _ = engine.load_yolo(yolo_variant);
-                }
-            }
-
-            for (i, image_id) in image_ids.iter().enumerate() {
-                let id_refs: Vec<&str> = vec![image_id.as_str()];
-                if let Ok(images) = state.db.get_images_by_ids(&id_refs) {
-                    if let Some(img) = images.first() {
-                        let detect_path =
-                            crate::commands::resolve_image_path_for_ml(img, &state.app_data_dir);
-                        let engine = state.detection_engine.lock();
-                        if let Ok(detections) = engine.detect(&detect_path) {
-                            drop(engine);
-                            let _ =
-                                state
-                                    .db
-                                    .store_detections(image_id, yolo_model_name, &detections);
-                        }
-                    }
-                }
-
-                let _ = app.emit(
-                    "auto-detection-progress",
-                    serde_json::json!({
-                        "current": i + 1, "total": image_ids.len(), "model": yolo_model_name
-                    }),
-                );
-            }
         }
+    });
+}
 
-        // NudeNet safety check (if model available)
-        let nudenet_available = {
-            let engine = state.safety_engine.lock();
-            engine.is_nudenet_available()
-        };
+fn run_post_import_detection_blocking(app: AppHandle, image_ids: Vec<String>) {
+    let state: State<'_, AppState> = app.state();
+    let yolo_variant = crate::db_core::detection::YoloVariant::Medium;
+    let yolo_model_name = yolo_variant.model_name();
+    let yolo_available = {
+        let engine = state.detection_engine.lock();
+        engine.is_variant_available(yolo_variant)
+    };
+    let nudenet_available = {
+        let engine = state.safety_engine.lock();
+        engine.is_nudenet_available()
+    };
+    let stage_size = image_ids.len() as u32;
+    let enabled_stages = u32::from(yolo_available) + u32::from(nudenet_available);
+    let total = stage_size.saturating_mul(enabled_stages);
+    let (job_id, cancel) = state.jobs.create_job("detection", total);
+    let _ = app.emit(
+        "job-status-changed",
+        serde_json::json!({
+            "job_id": &job_id,
+            "kind": "detection",
+            "status": "running",
+            "current": 0,
+            "total": total,
+        }),
+    );
+    let mut completed_stages = 0u32;
 
-        if nudenet_available {
-            let _ = app.emit(
-                "auto-detection-start",
-                serde_json::json!({
-                    "model": "nudenet", "count": image_ids.len()
-                }),
-            );
-
-            {
-                let mut engine = state.safety_engine.lock();
-                if engine.session.is_none() {
-                    let _ = engine.load_nudenet();
-                }
-            }
-
-            for (i, image_id) in image_ids.iter().enumerate() {
-                let id_refs: Vec<&str> = vec![image_id.as_str()];
-                if let Ok(images) = state.db.get_images_by_ids(&id_refs) {
-                    if let Some(img) = images.first() {
-                        let detect_path =
-                            crate::commands::resolve_image_path_for_ml(img, &state.app_data_dir);
-                        let engine = state.safety_engine.lock();
-                        if let Ok(detections) = engine.detect(&detect_path) {
-                            drop(engine);
-                            let _ = state.db.store_detections(image_id, "nudenet", &detections);
-                        }
-                    }
-                }
-
-                let _ = app.emit(
-                    "auto-detection-progress",
-                    serde_json::json!({
-                        "current": i + 1, "total": image_ids.len(), "model": "nudenet"
-                    }),
-                );
-            }
-        }
-
+    if yolo_available && !cancel.is_cancelled() {
         let _ = app.emit(
-            "auto-detection-complete",
+            "auto-detection-start",
             serde_json::json!({
-                "count": image_ids.len()
+                "job_id": &job_id,
+                "model": yolo_model_name,
+                "current": completed_stages,
+                "total": total,
             }),
         );
-    });
+        {
+            let mut engine = state.detection_engine.lock();
+            if engine.session.is_none() {
+                let _ = engine.load_yolo(yolo_variant);
+            }
+        }
+        for (index, image_id) in image_ids.iter().enumerate() {
+            if cancel.is_cancelled() {
+                break;
+            }
+            if let Ok(images) = state.db.get_images_by_ids(&[image_id.as_str()]) {
+                if let Some(image) = images.first() {
+                    let path =
+                        crate::commands::resolve_image_path_for_ml(image, &state.app_data_dir);
+                    let engine = state.detection_engine.lock();
+                    if let Ok(detections) = engine.detect(&path) {
+                        drop(engine);
+                        let _ = state
+                            .db
+                            .store_detections(image_id, yolo_model_name, &detections);
+                    }
+                }
+            }
+            let current = completed_stages + (index + 1) as u32;
+            state.jobs.update_progress(&job_id, current, None);
+            let _ = app.emit(
+                "auto-detection-progress",
+                serde_json::json!({
+                    "job_id": &job_id,
+                    "current": current,
+                    "total": total,
+                    "model": yolo_model_name,
+                }),
+            );
+        }
+        if !cancel.is_cancelled() {
+            completed_stages = completed_stages.saturating_add(stage_size);
+        }
+    }
+
+    if nudenet_available && !cancel.is_cancelled() {
+        let _ = app.emit(
+            "auto-detection-start",
+            serde_json::json!({
+                "job_id": &job_id,
+                "model": "nudenet",
+                "current": completed_stages,
+                "total": total,
+            }),
+        );
+        {
+            let mut engine = state.safety_engine.lock();
+            if engine.session.is_none() {
+                let _ = engine.load_nudenet();
+            }
+        }
+        for (index, image_id) in image_ids.iter().enumerate() {
+            if cancel.is_cancelled() {
+                break;
+            }
+            if let Ok(images) = state.db.get_images_by_ids(&[image_id.as_str()]) {
+                if let Some(image) = images.first() {
+                    let path =
+                        crate::commands::resolve_image_path_for_ml(image, &state.app_data_dir);
+                    let engine = state.safety_engine.lock();
+                    if let Ok(detections) = engine.detect(&path) {
+                        drop(engine);
+                        let _ = state.db.store_detections(image_id, "nudenet", &detections);
+                    }
+                }
+            }
+            let current = completed_stages + (index + 1) as u32;
+            state.jobs.update_progress(&job_id, current, None);
+            let _ = app.emit(
+                "auto-detection-progress",
+                serde_json::json!({
+                    "job_id": &job_id,
+                    "current": current,
+                    "total": total,
+                    "model": "nudenet",
+                }),
+            );
+        }
+        if !cancel.is_cancelled() {
+            completed_stages = completed_stages.saturating_add(stage_size);
+        }
+    }
+
+    let status = if cancel.is_cancelled() {
+        state.jobs.mark_cancelled(&job_id);
+        "cancelled"
+    } else {
+        state.jobs.complete(&job_id);
+        "completed"
+    };
+    let _ = app.emit(
+        "job-status-changed",
+        serde_json::json!({
+            "job_id": &job_id,
+            "kind": "detection",
+            "status": status,
+            "current": state.jobs.get(&job_id).map(|job| job.current).unwrap_or(0),
+            "total": total,
+        }),
+    );
+    let _ = app.emit(
+        "auto-detection-complete",
+        serde_json::json!({
+            "job_id": &job_id,
+            "current": state.jobs.get(&job_id).map(|job| job.current).unwrap_or(completed_stages),
+            "total": total,
+            "cancelled": cancel.is_cancelled(),
+        }),
+    );
+    state.jobs.persist_terminal(&job_id, &state.db);
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::db_core::db::Database;
+
+    #[test]
+    fn synthetic_10k_import_work_is_bounded_and_cancellable_between_files() {
+        let entries: Vec<PathBuf> = (0..10_000)
+            .map(|index| PathBuf::from(format!("synthetic-{index}.png")))
+            .collect();
+        let cancel = CancellationToken::new();
+        let cancel_after_progress = cancel.clone();
+        let mut max_total = 0;
+
+        let summary = process_import_entries(
+            &entries,
+            &cancel,
+            |current, total, _path| {
+                max_total = total;
+                if current == 128 {
+                    cancel_after_progress.cancel();
+                }
+            },
+            |path| Ok(Some(path.to_string_lossy().to_string())),
+        );
+
+        assert_eq!(max_total, 10_000);
+        assert_eq!(summary.imported, 128);
+        assert!(summary.cancelled);
+        assert_eq!(summary.image_ids.len(), 128);
+    }
+
+    #[test]
+    fn synthetic_10k_folder_discovery_stops_when_cancelled() {
+        let cancel = CancellationToken::new();
+        let cancel_during_walk = cancel.clone();
+        let candidates = (0..10_000).map(move |index| {
+            if index == 128 {
+                cancel_during_walk.cancel();
+            }
+            PathBuf::from(format!("synthetic-{index}.png"))
+        });
+
+        let discovery = collect_cancellable_entries(candidates, &cancel, |_| true);
+
+        assert!(discovery.cancelled);
+        assert_eq!(discovery.entries.len(), 128);
+    }
+
+    #[test]
+    fn synthetic_10k_import_keeps_browse_and_job_listing_responsive() {
+        use std::sync::mpsc;
+        use std::time::{Duration, Instant};
+
+        let tmp = tempfile::tempdir().unwrap();
+        let db = Database::open(&tmp.path().join("responsive-import.db")).unwrap();
+        let jobs = JobRegistry::default();
+        let (job_id, cancel) = jobs.create_job("import", 10_000);
+        let entries: Vec<PathBuf> = (0..10_000)
+            .map(|index| PathBuf::from(format!("synthetic-{index}.png")))
+            .collect();
+        let worker_db = db.clone();
+        let worker_cancel = cancel.clone();
+        let (writer_started_tx, writer_started_rx) = mpsc::channel();
+        let (release_writer_tx, release_writer_rx) = mpsc::channel();
+
+        let worker = std::thread::spawn(move || {
+            process_import_entries(
+                &entries,
+                &worker_cancel,
+                |_current, _total, _path| {},
+                |_path| {
+                    let writer = worker_db.conn.lock();
+                    writer.execute_batch("BEGIN IMMEDIATE").unwrap();
+                    writer_started_tx.send(()).unwrap();
+                    release_writer_rx.recv().unwrap();
+                    writer.execute_batch("ROLLBACK").unwrap();
+                    worker_cancel.cancel();
+                    Ok(None)
+                },
+            )
+        });
+        writer_started_rx
+            .recv_timeout(Duration::from_secs(1))
+            .expect("synthetic import should enter its database stage");
+
+        let started = Instant::now();
+        assert_eq!(db.image_count().unwrap(), 0);
+        assert!(
+            started.elapsed() < Duration::from_millis(250),
+            "browse reads must not wait for the import writer"
+        );
+        let started = Instant::now();
+        assert_eq!(jobs.list().first().unwrap().job_id, job_id);
+        assert!(
+            started.elapsed() < Duration::from_millis(250),
+            "list_jobs must not wait for import work"
+        );
+
+        release_writer_tx.send(()).unwrap();
+        let summary = worker.join().unwrap();
+        assert!(summary.cancelled);
+    }
+
+    #[test]
+    fn tauri_import_commands_dispatch_blocking_work_to_the_blocking_pool() {
+        let source = include_str!("import.rs");
+        let production = source.split("#[cfg(test)]").next().unwrap();
+        assert_eq!(
+            production
+                .matches("tauri::async_runtime::spawn_blocking")
+                .count(),
+            5
+        );
+        assert!(production.contains("process_import_entries("));
+        assert!(production.contains("cancel.is_cancelled()"));
+    }
+
+    #[test]
+    fn import_outcome_is_sealed_only_after_fallible_child_job_preparation() {
+        let source = include_str!("import.rs");
+        let folder = &source[source.find("fn import_folder_blocking(").unwrap()
+            ..source.find("pub async fn import_files(").unwrap()];
+        let files = &source[source.find("fn import_files_blocking(").unwrap()
+            ..source.find("struct ThumbnailProgress").unwrap()];
+
+        for worker in [folder, files] {
+            let prepare = worker.find("filter_image_ids_for_auto_jobs").unwrap();
+            let seal = worker.find("seal_import_job").unwrap();
+            let audit = worker.find("log_session_event").unwrap();
+            assert!(prepare < seal && seal < audit);
+        }
+    }
+
+    #[test]
+    fn child_jobs_emit_terminal_status_before_database_persistence() {
+        let source = include_str!("import.rs");
+        let quality = &source[source.find("fn run_post_import_quality_analysis").unwrap()
+            ..source
+                .find("fn analyze_quality_for_imported_images")
+                .unwrap()];
+        let detection = &source[source
+            .find("fn run_post_import_detection_blocking")
+            .unwrap()
+            ..source.find("#[cfg(test)]\nmod tests").unwrap()];
+
+        for child in [quality, detection] {
+            let terminal_event = child.rfind("job-status-changed").unwrap();
+            let persistence = child.rfind("persist_terminal").unwrap();
+            assert!(terminal_event < persistence);
+        }
+    }
+
+    #[test]
+    fn import_progress_uses_the_registered_job_identity() {
+        let payload = serde_json::to_value(ImportProgress {
+            job_id: "job_import".to_string(),
+            progress_id: Some("sidebar-import".to_string()),
+            current: 3,
+            total: 10,
+            filename: "image.png".to_string(),
+        })
+        .unwrap();
+
+        assert_eq!(payload["job_id"], "job_import");
+        assert_eq!(payload["progress_id"], "sidebar-import");
+        assert_eq!(payload["current"], 3);
+        assert_eq!(payload["total"], 10);
+    }
+
+    #[test]
+    fn cancellation_is_sealed_before_child_jobs_and_audit_logging() {
+        let jobs = JobRegistry::default();
+        let (cancelled_id, cancelled_token) = jobs.create_job("import", 1);
+        cancelled_token.cancel();
+        assert!(seal_import_job(
+            &jobs,
+            &cancelled_id,
+            &cancelled_token,
+            false
+        ));
+        assert_eq!(jobs.get(&cancelled_id).unwrap().status, "cancelled");
+        assert_eq!(import_audit_event_type(true), "import_cancelled");
+
+        let (completed_id, completed_token) = jobs.create_job("import", 1);
+        assert!(!seal_import_job(
+            &jobs,
+            &completed_id,
+            &completed_token,
+            false
+        ));
+        assert_eq!(jobs.get(&completed_id).unwrap().status, "completed");
+        assert!(jobs.cancel(&completed_id).is_err());
+        assert_eq!(import_audit_event_type(false), "import_completed");
+    }
 
     #[test]
     fn post_import_detection_persists_and_emits_canonical_medium_yolo_model_name() {

--- a/src-tauri/src/db_core/db.rs
+++ b/src-tauri/src/db_core/db.rs
@@ -41,6 +41,7 @@ const MIGRATIONS: &[(i64, &str)] = &[
 #[derive(Clone)]
 pub struct Database {
     pub(crate) conn: Arc<Mutex<Connection>>,
+    read_conn: Option<Arc<Mutex<Connection>>>,
 }
 
 pub(crate) fn sql_u64(value: u64) -> rusqlite::Result<i64> {
@@ -258,11 +259,13 @@ impl Database {
         let should_consider_backup = should_consider_migration_backup(db_path);
         let conn = Connection::open(db_path)?;
         Self::configure_connection(&conn)?;
-        let db = Database {
+        let mut db = Database {
             conn: Arc::new(Mutex::new(conn)),
+            read_conn: None,
         };
         db.preflight_migrations(db_path, should_consider_backup)?;
         db.run_migrations()?;
+        db.read_conn = Self::open_read_connection(db_path)?;
         Ok(db)
     }
 
@@ -272,6 +275,21 @@ impl Database {
         conn.pragma_update(None, "synchronous", "NORMAL")?;
         conn.pragma_update(None, "busy_timeout", 5000)?;
         Ok(())
+    }
+
+    fn open_read_connection(db_path: &Path) -> Result<Option<Arc<Mutex<Connection>>>> {
+        if db_path == Path::new(":memory:") {
+            return Ok(None);
+        }
+
+        let conn = Connection::open(db_path)?;
+        Self::configure_connection(&conn)?;
+        conn.pragma_update(None, "query_only", true)?;
+        Ok(Some(Arc::new(Mutex::new(conn))))
+    }
+
+    pub(crate) fn read_connection(&self) -> parking_lot::MutexGuard<'_, Connection> {
+        self.read_conn.as_ref().unwrap_or(&self.conn).lock()
     }
 
     fn preflight_migrations(&self, db_path: &Path, should_consider_backup: bool) -> Result<()> {
@@ -3703,84 +3721,71 @@ mod file_watcher_tests {
     }
 
     #[test]
-    fn test_concurrent_read_write_lock_hold_times() {
-        use std::sync::Arc;
-        use std::thread;
-        use std::time::{Duration, Instant};
+    fn test_file_database_opens_a_query_only_read_connection() {
+        let tmp = tempfile::tempdir().unwrap();
+        let db = Database::open(&tmp.path().join("read-connection.db")).unwrap();
+        let read_conn = db
+            .read_conn
+            .as_ref()
+            .expect("file databases need a read connection");
+        let conn = read_conn.lock();
+        let query_only: i64 = conn
+            .pragma_query_value(None, "query_only", |row| row.get(0))
+            .unwrap();
+        let timeout: i64 = conn
+            .pragma_query_value(None, "busy_timeout", |row| row.get(0))
+            .unwrap();
+
+        assert_eq!(query_only, 1);
+        assert_eq!(timeout, 5000);
+    }
+
+    #[test]
+    fn test_library_stats_read_does_not_wait_for_writer_transaction() {
+        use std::sync::mpsc;
+        use std::time::Duration;
 
         let tmp = tempfile::tempdir().unwrap();
-        let db_path = tmp.path().join("bench.db");
-        let db = Arc::new(Database::open(&db_path).unwrap());
+        let db_path = tmp.path().join("concurrent.db");
+        let db = Database::open(&db_path).unwrap();
+        insert_test_image(&db, "visible", "hash-visible");
+        let collection_id = db.create_collection("Visible").unwrap();
+        db.add_to_collection(&collection_id, &["visible"]).unwrap();
 
-        // Seed with images
-        for i in 0..200 {
-            insert_test_image(&db, &format!("img-{}", i), &format!("hash-{}", i));
-        }
+        let writer = db.conn.lock();
+        writer.execute_batch("BEGIN IMMEDIATE").unwrap();
+        writer
+            .execute(
+                "INSERT INTO images (id, sha256_hash, width, height, format, file_size, created_at, imported_at)
+                 VALUES ('uncommitted', 'hash-uncommitted', 1, 1, 'png', 1, '2026-01-01', '2026-01-01')",
+                [],
+            )
+            .unwrap();
 
-        let db_clone = Arc::clone(&db);
-        let writer = thread::spawn(move || {
-            let mut max_hold = Duration::ZERO;
-            for i in 0..100 {
-                let t0 = Instant::now();
-                {
-                    let conn = db_clone.conn.lock();
-                    let _ = conn.execute(
-                        "INSERT OR REPLACE INTO selections (image_id, project_id, decision, rating, color_label) VALUES (?1, '__global__', 'accept', 3, '')",
-                        rusqlite::params![format!("img-{}", i % 200)],
-                    );
-                }
-                let hold = t0.elapsed();
-                if hold > max_hold {
-                    max_hold = hold;
-                }
-            }
-            max_hold
+        let reader_db = db.clone();
+        let (tx, rx) = mpsc::channel();
+        std::thread::spawn(move || {
+            let result = (|| -> Result<(u32, usize, usize, usize, usize, usize)> {
+                Ok((
+                    reader_db.image_count()?,
+                    reader_db.list_images(10, 0)?.len(),
+                    reader_db.list_images_by_folder("/tmp", 10, 0)?.len(),
+                    reader_db
+                        .list_images_in_scope(&["/tmp".to_string()], &[], &[], 10, 0)?
+                        .len(),
+                    reader_db.list_collection_images(&collection_id)?.len(),
+                    reader_db.get_images_by_ids(&["visible"])?.len(),
+                ))
+            })();
+            tx.send(result).unwrap();
         });
 
-        let db_clone2 = Arc::clone(&db);
-        let reader = thread::spawn(move || {
-            let mut max_hold = Duration::ZERO;
-            for _ in 0..100 {
-                let t0 = Instant::now();
-                {
-                    let conn = db_clone2.conn.lock();
-                    let _ = conn.query_row("SELECT COUNT(*) FROM images", [], |row| {
-                        row.get::<_, i64>(0)
-                    });
-                }
-                let hold = t0.elapsed();
-                if hold > max_hold {
-                    max_hold = hold;
-                }
-            }
-            max_hold
-        });
+        let browse_counts = rx
+            .recv_timeout(Duration::from_millis(250))
+            .expect("WAL browse queries must stay responsive during a write transaction")
+            .unwrap();
+        assert_eq!(browse_counts, (1, 1, 1, 1, 1, 1));
 
-        let writer_max = writer.join().unwrap();
-        let reader_max = reader.join().unwrap();
-
-        // Document findings: with a single Mutex<Connection>, all access
-        // serializes. WAL mode helps when multiple connections exist, but the
-        // current single-connection architecture means lock contention is the
-        // bottleneck. Report the measured hold times.
-        eprintln!(
-            "Lock hold times — writer max: {:.2}ms, reader max: {:.2}ms",
-            writer_max.as_secs_f64() * 1000.0,
-            reader_max.as_secs_f64() * 1000.0,
-        );
-
-        // Under normal desktop load, holds should be well under 50ms even
-        // with contention from a competing thread.
-        let threshold = Duration::from_millis(50);
-        assert!(
-            writer_max < threshold,
-            "Writer lock hold exceeded threshold: {:.2}ms",
-            writer_max.as_secs_f64() * 1000.0
-        );
-        assert!(
-            reader_max < threshold,
-            "Reader lock hold exceeded threshold: {:.2}ms",
-            reader_max.as_secs_f64() * 1000.0
-        );
+        writer.execute_batch("ROLLBACK").unwrap();
     }
 }

--- a/src-tauri/src/db_core/import.rs
+++ b/src-tauri/src/db_core/import.rs
@@ -36,6 +36,21 @@ pub fn sync_file(
     file_path: &Path,
     app_data_dir: &Path,
 ) -> Result<SyncOutcome, String> {
+    sync_file_cancellable(db, file_path, app_data_dir, &|| false)
+}
+
+pub fn sync_file_cancellable<C>(
+    db: &Database,
+    file_path: &Path,
+    app_data_dir: &Path,
+    should_cancel: &C,
+) -> Result<SyncOutcome, String>
+where
+    C: Fn() -> bool + ?Sized,
+{
+    if should_cancel() {
+        return Err("Import cancelled".to_string());
+    }
     let ext = file_path
         .extension()
         .and_then(|e| e.to_str())
@@ -92,7 +107,7 @@ pub fn sync_file(
             return Ok(SyncOutcome::Restored);
         }
 
-        let hash = hash_file(file_path).map_err(|e| format!("Read error: {}", e))?;
+        let hash = hash_file_cancellable(file_path, should_cancel)?;
 
         if let Some(img) = db.find_by_hash(&hash).map_err(|e| e.to_string())? {
             if img.id == existing_file.image_id {
@@ -105,19 +120,27 @@ pub fn sync_file(
             }
             if can_decode {
                 let _ = db.repoint_image_file(&existing_file.id, &img.id, file_size, &mtime);
+                if should_cancel() {
+                    return Ok(SyncOutcome::ContentChanged { image_id: img.id });
+                }
                 match crate::db_core::image_decode::decode_image(file_path, module_raw) {
                     Ok(decoded) => {
-                        let _ = thumbnails::generate_thumbnail_from_image(
-                            &decoded.image,
-                            app_data_dir,
-                            &img.id,
-                        );
+                        if !should_cancel() {
+                            let _ = thumbnails::generate_thumbnail_from_image(
+                                &decoded.image,
+                                app_data_dir,
+                                &img.id,
+                            );
+                        }
                     }
                     Err(e) => {
                         crate::safe_eprintln!("Thumbnail decode failed for {}: {}", path_str, e)
                     }
                 }
             } else if is_document {
+                if should_cancel() {
+                    return Ok(SyncOutcome::ContentChanged { image_id: img.id });
+                }
                 validate_pdf_import(file_path)?;
                 let _ = db.repoint_image_file(&existing_file.id, &img.id, file_size, &mtime);
                 let _ = thumbnails::generate_document_thumbnail(file_path, app_data_dir, &img.id);
@@ -127,32 +150,27 @@ pub fn sync_file(
         }
 
         // New content: only now read the bytes (source detection / decode need them).
-        let data = fs::read(file_path).map_err(|e| format!("Read error: {}", e))?;
-        let (image_id, decoded) =
-            create_image_record(db, file_path, &hash, &ext, &data, can_decode, module_raw)?;
+        let data = read_file_cancellable(file_path, should_cancel)?;
+        let (image_id, decoded) = create_image_record(
+            db,
+            file_path,
+            &hash,
+            &ext,
+            &data,
+            can_decode,
+            module_raw,
+            should_cancel,
+        )?;
         let _ = db.repoint_image_file(&existing_file.id, &image_id, file_size, &mtime);
         if can_decode {
-            let decoded_dims = decoded
-                .as_ref()
-                .map(|d| (d.image.width(), d.image.height()));
-            if let Some(decoded) = &decoded {
-                let _ = thumbnails::generate_thumbnail_from_image(
-                    &decoded.image,
-                    app_data_dir,
-                    &image_id,
-                );
-                if let Some(metadata) = &decoded.raw_metadata {
-                    if let Ok(meta_json) = serde_json::to_string(metadata) {
-                        let _ = db.update_raw_metadata(&image_id, &meta_json);
-                    }
-                }
-            } else {
-                let _ = thumbnails::generate_thumbnail(file_path, app_data_dir, &image_id);
-            }
-            run_source_detection(db, file_path, &image_id, &ext, decoded_dims);
-            run_sidecar_detection(db, file_path, &image_id);
-            run_perceptual_hash(db, file_path, &image_id, decoded.as_ref().map(|d| &d.image));
-            run_color_metrics(db, file_path, &image_id, decoded.as_ref().map(|d| &d.image));
+            enrich_image(
+                db,
+                file_path,
+                app_data_dir,
+                &image_id,
+                &ext,
+                decoded.as_ref(),
+            );
         } else if is_document {
             validate_pdf_import(file_path)?;
             let _ = thumbnails::generate_document_thumbnail(file_path, app_data_dir, &image_id);
@@ -162,7 +180,7 @@ pub fn sync_file(
     }
 
     // New path
-    let hash = hash_file(file_path).map_err(|e| format!("Read error: {}", e))?;
+    let hash = hash_file_cancellable(file_path, should_cancel)?;
 
     if let Some(existing_img) = db.find_by_hash(&hash).map_err(|e| e.to_string())? {
         let file_record = ImageFile {
@@ -182,13 +200,21 @@ pub fn sync_file(
     }
 
     // New content: only now read the bytes (source detection / decode need them).
-    let data = fs::read(file_path).map_err(|e| format!("Read error: {}", e))?;
+    let data = read_file_cancellable(file_path, should_cancel)?;
     if is_document {
         validate_pdf_import(file_path)?;
     }
 
-    let (image_id, decoded) =
-        create_image_record(db, file_path, &hash, &ext, &data, can_decode, module_raw)?;
+    let (image_id, decoded) = create_image_record(
+        db,
+        file_path,
+        &hash,
+        &ext,
+        &data,
+        can_decode,
+        module_raw,
+        should_cancel,
+    )?;
     let file_record = ImageFile {
         id: Uuid::new_v4().to_string(),
         image_id: image_id.clone(),
@@ -202,24 +228,14 @@ pub fn sync_file(
         .map_err(|e| e.to_string())?;
 
     if can_decode {
-        let decoded_dims = decoded
-            .as_ref()
-            .map(|d| (d.image.width(), d.image.height()));
-        if let Some(decoded) = &decoded {
-            let _ =
-                thumbnails::generate_thumbnail_from_image(&decoded.image, app_data_dir, &image_id);
-            if let Some(metadata) = &decoded.raw_metadata {
-                if let Ok(meta_json) = serde_json::to_string(metadata) {
-                    let _ = db.update_raw_metadata(&image_id, &meta_json);
-                }
-            }
-        } else {
-            let _ = thumbnails::generate_thumbnail(file_path, app_data_dir, &image_id);
-        }
-        run_source_detection(db, file_path, &image_id, &ext, decoded_dims);
-        run_sidecar_detection(db, file_path, &image_id);
-        run_perceptual_hash(db, file_path, &image_id, decoded.as_ref().map(|d| &d.image));
-        run_color_metrics(db, file_path, &image_id, decoded.as_ref().map(|d| &d.image));
+        enrich_image(
+            db,
+            file_path,
+            app_data_dir,
+            &image_id,
+            &ext,
+            decoded.as_ref(),
+        );
         Ok(SyncOutcome::NewImport { image_id })
     } else if is_document {
         let _ = thumbnails::generate_document_thumbnail(file_path, app_data_dir, &image_id);
@@ -316,7 +332,19 @@ pub fn import_file(
     file_path: &Path,
     app_data_dir: &Path,
 ) -> Result<Option<String>, String> {
-    match sync_file(db, file_path, app_data_dir)? {
+    import_file_cancellable(db, file_path, app_data_dir, &|| false)
+}
+
+pub fn import_file_cancellable<C>(
+    db: &Database,
+    file_path: &Path,
+    app_data_dir: &Path,
+    should_cancel: &C,
+) -> Result<Option<String>, String>
+where
+    C: Fn() -> bool + ?Sized,
+{
+    match sync_file_cancellable(db, file_path, app_data_dir, should_cancel)? {
         SyncOutcome::NewImport { image_id } | SyncOutcome::ContentChanged { image_id } => {
             Ok(Some(image_id))
         }
@@ -332,7 +360,11 @@ fn create_image_record(
     data: &[u8],
     can_decode: bool,
     module_raw: bool,
+    should_cancel: &(impl Fn() -> bool + ?Sized),
 ) -> Result<(String, Option<crate::db_core::image_decode::DecodedImage>), String> {
+    if should_cancel() {
+        return Err("Import cancelled".to_string());
+    }
     let decoded = if can_decode {
         Some(crate::db_core::image_decode::decode_image(
             file_path, module_raw,
@@ -340,6 +372,9 @@ fn create_image_record(
     } else {
         None
     };
+    if should_cancel() {
+        return Err("Import cancelled".to_string());
+    }
     let (width, height) = if crate::extensions::is_document_extension(ext) {
         (DOCUMENT_PREVIEW_DIMENSION, DOCUMENT_PREVIEW_DIMENSION)
     } else {
@@ -389,19 +424,98 @@ fn import_size_within_limit(size: u64) -> bool {
 
 /// Stream a file through SHA-256 in fixed-size chunks so the whole file never
 /// needs to live in a single `Vec<u8>` just to compute its content hash.
+#[cfg(test)]
 fn hash_file(path: &Path) -> std::io::Result<String> {
+    hash_file_cancellable(path, &|| false).map_err(std::io::Error::other)
+}
+
+fn hash_file_cancellable(
+    path: &Path,
+    should_cancel: &(impl Fn() -> bool + ?Sized),
+) -> Result<String, String> {
     use std::io::Read;
-    let mut file = fs::File::open(path)?;
+    let mut file = fs::File::open(path).map_err(|error| format!("Read error: {error}"))?;
     let mut hasher = Sha256::new();
     let mut buf = [0u8; 64 * 1024];
     loop {
-        let n = file.read(&mut buf)?;
+        if should_cancel() {
+            return Err("Import cancelled".to_string());
+        }
+        let n = file
+            .read(&mut buf)
+            .map_err(|error| format!("Read error: {error}"))?;
         if n == 0 {
             break;
         }
         hasher.update(&buf[..n]);
     }
     Ok(format!("{:x}", hasher.finalize()))
+}
+
+fn read_file_cancellable(
+    path: &Path,
+    should_cancel: &(impl Fn() -> bool + ?Sized),
+) -> Result<Vec<u8>, String> {
+    use std::io::Read;
+    let mut file = fs::File::open(path).map_err(|error| format!("Read error: {error}"))?;
+    let capacity = file
+        .metadata()
+        .ok()
+        .and_then(|metadata| usize::try_from(metadata.len()).ok())
+        .unwrap_or(0);
+    let mut data = Vec::with_capacity(capacity);
+    let mut buffer = [0u8; 64 * 1024];
+    loop {
+        if should_cancel() {
+            return Err("Import cancelled".to_string());
+        }
+        let read = file
+            .read(&mut buffer)
+            .map_err(|error| format!("Read error: {error}"))?;
+        if read == 0 {
+            return Ok(data);
+        }
+        data.extend_from_slice(&buffer[..read]);
+    }
+}
+
+fn enrich_image(
+    db: &Database,
+    file_path: &Path,
+    app_data_dir: &Path,
+    image_id: &str,
+    ext: &str,
+    decoded: Option<&crate::db_core::image_decode::DecodedImage>,
+) {
+    // Once the image/file rows are committed, finish this image's enrichment as
+    // one logical unit. Cancellation is observed before that commit and again
+    // before the next file, avoiding a permanently half-enriched unchanged row.
+    if let Some(decoded) = decoded {
+        let _ = thumbnails::generate_thumbnail_from_image(&decoded.image, app_data_dir, image_id);
+        if let Some(metadata) = &decoded.raw_metadata {
+            if let Ok(meta_json) = serde_json::to_string(metadata) {
+                let _ = db.update_raw_metadata(image_id, &meta_json);
+            }
+        }
+    } else {
+        let _ = thumbnails::generate_thumbnail(file_path, app_data_dir, image_id);
+    }
+
+    let decoded_dims = decoded.map(|decoded| (decoded.image.width(), decoded.image.height()));
+    run_source_detection(db, file_path, image_id, ext, decoded_dims);
+    run_sidecar_detection(db, file_path, image_id);
+    run_perceptual_hash(
+        db,
+        file_path,
+        image_id,
+        decoded.map(|decoded| &decoded.image),
+    );
+    run_color_metrics(
+        db,
+        file_path,
+        image_id,
+        decoded.map(|decoded| &decoded.image),
+    );
 }
 
 fn run_source_detection(
@@ -517,6 +631,7 @@ mod tests {
     use super::*;
     use rusqlite::params;
     use std::io::Write;
+    use std::sync::atomic::{AtomicUsize, Ordering};
 
     #[test]
     fn raw_module_default_is_enabled() {
@@ -552,6 +667,32 @@ mod tests {
         let path = dir.path().join("empty.bin");
         std::fs::File::create(&path).unwrap();
         assert_eq!(hash_file(&path).unwrap(), compute_hash(&[]));
+    }
+
+    #[test]
+    fn streaming_hash_stops_between_chunks_when_cancelled() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("large.bin");
+        std::fs::write(&path, vec![7_u8; 256 * 1024]).unwrap();
+        let checks = AtomicUsize::new(0);
+
+        let result = hash_file_cancellable(&path, &|| checks.fetch_add(1, Ordering::SeqCst) >= 1);
+
+        assert_eq!(result.unwrap_err(), "Import cancelled");
+        assert_eq!(checks.load(Ordering::SeqCst), 2);
+    }
+
+    #[test]
+    fn buffered_read_stops_between_chunks_when_cancelled() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("large.bin");
+        std::fs::write(&path, vec![9_u8; 256 * 1024]).unwrap();
+        let checks = AtomicUsize::new(0);
+
+        let result = read_file_cancellable(&path, &|| checks.fetch_add(1, Ordering::SeqCst) >= 1);
+
+        assert_eq!(result.unwrap_err(), "Import cancelled");
+        assert_eq!(checks.load(Ordering::SeqCst), 2);
     }
 
     #[test]

--- a/src-tauri/src/db_core/queries/collections.rs
+++ b/src-tauri/src/db_core/queries/collections.rs
@@ -26,7 +26,7 @@ impl Database {
         &self,
         include_rejected: bool,
     ) -> Result<Vec<(String, String, u32)>> {
-        let conn = self.conn.lock();
+        let conn = self.read_connection();
         let sql = format!(
             "SELECT p.id, p.name, COUNT(DISTINCT f.image_id) as cnt
              FROM projects p
@@ -81,7 +81,7 @@ impl Database {
     }
 
     pub fn image_collection_ids(&self, image_id: &str) -> Result<Vec<String>> {
-        let conn = self.conn.lock();
+        let conn = self.read_connection();
         let mut stmt =
             conn.prepare("SELECT collection_id FROM collection_items WHERE image_id = ?1")?;
         let rows = stmt.query_map(params![image_id], |row| row.get::<_, String>(0))?;
@@ -97,7 +97,7 @@ impl Database {
         collection_id: &str,
         include_rejected: bool,
     ) -> Result<Vec<ImageWithFile>> {
-        let conn = self.conn.lock();
+        let conn = self.read_connection();
         let sql = format!(
             "SELECT i.id, i.sha256_hash, i.width, i.height, i.format, i.file_size,
                     i.created_at, i.imported_at, f.path,
@@ -158,7 +158,7 @@ impl Database {
         offset: u32,
         include_rejected: bool,
     ) -> Result<Vec<ImageWithFile>> {
-        let conn = self.conn.lock();
+        let conn = self.read_connection();
         let sql = format!(
             "SELECT i.id, i.sha256_hash, i.width, i.height, i.format, i.file_size,
                     i.created_at, i.imported_at, f.path,
@@ -228,7 +228,7 @@ impl Database {
     }
 
     pub fn get_collection_settings_json(&self, collection_id: &str) -> Result<Option<String>> {
-        let conn = self.conn.lock();
+        let conn = self.read_connection();
         let mut stmt = conn.prepare("SELECT settings_json FROM projects WHERE id = ?1")?;
         let mut rows = stmt.query_map(params![collection_id], |row| row.get(0))?;
         match rows.next() {

--- a/src-tauri/src/db_core/queries/images.rs
+++ b/src-tauri/src/db_core/queries/images.rs
@@ -365,7 +365,7 @@ impl Database {
         offset: u32,
         include_rejected: bool,
     ) -> Result<Vec<ImageWithFile>> {
-        let conn = self.conn.lock();
+        let conn = self.read_connection();
         let sql = format!(
             "SELECT i.id, i.sha256_hash, i.width, i.height, i.format, i.file_size,
                     i.created_at, i.imported_at, f.path,
@@ -460,7 +460,7 @@ impl Database {
         args.push(Value::Integer(limit as i64));
         args.push(Value::Integer(offset as i64));
 
-        let conn = self.conn.lock();
+        let conn = self.read_connection();
         let mut stmt = conn.prepare(&sql)?;
         let rows = stmt.query_map(rusqlite::params_from_iter(args), map_image_with_file_row)?;
         rows.collect::<Result<Vec<_>>>()
@@ -484,7 +484,7 @@ impl Database {
         offset: u32,
         include_rejected: bool,
     ) -> Result<Vec<ImageWithFile>> {
-        let conn = self.conn.lock();
+        let conn = self.read_connection();
         let mut sql = String::from(
             "SELECT i.id, i.sha256_hash, i.width, i.height, i.format, i.file_size,
                     i.created_at, i.imported_at, f.path,
@@ -552,7 +552,7 @@ impl Database {
         // The CASE matches std::path::Path::parent exactly: a path with no '/'
         // has no parent (excluded, like `None`); a root-level file ("/x.png")
         // whose stripped prefix is empty maps to "/".
-        let conn = self.conn.lock();
+        let conn = self.read_connection();
         let sql = format!(
             "SELECT folder, COUNT(*) AS cnt
              FROM (
@@ -594,7 +594,7 @@ impl Database {
         offset: u32,
         include_rejected: bool,
     ) -> Result<Vec<ImageWithFile>> {
-        let conn = self.conn.lock();
+        let conn = self.read_connection();
         // Prefix-match on substr rather than LIKE: `_` and `%` are wildcards in
         // LIKE, so a folder named `2025_Trips` would also pull in `2025XTrips`.
         // This mirrors delete_images_by_folder, which avoids LIKE for the same
@@ -650,7 +650,7 @@ impl Database {
     }
 
     pub fn image_count_with_visibility(&self, include_rejected: bool) -> Result<u32> {
-        let conn = self.conn.lock();
+        let conn = self.read_connection();
         let sql = format!(
             "SELECT COUNT(DISTINCT i.id) FROM images i
              JOIN image_files f ON f.image_id = i.id AND f.missing_at IS NULL
@@ -662,7 +662,7 @@ impl Database {
     }
 
     pub fn list_image_ids(&self) -> Result<Vec<String>> {
-        let conn = self.conn.lock();
+        let conn = self.read_connection();
         let mut stmt = conn.prepare(
             "SELECT DISTINCT i.id
              FROM images i
@@ -677,7 +677,7 @@ impl Database {
         if ids.is_empty() {
             return Ok(vec![]);
         }
-        let conn = self.conn.lock();
+        let conn = self.read_connection();
         let placeholders: Vec<String> = ids
             .iter()
             .enumerate()

--- a/src-tauri/src/db_core/queries/smart_collections.rs
+++ b/src-tauri/src/db_core/queries/smart_collections.rs
@@ -33,7 +33,7 @@ impl Database {
         &self,
         include_rejected: bool,
     ) -> Result<Vec<SmartCollection>> {
-        let conn = self.conn.lock();
+        let conn = self.read_connection();
         let mut stmt = conn.prepare(
             "SELECT id, name, description, collection_type, filter_json, nl_query,
                     is_preset, sort_order, created_at
@@ -140,7 +140,7 @@ impl Database {
 
         let visibility =
             RejectedVisibility::from_include_rejected(include_rejected).for_filter(&filter);
-        let conn = self.conn.lock();
+        let conn = self.read_connection();
         let sql = format!(
             "SELECT COUNT(DISTINCT i.id)
              FROM images i
@@ -186,7 +186,7 @@ impl Database {
 
         let visibility =
             RejectedVisibility::from_include_rejected(include_rejected).for_filter(&filter);
-        let conn = self.conn.lock();
+        let conn = self.read_connection();
         let mut sql = format!(
             "SELECT i.id, i.sha256_hash, i.width, i.height, i.format, i.file_size,
                     i.created_at, i.imported_at, f.path,

--- a/src-tauri/src/services/jobs.rs
+++ b/src-tauri/src/services/jobs.rs
@@ -78,6 +78,14 @@ impl JobRegistry {
         }
     }
 
+    pub fn update_total(&self, job_id: &str, total: u32) {
+        let mut jobs = self.jobs.lock().unwrap();
+        if let Some(state) = jobs.get_mut(job_id) {
+            state.snapshot.total = total;
+            state.snapshot.updated_at = chrono::Utc::now().to_rfc3339();
+        }
+    }
+
     pub fn complete(&self, job_id: &str) {
         let mut jobs = self.jobs.lock().unwrap();
         if let Some(state) = jobs.get_mut(job_id) {
@@ -189,12 +197,18 @@ impl JobRegistry {
     }
 
     pub fn persist_terminal(&self, job_id: &str, db: &crate::db_core::db::Database) {
-        let jobs = self.jobs.lock().unwrap();
-        if let Some(state) = jobs.get(job_id) {
-            let status = &state.snapshot.status;
-            if matches!(status.as_str(), "completed" | "failed" | "cancelled") {
-                let _ = db.save_job(&state.snapshot);
-            }
+        let snapshot = {
+            let jobs = self.jobs.lock().unwrap();
+            jobs.get(job_id).and_then(|state| {
+                matches!(
+                    state.snapshot.status.as_str(),
+                    "completed" | "failed" | "cancelled"
+                )
+                .then(|| state.snapshot.clone())
+            })
+        };
+        if let Some(snapshot) = snapshot {
+            let _ = db.save_job(&snapshot);
         }
     }
 
@@ -287,6 +301,55 @@ mod tests {
         let snapshot = registry.get(&job_id).unwrap();
         assert_eq!(snapshot.current, 42);
         assert_eq!(snapshot.message.as_deref(), Some("Processing image_abc"));
+    }
+
+    #[test]
+    fn test_update_total_after_background_discovery() {
+        let registry = JobRegistry::default();
+        let (job_id, _) = registry.create_job("import", 0);
+
+        registry.update_total(&job_id, 10_000);
+
+        let snapshot = registry.get(&job_id).unwrap();
+        assert_eq!(snapshot.total, 10_000);
+        assert_eq!(snapshot.status, "running");
+    }
+
+    #[test]
+    fn terminal_persistence_does_not_hold_the_registry_lock_during_database_io() {
+        use std::sync::mpsc;
+        use std::time::Duration;
+
+        let db = test_db();
+        let registry = JobRegistry::default();
+        let (job_id, _) = registry.create_job("import", 1);
+        registry.complete(&job_id);
+
+        let writer = db.conn.lock();
+        writer.execute_batch("BEGIN IMMEDIATE").unwrap();
+
+        let persist_registry = registry.clone();
+        let persist_db = db.clone();
+        let persist_job_id = job_id.clone();
+        let (started_tx, started_rx) = mpsc::channel();
+        let persist = std::thread::spawn(move || {
+            started_tx.send(()).unwrap();
+            persist_registry.persist_terminal(&persist_job_id, &persist_db);
+        });
+        started_rx.recv().unwrap();
+        std::thread::sleep(Duration::from_millis(20));
+
+        let list_registry = registry.clone();
+        let (list_tx, list_rx) = mpsc::channel();
+        std::thread::spawn(move || list_tx.send(list_registry.list()).unwrap());
+        let snapshots = list_rx
+            .recv_timeout(Duration::from_millis(250))
+            .expect("list_jobs must not wait for terminal job persistence");
+        assert_eq!(snapshots.len(), 1);
+
+        writer.execute_batch("ROLLBACK").unwrap();
+        drop(writer);
+        persist.join().unwrap();
     }
 
     #[test]

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -183,6 +183,7 @@ export interface ImportResponse {
     errors: string[];
     batch_id: string | null;
     image_ids: string[];
+    cancelled: boolean;
 }
 
 export interface GenerationRun {
@@ -616,14 +617,14 @@ export async function listImageIds(): Promise<string[]> {
     return invoke<string[]>('list_image_ids');
 }
 
-export async function importFolder(folderPath: string, sessionId?: string | null): Promise<ImportResponse> {
-    const result = await invoke<ImportResponse>('import_folder', { folderPath, sessionId: sessionId ?? null });
+export async function importFolder(folderPath: string, sessionId?: string | null, progressId?: string | null): Promise<ImportResponse> {
+    const result = await invoke<ImportResponse>('import_folder', { folderPath, sessionId: sessionId ?? null, progressId: progressId ?? null });
     emitSessionEventsRefresh();
     return result;
 }
 
-export async function importFiles(filePaths: string[], sessionId?: string | null): Promise<ImportResponse> {
-    const result = await invoke<ImportResponse>('import_files', { filePaths, sessionId: sessionId ?? null });
+export async function importFiles(filePaths: string[], sessionId?: string | null, progressId?: string | null): Promise<ImportResponse> {
+    const result = await invoke<ImportResponse>('import_files', { filePaths, sessionId: sessionId ?? null, progressId: progressId ?? null });
     emitSessionEventsRefresh();
     return result;
 }

--- a/src/lib/components/JobProgressPanel.svelte
+++ b/src/lib/components/JobProgressPanel.svelte
@@ -95,19 +95,15 @@
                 upsertDownload('evt_nudenet_download', 'nudenet-download', e.payload.downloaded, e.payload.total, e.payload.status);
             });
             const u13 = await listen<any>('auto-detection-start', (e) => {
-                const model = e.payload.model ?? 'model';
-                upsertJob(`evt_auto_detection_${model}`, 'auto-detection', 'running', 0, e.payload.count ?? 0, model);
+                upsertJob(e.payload.job_id, 'detection', 'running', e.payload.current ?? 0, e.payload.total ?? 0, e.payload.model ?? 'model');
             });
             const u14 = await listen<any>('auto-detection-progress', (e) => {
-                const model = e.payload.model ?? 'model';
-                upsertJob(`evt_auto_detection_${model}`, 'auto-detection', 'running', e.payload.current, e.payload.total, model);
+                upsertJob(e.payload.job_id, 'detection', 'running', e.payload.current, e.payload.total, e.payload.model ?? 'model');
             });
             const u15 = await listen<any>('auto-detection-complete', (e) => {
-                const count = e.payload.count ?? 0;
-                for (const job of jobs.filter(j => j.kind === 'auto-detection' && j.status === 'running')) {
-                    upsertJob(job.job_id, job.kind, 'completed', job.total || count, job.total || count, job.message);
-                    scheduleFadeOut(job.job_id);
-                }
+                const status = e.payload.cancelled ? 'cancelled' : 'completed';
+                upsertJob(e.payload.job_id, 'detection', status, e.payload.current ?? e.payload.total ?? 0, e.payload.total ?? 0, null);
+                scheduleFadeOut(e.payload.job_id);
             });
             const u16 = await listen<any>('health-check-progress', (e) => {
                 upsertJob(e.payload.job_id ?? `evt_health_check`, 'health-check', 'running', e.payload.current, e.payload.total, null);

--- a/src/lib/components/Sidebar.svelte
+++ b/src/lib/components/Sidebar.svelte
@@ -725,15 +725,17 @@
         if (!selected) return;
 
         importing = true;
+        const progressId = crypto.randomUUID();
         importCurrent = 0;
         importTotal = 0;
         setLastResult('');
 
         // Listen for progress events
         let lastRefresh = 0;
-        const unlisten: UnlistenFn = await listen<{ current: number; total: number; filename: string }>(
+        const unlisten: UnlistenFn = await listen<{ progress_id?: string; current: number; total: number; filename: string }>(
             'import-progress',
             async (event) => {
+                if (event.payload.progress_id !== progressId) return;
                 importCurrent = event.payload.current;
                 importTotal = event.payload.total;
 
@@ -747,11 +749,17 @@
         );
 
         try {
-            const result = await apiImportFolder(selected as string);
+            const result = await apiImportFolder(selected as string, null, progressId);
             const folderName = (selected as string).split('/').filter(Boolean).pop() ?? selected;
             let summary = `+${result.imported} imported, ${result.skipped} skipped`;
             if (result.errors.length > 0) {
                 summary += `, ${result.errors.length} errors`;
+            }
+            if (result.cancelled) {
+                setLastResult(`Cancelled: ${summary}`);
+                showToast('Import cancelled', { detail: summary, type: 'warning', duration: 8000 });
+                await refreshImages();
+                return;
             }
             setLastResult(summary, result.errors.length > 0 ? 'error' : 'success');
             const importedFolder = selected as string;

--- a/src/lib/components/job-progress-panel-detection.behavior.test.ts
+++ b/src/lib/components/job-progress-panel-detection.behavior.test.ts
@@ -1,0 +1,58 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import '@testing-library/jest-dom/vitest';
+import { cleanup, render, screen, waitFor } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+
+const mocks = vi.hoisted(() => ({
+    cancelJob: vi.fn().mockResolvedValue(undefined),
+    listen: vi.fn(),
+    listJobs: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock('@tauri-apps/api/event', () => ({ listen: mocks.listen }));
+vi.mock('$lib/api', () => ({
+    cancelJob: mocks.cancelJob,
+    listJobs: mocks.listJobs,
+    pauseJob: vi.fn(),
+    resumeJob: vi.fn(),
+}));
+
+import JobProgressPanel from './JobProgressPanel.svelte';
+
+afterEach(() => cleanup());
+beforeEach(() => vi.clearAllMocks());
+
+describe('JobProgressPanel detection jobs', () => {
+    it('keeps both model stages on the real cancellable job row', async () => {
+        const handlers = new Map<string, (event: { payload: Record<string, unknown> }) => void>();
+        mocks.listen.mockImplementation(async (name: string, handler: (event: { payload: Record<string, unknown> }) => void) => {
+            handlers.set(name, handler);
+            return vi.fn();
+        });
+        const user = userEvent.setup();
+        render(JobProgressPanel);
+        await waitFor(() => expect(handlers.has('auto-detection-progress')).toBe(true));
+
+        handlers.get('job-status-changed')?.({
+            payload: { job_id: 'job_detection_real', kind: 'detection', status: 'running', current: 0, total: 20 },
+        });
+        handlers.get('auto-detection-start')?.({
+            payload: { job_id: 'job_detection_real', model: 'yolo11m', current: 0, total: 20 },
+        });
+        handlers.get('auto-detection-progress')?.({
+            payload: { job_id: 'job_detection_real', model: 'yolo11m', current: 10, total: 20 },
+        });
+        handlers.get('auto-detection-start')?.({
+            payload: { job_id: 'job_detection_real', model: 'nudenet', current: 10, total: 20 },
+        });
+        handlers.get('auto-detection-progress')?.({
+            payload: { job_id: 'job_detection_real', model: 'nudenet', current: 11, total: 20 },
+        });
+
+        await waitFor(() => expect(screen.getAllByText('Detection')).toHaveLength(1));
+        expect(screen.getByText(/11\/20/)).toBeInTheDocument();
+        await user.click(screen.getByRole('button', { name: 'Cancel Detection' }));
+        expect(mocks.cancelJob).toHaveBeenCalledWith('job_detection_real');
+    });
+});

--- a/src/lib/components/sidebar-import-progress.behavior.test.ts
+++ b/src/lib/components/sidebar-import-progress.behavior.test.ts
@@ -1,0 +1,102 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import '@testing-library/jest-dom/vitest';
+import { cleanup, render, screen, waitFor } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import { get } from 'svelte/store';
+
+const mocks = vi.hoisted(() => ({
+    open: vi.fn(),
+    importFolder: vi.fn(),
+    listen: vi.fn(),
+}));
+
+vi.mock('@tauri-apps/api/core', () => ({ convertFileSrc: vi.fn((path: string) => path) }));
+vi.mock('@tauri-apps/plugin-dialog', () => ({ open: mocks.open }));
+vi.mock('@tauri-apps/api/event', () => ({ listen: mocks.listen }));
+vi.mock('$lib/image-loading', () => ({ loadImagesForCurrentScope: vi.fn().mockResolvedValue(undefined) }));
+vi.mock('$lib/clipboard-monitor', () => ({ applyClipboardMonitorCollection: vi.fn() }));
+vi.mock('$lib/view-utils', () => ({ safeAssetPreviewPath: vi.fn(() => null) }));
+vi.mock('$lib/api', () => ({
+    countByDetectedClass: vi.fn().mockResolvedValue(0),
+    createCanvas: vi.fn(),
+    createCollection: vi.fn(),
+    createSession: vi.fn(),
+    deleteCollectionApi: vi.fn(),
+    deleteFolder: vi.fn(),
+    getClipboardMonitorStatus: vi.fn().mockResolvedValue(null),
+    getImageCount: vi.fn().mockResolvedValue(0),
+    importFolder: mocks.importFolder,
+    listCanvases: vi.fn().mockResolvedValue([]),
+    listCollections: vi.fn().mockResolvedValue([]),
+    listCollectionImages: vi.fn().mockResolvedValue([]),
+    listDetectedClasses: vi.fn().mockResolvedValue([]),
+    listFolders: vi.fn().mockResolvedValue([]),
+    listSessions: vi.fn().mockResolvedValue([]),
+    listSmartCollections: vi.fn().mockResolvedValue([]),
+    moveClipboardCaptureFolder: vi.fn(),
+    publishClipboardCollection: vi.fn(),
+    regenerateThumbnails: vi.fn(),
+    renameCollectionApi: vi.fn(),
+    renameFolder: vi.fn(),
+    rescanSources: vi.fn(),
+    setClipboardMonitorCaptureExistingOnStart: vi.fn(),
+    startClipboardMonitor: vi.fn(),
+    stopClipboardMonitor: vi.fn(),
+    validateSessionFolder: vi.fn().mockResolvedValue(true),
+}));
+
+import Sidebar from './Sidebar.svelte';
+import { toasts } from '$lib/stores';
+
+afterEach(() => cleanup());
+beforeEach(() => {
+    vi.clearAllMocks();
+    toasts.set([]);
+    vi.stubGlobal('crypto', { randomUUID: () => 'sidebar-import-own' });
+});
+
+describe('Sidebar import progress ownership', () => {
+    it('ignores another import and reports cancellation truthfully', async () => {
+        let progressHandler: ((event: { payload: Record<string, unknown> }) => void) | undefined;
+        mocks.listen.mockImplementation(async (name: string, handler: typeof progressHandler) => {
+            if (name === 'import-progress') progressHandler = handler;
+            return vi.fn();
+        });
+        mocks.open.mockResolvedValue('/photos/current');
+        let resolveImport!: (value: unknown) => void;
+        mocks.importFolder.mockImplementation(
+            () => new Promise(resolve => { resolveImport = resolve; }),
+        );
+
+        const user = userEvent.setup();
+        render(Sidebar);
+        await user.click(await screen.findByRole('button', { name: '+ Import Folder' }));
+        await waitFor(() => expect(mocks.importFolder).toHaveBeenCalledWith(
+            '/photos/current',
+            null,
+            'sidebar-import-own',
+        ));
+
+        progressHandler?.({ payload: { progress_id: 'another-import', current: 9, total: 10 } });
+        expect(screen.getByRole('button', { name: 'Scanning...' })).toBeInTheDocument();
+
+        progressHandler?.({ payload: { progress_id: 'sidebar-import-own', current: 2, total: 10 } });
+        expect(await screen.findByRole('button', { name: 'Importing 2/10...' })).toBeInTheDocument();
+
+        resolveImport({
+            imported: 2,
+            skipped: 0,
+            errors: [],
+            batch_id: 'batch-partial',
+            image_ids: ['one', 'two'],
+            cancelled: true,
+        });
+
+        expect(await screen.findByText('Cancelled: +2 imported, 0 skipped')).toBeInTheDocument();
+        expect(get(toasts).at(-1)).toMatchObject({
+            message: 'Import cancelled',
+            type: 'warning',
+        });
+    });
+});


### PR DESCRIPTION
## Summary
- move import discovery, decode, enrichment, quality analysis, and detection off async command paths
- add cancellable import jobs with truthful per-import progress and cancellation outcomes
- add a query-only WAL reader for library, folder, collection, smart-collection, scoped, and ID browse reads
- keep registry access responsive during terminal persistence and reconcile detection progress onto its real cancellable job

## Safety and audit behavior
- cancellation is checked during discovery, streaming hash/read, before commit, and between files
- once an image is committed, its enrichment finishes as one logical unit to avoid permanent partial records
- cancelled partial imports are recorded as `import_cancelled`, not completed
- fallible child-job preparation completes before the import outcome is sealed and audited

## Verification
- `npm run preflight -- full`
- `npm run build`
- 1,232 frontend tests passed
- 805 Rust tests passed, 3 ignored
- independent spec review: PASS
- independent standards/correctness review: PASS

Closes imageview-dtj.4