### PR TITLE
feat: add scoped embedding nearest neighbors

### DIFF
--- a/src-tauri/permissions/app-ai-processing.toml
+++ b/src-tauri/permissions/app-ai-processing.toml
@@ -21,6 +21,7 @@ commands.allow = [
   "estimate_generation_cost",
   "find_near_duplicates_by_phash",
   "find_similar_images",
+  "find_similar_images_in_scope",
   "generate_embeddings",
   "generate_gemini_embeddings",
   "generate_model_embeddings",

--- a/src-tauri/src/commands/embeddings.rs
+++ b/src-tauri/src/commands/embeddings.rs
@@ -428,6 +428,25 @@ pub async fn find_similar_images(
 }
 
 #[tauri::command]
+pub async fn find_similar_images_in_scope(
+    state: State<'_, AppState>,
+    scope: crate::db_core::models::EmbeddingScope,
+    image_id: String,
+    top_k: u32,
+    model: Option<String>,
+) -> Result<Vec<(String, f32)>, String> {
+    let ctx = crate::services::ServiceContext::from_app_state(&state, None);
+    crate::services::ai::find_similar_images_in_scope(
+        &ctx,
+        &scope,
+        &image_id,
+        top_k as usize,
+        model.as_deref(),
+    )
+    .map_err(|e| e.to_string())
+}
+
+#[tauri::command]
 pub async fn generate_similarity_groups(
     state: State<'_, AppState>,
     model: Option<String>,

--- a/src-tauri/src/db_core/queries/embeddings.rs
+++ b/src-tauri/src/db_core/queries/embeddings.rs
@@ -384,6 +384,81 @@ impl Database {
         Ok(scores)
     }
 
+    /// Finds nearest neighbors among the live images admitted by `scope`.
+    /// The scope is applied in SQL before vector decoding and scoring, and
+    /// the source image is always excluded from the candidate set.
+    pub fn find_similar_in_scope(
+        &self,
+        image_id: &str,
+        model_name: &str,
+        scope: &EmbeddingScope,
+        top_k: usize,
+    ) -> Result<Option<Vec<(String, f32)>>> {
+        let (scope_clause, scope_params, visibility) = scoped_where_clause(scope)?;
+        let (source_bytes, raw_candidates): (Option<Vec<u8>>, Vec<(String, Vec<u8>)>) = {
+            let mut conn = self.read_connection();
+            let transaction = conn.transaction()?;
+            let source_bytes = transaction
+                .query_row(
+                    "SELECT vector FROM embeddings WHERE image_id = ?1 AND model_name = ?2",
+                    params![image_id, model_name],
+                    |row| row.get(0),
+                )
+                .optional()?;
+
+            let candidate_sql = format!(
+                "SELECT DISTINCT e.image_id, e.vector
+                 FROM embeddings e
+                 JOIN images i ON i.id = e.image_id
+                 JOIN image_files f ON f.image_id = i.id AND f.missing_at IS NULL
+                 LEFT JOIN selections s ON s.image_id = i.id AND s.project_id = '__global__'
+                 LEFT JOIN image_quality_metrics qm ON qm.image_id = i.id
+                 LEFT JOIN image_color_metrics cm ON cm.image_id = i.id
+                 LEFT JOIN image_similarity_group_items sgi ON sgi.image_id = i.id
+                 WHERE e.model_name = ? AND e.image_id != ?
+                   AND ({scope_clause}) AND {}",
+                visibility.sql_predicate()
+            );
+            let mut candidate_params = vec![
+                Value::Text(model_name.to_string()),
+                Value::Text(image_id.to_string()),
+            ];
+            candidate_params.extend(scope_params);
+            let raw_candidates = {
+                let mut stmt = transaction.prepare(&candidate_sql)?;
+                let rows = stmt.query_map(to_param_refs(&candidate_params).as_slice(), |row| {
+                    Ok((row.get::<_, String>(0)?, row.get::<_, Vec<u8>>(1)?))
+                })?;
+                rows.collect::<Result<Vec<_>>>()?
+            };
+            transaction.commit()?;
+            (source_bytes, raw_candidates)
+        };
+
+        let Some(source_bytes) = source_bytes else {
+            return Ok(None);
+        };
+        if top_k == 0 {
+            return Ok(Some(Vec::new()));
+        }
+
+        let source = decode_embedding_bytes(&source_bytes);
+        let mut scores: Vec<(String, f32)> = raw_candidates
+            .into_iter()
+            .map(|(id, bytes)| {
+                let candidate = decode_embedding_bytes(&bytes);
+                (id, cosine_similarity(&source, &candidate))
+            })
+            .collect();
+        scores.sort_by(|a, b| {
+            b.1.partial_cmp(&a.1)
+                .unwrap_or(std::cmp::Ordering::Equal)
+                .then_with(|| a.0.cmp(&b.0))
+        });
+        scores.truncate(top_k);
+        Ok(Some(scores))
+    }
+
     pub fn embedding_count(&self, model_name: &str) -> Result<u32> {
         let conn = self.conn.lock();
         conn.query_row(
@@ -519,6 +594,37 @@ mod tests {
         db.store_embedding("img1", "model-a", &[1.0, 0.0]).unwrap();
         let result = db.find_similar(&[1.0, 0.0], "model-b", 10).unwrap();
         assert!(result.is_empty());
+    }
+
+    #[test]
+    fn scoped_neighbors_filter_candidates_before_scoring_and_exclude_source() {
+        let db = open_test_db();
+        for (id, path, vector) in [
+            ("source", "/selected/source.png", vec![1.0, 0.0]),
+            ("in-close", "/selected/close.png", vec![0.8, 0.6]),
+            ("in-far", "/selected/far.png", vec![0.0, 1.0]),
+            ("outside-closest", "/other/closest.png", vec![0.999, 0.001]),
+        ] {
+            insert_scoped_image(&db, id, path, 500, 500, None);
+            db.store_embedding(id, "model", &vector).unwrap();
+        }
+        let scope = EmbeddingScope::Folder {
+            path: "/selected".to_string(),
+            min_size: 0,
+            include_rejected: false,
+        };
+
+        let neighbors = db
+            .find_similar_in_scope("source", "model", &scope, 2)
+            .unwrap()
+            .expect("source embedding exists");
+
+        assert_eq!(neighbors.len(), 2);
+        assert_eq!(neighbors[0].0, "in-close");
+        assert!((neighbors[0].1 - 0.8).abs() < 0.000_001);
+        assert_eq!(neighbors[1], ("in-far".to_string(), 0.0));
+        assert!(neighbors.iter().all(|(id, _)| id != "source"));
+        assert!(neighbors.iter().all(|(id, _)| id != "outside-closest"));
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -243,6 +243,20 @@ mod gui_launch_tests {
             vec![image.to_string_lossy()]
         );
     }
+
+    #[test]
+    fn scoped_neighbor_command_is_registered_and_permitted() {
+        let command_registry = include_str!("lib.rs");
+        let ai_permissions = include_str!("../permissions/app-ai-processing.toml");
+        let command_name = concat!("find_similar_images", "_in_scope");
+        let registry_entry = format!("commands::embeddings::{command_name},");
+        let permission_entry = format!("\"{command_name}\",");
+
+        assert!(command_registry.contains(&registry_entry));
+        assert!(ai_permissions
+            .lines()
+            .any(|line| line.trim() == permission_entry));
+    }
 }
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
@@ -571,6 +585,7 @@ pub fn run() {
             commands::embeddings::get_scoped_embedding_page,
             commands::embeddings::list_scoped_image_ids,
             commands::embeddings::find_similar_images,
+            commands::embeddings::find_similar_images_in_scope,
             commands::embeddings::generate_similarity_groups,
             commands::embeddings::list_similarity_groups,
             commands::embeddings::list_similarity_group_images,

--- a/src-tauri/src/services/ai.rs
+++ b/src-tauri/src/services/ai.rs
@@ -12,6 +12,7 @@ use crate::services::{Pagination, ServiceContext, ServiceError};
 use std::collections::HashSet;
 
 const MAX_EMBEDDING_PAGE_SIZE: u32 = 5000;
+const MAX_SIMILAR_IMAGES: usize = 250;
 const SIMILARITY_GROUPING_METHOD: &str = "greedy_threshold_v1";
 
 /// Upper bound on the number of embeddings `generate_similarity_groups` will
@@ -35,6 +36,20 @@ pub fn find_similar_images(
         .get_embedding_vector(image_id, model_name)?
         .ok_or_else(|| ServiceError::NotFound("Image has no embedding".into()))?;
     Ok(ctx.db.find_similar(&query, model_name, top_k)?)
+}
+
+pub fn find_similar_images_in_scope(
+    ctx: &ServiceContext,
+    scope: &EmbeddingScope,
+    image_id: &str,
+    top_k: usize,
+    model: Option<&str>,
+) -> Result<Vec<(String, f32)>, ServiceError> {
+    let model_name = model.unwrap_or("clip-vit-b32");
+    let top_k = top_k.clamp(1, MAX_SIMILAR_IMAGES);
+    ctx.db
+        .find_similar_in_scope(image_id, model_name, scope, top_k)?
+        .ok_or_else(|| ServiceError::NotFound("Image has no embedding".into()))
 }
 
 pub fn get_all_embeddings(
@@ -607,6 +622,31 @@ mod tests {
             ServiceError::NotFound(msg) => assert!(msg.contains("no embedding")),
             other => panic!("Expected NotFound, got {:?}", other),
         }
+    }
+
+    #[test]
+    fn scoped_neighbor_service_clamps_top_k_to_standard_page_bounds() {
+        let (db, s, d, ee, de, se, _tmp) = make_ctx_parts();
+        insert_test_image(&db, "source");
+        db.store_embedding("source", "clip-vit-b32", &[1.0, 0.0])
+            .unwrap();
+        for index in 0..251 {
+            let id = format!("candidate-{index:03}");
+            insert_test_image(&db, &id);
+            db.store_embedding(&id, "clip-vit-b32", &[1.0, index as f32 / 1_000.0])
+                .unwrap();
+        }
+        let c = ctx(&db, &s, &d, &ee, &de, &se);
+        let scope = EmbeddingScope::All {
+            include_rejected: false,
+        };
+
+        let minimum = find_similar_images_in_scope(&c, &scope, "source", 0, None).unwrap();
+        let maximum = find_similar_images_in_scope(&c, &scope, "source", usize::MAX, None).unwrap();
+
+        assert_eq!(minimum.len(), 1);
+        assert_eq!(maximum.len(), 250);
+        assert!(maximum.iter().all(|(id, _)| id != "source"));
     }
 
     #[test]

--- a/src-tauri/src/services/ai.rs
+++ b/src-tauri/src/services/ai.rs
@@ -12,7 +12,7 @@ use crate::services::{Pagination, ServiceContext, ServiceError};
 use std::collections::HashSet;
 
 const MAX_EMBEDDING_PAGE_SIZE: u32 = 5000;
-const MAX_SIMILAR_IMAGES: usize = 250;
+const MAX_SIMILAR_IMAGES: usize = 100;
 const SIMILARITY_GROUPING_METHOD: &str = "greedy_threshold_v1";
 
 /// Upper bound on the number of embeddings `generate_similarity_groups` will
@@ -46,7 +46,7 @@ pub fn find_similar_images_in_scope(
     model: Option<&str>,
 ) -> Result<Vec<(String, f32)>, ServiceError> {
     let model_name = model.unwrap_or("clip-vit-b32");
-    let top_k = top_k.clamp(1, MAX_SIMILAR_IMAGES);
+    let top_k = top_k.min(MAX_SIMILAR_IMAGES);
     ctx.db
         .find_similar_in_scope(image_id, model_name, scope, top_k)?
         .ok_or_else(|| ServiceError::NotFound("Image has no embedding".into()))
@@ -630,7 +630,7 @@ mod tests {
         insert_test_image(&db, "source");
         db.store_embedding("source", "clip-vit-b32", &[1.0, 0.0])
             .unwrap();
-        for index in 0..251 {
+        for index in 0..101 {
             let id = format!("candidate-{index:03}");
             insert_test_image(&db, &id);
             db.store_embedding(&id, "clip-vit-b32", &[1.0, index as f32 / 1_000.0])
@@ -644,8 +644,8 @@ mod tests {
         let minimum = find_similar_images_in_scope(&c, &scope, "source", 0, None).unwrap();
         let maximum = find_similar_images_in_scope(&c, &scope, "source", usize::MAX, None).unwrap();
 
-        assert_eq!(minimum.len(), 1);
-        assert_eq!(maximum.len(), 250);
+        assert!(minimum.is_empty());
+        assert_eq!(maximum.len(), 100);
         assert!(maximum.iter().all(|(id, _)| id != "source"));
     }
 

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1080,6 +1080,20 @@ export async function findSimilarImages(imageId: string, topK: number, model?: s
     return invoke('find_similar_images', { imageId, topK, model: model ?? null });
 }
 
+export async function findSimilarImagesInScope(
+    scope: LibraryScope,
+    imageId: string,
+    topK: number,
+    model?: string,
+): Promise<[string, number][]> {
+    return invoke('find_similar_images_in_scope', {
+        scope,
+        imageId,
+        topK,
+        model: model ?? null,
+    });
+}
+
 export async function generateSimilarityGroups(
     model?: string,
     threshold = 0.88,

--- a/src/lib/components/EmbeddingExplorer.svelte
+++ b/src/lib/components/EmbeddingExplorer.svelte
@@ -48,6 +48,7 @@
         getImageCountForScope,
         listImageIdsForScope,
     } from '$lib/embedding-scope';
+    import { loadEmbeddingNeighbors, type EmbeddingNeighbor } from '$lib/embedding-neighbors';
 
     // State
     let downloading = $state(false);
@@ -192,6 +193,10 @@
     let imageMap = $state<Map<string, ImageWithFile>>(new Map());
     let selectedGenerationRun = $state<GenerationRun | null>(null);
     let selectedGenerationLoadSeq = 0;
+    let nearestNeighbors = $state<EmbeddingNeighbor[]>([]);
+    let neighborsLoading = $state(false);
+    let neighborsError = $state<string | null>(null);
+    let neighborLoadSeq = 0;
     let projecting = $state(false);
     let projectionWorker: Worker | null = null;
     let cancelProjectionWork: (() => void) | null = null;
@@ -257,6 +262,39 @@
             })
             .catch(() => {
                 if (loadSeq === selectedGenerationLoadSeq) selectedGenerationRun = null;
+            });
+    });
+
+    $effect(() => {
+        const id = selectedPoint?.id ?? null;
+        const scope = $libraryScope;
+        const requestedScopeKey = libraryScopeKey(scope);
+        const model = modelNameForProvider(selectedProvider);
+        const loadSeq = ++neighborLoadSeq;
+        nearestNeighbors = [];
+        neighborsError = null;
+        if (!id) {
+            neighborsLoading = false;
+            return;
+        }
+
+        neighborsLoading = true;
+        loadEmbeddingNeighbors(scope, id, model, 6)
+            .then(neighbors => {
+                if (loadSeq !== neighborLoadSeq) return;
+                if (selectedPoint?.id !== id) return;
+                if (libraryScopeKey(get(libraryScope)) !== requestedScopeKey) return;
+                if (modelNameForProvider(selectedProvider) !== model) return;
+                nearestNeighbors = neighbors;
+                neighborsLoading = false;
+            })
+            .catch(error => {
+                if (loadSeq !== neighborLoadSeq) return;
+                if (selectedPoint?.id !== id) return;
+                if (libraryScopeKey(get(libraryScope)) !== requestedScopeKey) return;
+                if (modelNameForProvider(selectedProvider) !== model) return;
+                neighborsError = error instanceof Error ? error.message : String(error);
+                neighborsLoading = false;
             });
     });
 
@@ -1031,6 +1069,16 @@
         const startIndex = currentIndex >= 0 ? currentIndex : (delta > 0 ? -1 : 0);
         const nextIndex = (startIndex + delta + navigationPoints.length) % navigationPoints.length;
         selectPoint(navigationPoints[nextIndex], interactionMode !== 'map' || largePreviewOpen);
+    }
+
+    function openNeighbor(neighbor: EmbeddingNeighbor) {
+        const point = points.find(candidate => candidate.id === neighbor.image.image.id);
+        if (point) {
+            selectPoint(point, true);
+            return;
+        }
+        focusedImageOverride.set(neighbor.image);
+        navigateTo('loupe');
     }
 
     function fitPointSet(viewPoints: Point[], padding: number) {
@@ -2128,6 +2176,43 @@
                     </button>
                 {/if}
             </div>
+            <div class="panel-section">
+                <div class="section-header">NEAREST</div>
+                {#if neighborsLoading}
+                    <div class="neighbor-status" role="status" aria-live="polite">Finding similar images...</div>
+                {:else if neighborsError}
+                    <div class="neighbor-status error" role="status" aria-live="polite">Could not load similar images</div>
+                {:else if nearestNeighbors.length === 0}
+                    <div class="neighbor-status" role="status" aria-live="polite">No similar images in this scope</div>
+                {:else}
+                    <div class="sr-only" role="status" aria-live="polite">
+                        {nearestNeighbors.length} similar {nearestNeighbors.length === 1 ? 'image' : 'images'} found
+                    </div>
+                    <div class="neighbor-list">
+                        {#each nearestNeighbors as neighbor (neighbor.image.image.id)}
+                            {@const previewPath = safeAssetPreviewPath(neighbor.image)}
+                            {@const projectedPoint = points.find(point => point.id === neighbor.image.image.id)}
+                            {@const filename = neighbor.image.path.split('/').pop()}
+                            {@const score = `${(neighbor.score * 100).toFixed(1)}%`}
+                            <button
+                                class="neighbor-row"
+                                onclick={() => openNeighbor(neighbor)}
+                                aria-label={projectedPoint
+                                    ? `Select ${filename}, similarity ${score}`
+                                    : `Open ${filename} in Loupe, similarity ${score}`}
+                            >
+                                {#if previewPath}
+                                    <img src={convertFileSrc(previewPath)} alt="" class="neighbor-thumb" />
+                                {:else}
+                                    <span class="neighbor-thumb unavailable" aria-hidden="true"></span>
+                                {/if}
+                                <span class="neighbor-name">{filename}</span>
+                                <span class="neighbor-score">{score}</span>
+                            </button>
+                        {/each}
+                    </div>
+                {/if}
+            </div>
         {/if}
     </div>
     {/if}
@@ -2683,6 +2768,80 @@
     .preview-dims {
         font-size: 10px;
         color: var(--text-secondary);
+    }
+
+    .neighbor-list {
+        display: grid;
+        gap: var(--spacing);
+    }
+
+    .neighbor-row {
+        display: grid;
+        grid-template-columns: 36px minmax(0, 1fr) auto;
+        align-items: center;
+        gap: var(--spacing);
+        width: 100%;
+        padding: var(--spacing);
+        background: var(--bg);
+        color: var(--text);
+        border: 1px solid var(--border);
+        border-radius: var(--radius);
+        font-family: var(--font);
+        cursor: pointer;
+        text-align: left;
+    }
+
+    .neighbor-row:hover,
+    .neighbor-row:focus-visible {
+        border-color: var(--blue);
+    }
+
+    .neighbor-thumb {
+        width: 36px;
+        height: 36px;
+        object-fit: cover;
+        border-radius: var(--radius);
+        background: var(--surface);
+    }
+
+    .neighbor-thumb.unavailable {
+        border: 1px solid var(--border);
+    }
+
+    .neighbor-name {
+        min-width: 0;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        font-size: 10px;
+    }
+
+    .neighbor-score {
+        color: var(--blue);
+        font-size: 10px;
+        font-variant-numeric: tabular-nums;
+    }
+
+    .neighbor-status {
+        color: var(--text-secondary);
+        font-size: 10px;
+        line-height: 1.4;
+    }
+
+    .neighbor-status.error {
+        color: var(--red);
+    }
+
+    .sr-only {
+        position: absolute;
+        width: 1px;
+        height: 1px;
+        padding: 0;
+        margin: -1px;
+        overflow: hidden;
+        clip: rect(0, 0, 0, 0);
+        white-space: nowrap;
+        border: 0;
     }
 
     .right-panel {

--- a/src/lib/components/embedding-explorer-scope.behavior.test.ts
+++ b/src/lib/components/embedding-explorer-scope.behavior.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import '@testing-library/jest-dom/vitest';
 import { cleanup, render, screen, waitFor } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
+import { get } from 'svelte/store';
 
 const mocks = vi.hoisted(() => ({
     getEmbeddingCountForScope: vi.fn(),
@@ -11,6 +12,7 @@ const mocks = vi.hoisted(() => ({
     listImageIdsForScope: vi.fn(),
     getImagesByIds: vi.fn(),
     generateModelEmbeddings: vi.fn(),
+    loadEmbeddingNeighbors: vi.fn(),
     workerMessages: [] as Array<Record<string, unknown>>,
 }));
 
@@ -34,6 +36,10 @@ vi.mock('$lib/embedding-scope', () => ({
     getEmbeddingPageForScope: mocks.getEmbeddingPageForScope,
     getImageCountForScope: mocks.getImageCountForScope,
     listImageIdsForScope: mocks.listImageIdsForScope,
+}));
+
+vi.mock('$lib/embedding-neighbors', () => ({
+    loadEmbeddingNeighbors: mocks.loadEmbeddingNeighbors,
 }));
 
 vi.mock('$lib/api', () => ({
@@ -60,6 +66,8 @@ import {
     importBatchFilter,
     minSizeFilter,
     showRejected,
+    focusedImageOverride,
+    viewMode,
 } from '$lib/stores';
 
 class FakeWorker {
@@ -136,6 +144,8 @@ beforeEach(() => {
     importBatchFilter.set(null);
     minSizeFilter.set(512);
     showRejected.set(false);
+    focusedImageOverride.set(null);
+    viewMode.set('grid');
 
     mocks.listImageIdsForScope.mockResolvedValue(['in-a', 'in-b']);
     mocks.getImageCountForScope.mockResolvedValue(2);
@@ -151,6 +161,9 @@ beforeEach(() => {
     });
     mocks.getImagesByIds.mockResolvedValue([image('in-b'), image('in-a')]);
     mocks.generateModelEmbeddings.mockResolvedValue(2);
+    mocks.loadEmbeddingNeighbors.mockResolvedValue([
+        { image: image('near-one'), score: 0.934 },
+    ]);
 
     vi.stubGlobal('Worker', FakeWorker);
     vi.stubGlobal('ResizeObserver', class {
@@ -241,4 +254,35 @@ describe('Embedding Explorer library scope', () => {
             .find(row => row.querySelector('.stat-label')?.textContent === 'Embeddings');
         expect(embeddingRow?.querySelector('.stat-value')).toHaveTextContent('0');
     });
+
+    it('loads ranked neighbors for the selected point in the current scope', async () => {
+        const user = userEvent.setup();
+        render(EmbeddingExplorer);
+        await waitFor(() => expect(mocks.workerMessages).toHaveLength(1));
+
+        const explorer = screen.getByRole('application', { name: 'Visual embeddings' });
+        explorer.focus();
+        await user.keyboard('{ArrowRight}');
+
+        await waitFor(() => expect(mocks.loadEmbeddingNeighbors).toHaveBeenCalledWith(
+            {
+                type: 'folder',
+                path: '/photos/scoped',
+                min_size: 512,
+                include_rejected: false,
+            },
+            'in-a',
+            'clip-vit-b32',
+            6,
+        ));
+        expect(await screen.findByText('near-one.png')).toBeInTheDocument();
+        expect(screen.getByText('93.4%')).toBeInTheDocument();
+
+        await user.click(screen.getByRole('button', {
+            name: 'Open near-one.png in Loupe, similarity 93.4%',
+        }));
+        expect(get(viewMode)).toBe('loupe');
+        expect(get(focusedImageOverride)?.image.id).toBe('near-one');
+    });
+
 });

--- a/src/lib/embedding-neighbors.test.ts
+++ b/src/lib/embedding-neighbors.test.ts
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { LibraryScope } from './library-scope';
+
+const mocks = vi.hoisted(() => ({
+    findSimilarImagesInScope: vi.fn(),
+    getImagesByIds: vi.fn(),
+}));
+
+vi.mock('./api', () => mocks);
+
+import { loadEmbeddingNeighbors } from './embedding-neighbors';
+
+const scope: LibraryScope = {
+    type: 'collection',
+    id: 'collection-1',
+    include_rejected: false,
+};
+
+beforeEach(() => {
+    vi.clearAllMocks();
+});
+
+describe('embedding neighbors', () => {
+    it('keeps similarity scores paired with backend-ranked images', async () => {
+        mocks.findSimilarImagesInScope.mockResolvedValue([
+            ['near-a', 0.982],
+            ['near-b', 0.761],
+        ]);
+        mocks.getImagesByIds.mockResolvedValue([
+            { image: { id: 'near-b' }, path: '/photos/b.png' },
+            { image: { id: 'near-a' }, path: '/photos/a.png' },
+        ]);
+
+        await expect(loadEmbeddingNeighbors(scope, 'source', 'clip-vit-b32', 6))
+            .resolves.toEqual([
+                expect.objectContaining({ score: 0.982, image: expect.objectContaining({ path: '/photos/a.png' }) }),
+                expect.objectContaining({ score: 0.761, image: expect.objectContaining({ path: '/photos/b.png' }) }),
+            ]);
+        expect(mocks.findSimilarImagesInScope).toHaveBeenCalledWith(
+            scope,
+            'source',
+            6,
+            'clip-vit-b32',
+        );
+        expect(mocks.getImagesByIds).toHaveBeenCalledWith(['near-a', 'near-b']);
+    });
+
+    it('drops stale database rows while preserving ranked score identity', async () => {
+        mocks.findSimilarImagesInScope.mockResolvedValue([
+            ['missing', 0.9],
+            ['present', 0.8],
+        ]);
+        mocks.getImagesByIds.mockResolvedValue([
+            { image: { id: 'present' }, path: '/photos/present.png' },
+        ]);
+
+        await expect(loadEmbeddingNeighbors(scope, 'source', 'clip-vit-b32', 6))
+            .resolves.toEqual([
+                expect.objectContaining({ score: 0.8, image: expect.objectContaining({ path: '/photos/present.png' }) }),
+            ]);
+    });
+});

--- a/src/lib/embedding-neighbors.ts
+++ b/src/lib/embedding-neighbors.ts
@@ -1,0 +1,26 @@
+import {
+    findSimilarImagesInScope,
+    getImagesByIds,
+    type ImageWithFile,
+} from './api';
+import type { LibraryScope } from './library-scope';
+
+export interface EmbeddingNeighbor {
+    image: ImageWithFile;
+    score: number;
+}
+
+export async function loadEmbeddingNeighbors(
+    scope: LibraryScope,
+    imageId: string,
+    model: string,
+    limit = 6,
+): Promise<EmbeddingNeighbor[]> {
+    const ranked = await findSimilarImagesInScope(scope, imageId, limit, model);
+    const images = await getImagesByIds(ranked.map(([id]) => id));
+    const byId = new Map(images.map(image => [image.image.id, image]));
+    return ranked.flatMap(([id, score]) => {
+        const image = byId.get(id);
+        return image ? [{ image, score }] : [];
+    });
+}


### PR DESCRIPTION
## Summary
- rank nearest neighbors inside the active Embedding Explorer scope
- show similarity scores when a point is selected
- keep projected neighbors in the explorer and open off-projection results in Loupe
- guard async results across selection, model, and scope changes

## Verification
- `npm run preflight -- full`
- `npm run build`
- Standards review: PASS
- Spec review: PASS

Closes imageview-4kl