### PR TITLE
feat: add selective cancellable embedding regeneration

### DIFF
--- a/src-tauri/permissions/app-ai-processing.toml
+++ b/src-tauri/permissions/app-ai-processing.toml
@@ -25,6 +25,7 @@ commands.allow = [
   "generate_embeddings",
   "generate_gemini_embeddings",
   "generate_model_embeddings",
+  "start_model_embedding_generation",
   "generate_similarity_groups",
   "get_clip_model_download_info",
   "get_color_metrics_count",

--- a/src-tauri/src/cli/tools/embeddings.rs
+++ b/src-tauri/src/cli/tools/embeddings.rs
@@ -108,6 +108,7 @@ pub fn generate_embeddings(ctx: &HeadlessContext, params: Value) -> Result<Value
         jobs: None,
         job_id: None,
         cancel: None,
+        mode: None,
         app: None,
         model_id: &model,
         image_ids: &parsed.image_ids,

--- a/src-tauri/src/commands/embeddings.rs
+++ b/src-tauri/src/commands/embeddings.rs
@@ -423,7 +423,23 @@ pub async fn start_model_embedding_generation(
         .await;
 
         let terminal = embedding_worker_terminal_outcome(result);
+        let worker_error = match &terminal {
+            crate::services::jobs::WorkerTerminalOutcome::Failed(error) => Some(error.clone()),
+            _ => None,
+        };
         state.jobs.finish_from_worker(&task_job_id, terminal);
+        if let Some(error) = worker_error {
+            if let Err(recovery_error) = state
+                .db
+                .fail_running_model_runs_for_job(&task_job_id, &error)
+            {
+                crate::safe_eprintln!(
+                    "Failed to recover model runs for embedding job {}: {}",
+                    task_job_id,
+                    recovery_error
+                );
+            }
+        }
         state.jobs.persist_terminal(&task_job_id, &state.db);
         if let Some(snapshot) = state.jobs.get(&task_job_id) {
             emit_embedding_job_snapshot(&task_app, &snapshot, &task_model, task_mode);

--- a/src-tauri/src/commands/embeddings.rs
+++ b/src-tauri/src/commands/embeddings.rs
@@ -410,20 +410,24 @@ pub async fn start_model_embedding_generation(
             generate_embeddings_for_model(&task_app, &state, &task_model, &targets, Some(control))
                 .await;
 
-        let (status, error) = match result {
-            Ok(outcome) if outcome.cancelled || cancel.is_cancelled() => {
-                state.jobs.mark_cancelled(&task_job_id);
-                ("cancelled", None)
-            }
-            Ok(_) => {
-                state.jobs.complete(&task_job_id);
-                ("completed", None)
-            }
-            Err(error) => {
-                state.jobs.fail(&task_job_id, &error);
-                ("failed", Some(error))
-            }
+        let (terminal, status, error) = match result {
+            Ok(outcome) if outcome.cancelled => (
+                crate::services::jobs::WorkerTerminalOutcome::Cancelled,
+                "cancelled",
+                None,
+            ),
+            Ok(_) => (
+                crate::services::jobs::WorkerTerminalOutcome::Completed,
+                "completed",
+                None,
+            ),
+            Err(error) => (
+                crate::services::jobs::WorkerTerminalOutcome::Failed(error.clone()),
+                "failed",
+                Some(error),
+            ),
         };
+        state.jobs.finish_from_worker(&task_job_id, terminal);
         state.jobs.persist_terminal(&task_job_id, &state.db);
         let snapshot = state.jobs.get(&task_job_id);
         emit_embedding_job_event(

--- a/src-tauri/src/commands/embeddings.rs
+++ b/src-tauri/src/commands/embeddings.rs
@@ -1,7 +1,9 @@
 use crate::db_core::gemini::GeminiEmbeddingProvider;
 use crate::AppState;
+use futures_util::FutureExt;
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
+use std::panic::AssertUnwindSafe;
 use std::path::Path;
 use tauri::{AppHandle, Emitter, Manager, State};
 use tokio_util::sync::CancellationToken;
@@ -109,11 +111,11 @@ pub struct StartModelEmbeddingGenerationResponse {
     pub model: String,
 }
 
-#[derive(Clone, Copy)]
-struct EmbeddingJobControl<'a> {
-    jobs: &'a crate::services::jobs::JobRegistry,
-    job_id: &'a str,
-    cancel: &'a CancellationToken,
+#[derive(Clone)]
+struct EmbeddingJobControl {
+    jobs: crate::services::jobs::JobRegistry,
+    job_id: String,
+    cancel: CancellationToken,
     mode: EmbeddingGenerationMode,
 }
 
@@ -388,11 +390,15 @@ pub async fn start_model_embedding_generation(
     if targets.is_empty() {
         state.jobs.complete(&job_id);
         state.jobs.persist_terminal(&job_id, &state.db);
-        emit_embedding_job_event(&app, &job_id, &model, mode, "completed", 0, 0, None);
+        if let Some(snapshot) = state.jobs.get(&job_id) {
+            emit_embedding_job_snapshot(&app, &snapshot, &model, mode);
+        }
         return Ok(response);
     }
 
-    emit_embedding_job_event(&app, &job_id, &model, mode, "running", 0, total, None);
+    if let Some(snapshot) = state.jobs.get(&job_id) {
+        emit_embedding_job_snapshot(&app, &snapshot, &model, mode);
+    }
 
     let task_app = app.clone();
     let task_job_id = job_id.clone();
@@ -401,45 +407,27 @@ pub async fn start_model_embedding_generation(
     crate::spawn_guarded(app, "embedding-generation", move || async move {
         let state = task_app.state::<AppState>();
         let control = EmbeddingJobControl {
-            jobs: &state.jobs,
-            job_id: &task_job_id,
-            cancel: &cancel,
+            jobs: state.jobs.clone(),
+            job_id: task_job_id.clone(),
+            cancel: cancel.clone(),
             mode: task_mode,
         };
-        let result =
-            generate_embeddings_for_model(&task_app, &state, &task_model, &targets, Some(control))
-                .await;
+        let result = AssertUnwindSafe(generate_embeddings_for_model(
+            &task_app,
+            &state,
+            &task_model,
+            &targets,
+            Some(control),
+        ))
+        .catch_unwind()
+        .await;
 
-        let (terminal, status, error) = match result {
-            Ok(outcome) if outcome.cancelled => (
-                crate::services::jobs::WorkerTerminalOutcome::Cancelled,
-                "cancelled",
-                None,
-            ),
-            Ok(_) => (
-                crate::services::jobs::WorkerTerminalOutcome::Completed,
-                "completed",
-                None,
-            ),
-            Err(error) => (
-                crate::services::jobs::WorkerTerminalOutcome::Failed(error.clone()),
-                "failed",
-                Some(error),
-            ),
-        };
+        let terminal = embedding_worker_terminal_outcome(result);
         state.jobs.finish_from_worker(&task_job_id, terminal);
         state.jobs.persist_terminal(&task_job_id, &state.db);
-        let snapshot = state.jobs.get(&task_job_id);
-        emit_embedding_job_event(
-            &task_app,
-            &task_job_id,
-            &task_model,
-            task_mode,
-            status,
-            snapshot.as_ref().map(|job| job.current).unwrap_or(0),
-            total,
-            error.as_deref(),
-        );
+        if let Some(snapshot) = state.jobs.get(&task_job_id) {
+            emit_embedding_job_snapshot(&task_app, &snapshot, &task_model, task_mode);
+        }
     });
 
     Ok(response)
@@ -450,7 +438,7 @@ async fn generate_embeddings_for_model(
     state: &AppState,
     model_id: &str,
     image_ids: &[String],
-    control: Option<EmbeddingJobControl<'_>>,
+    control: Option<EmbeddingJobControl>,
 ) -> Result<EmbeddingGenerationOutcome, String> {
     if model_id == GEMINI_EMBEDDING_MODEL_ID {
         return generate_gemini_embeddings_for(app, state, image_ids, control).await;
@@ -484,52 +472,90 @@ async fn generate_embeddings_for_model(
         return Err(format!("Unsupported embedding model '{}'", model_id));
     }
 
-    crate::services::model_pipeline::ensure_embedding_model_loaded(
-        &state.embedding_engine,
-        model_id,
-    )?;
-    let result = crate::services::model_pipeline::run_embedding_model(
-        crate::services::model_pipeline::EmbeddingRunRequest {
-            db: &state.db,
-            app_data_dir: &state.app_data_dir,
-            embedding_engine: &state.embedding_engine,
-            jobs: control.map(|value| value.jobs),
-            job_id: control.map(|value| value.job_id),
-            cancel: control.map(|value| value.cancel),
-            mode: control.map(|value| value.mode.as_str()),
-            app: Some(app),
-            model_id,
-            image_ids,
-        },
-    )?;
+    let task_app = app.clone();
+    let task_model = model_id.to_string();
+    let task_image_ids = image_ids.to_vec();
+    let result = tauri::async_runtime::spawn_blocking(move || {
+        let state = task_app.state::<AppState>();
+        crate::services::model_pipeline::ensure_embedding_model_loaded(
+            &state.embedding_engine,
+            &task_model,
+        )?;
+        crate::services::model_pipeline::run_embedding_model(
+            crate::services::model_pipeline::EmbeddingRunRequest {
+                db: &state.db,
+                app_data_dir: &state.app_data_dir,
+                embedding_engine: &state.embedding_engine,
+                jobs: control.as_ref().map(|value| &value.jobs),
+                job_id: control.as_ref().map(|value| value.job_id.as_str()),
+                cancel: control.as_ref().map(|value| &value.cancel),
+                mode: control.as_ref().map(|value| value.mode.as_str()),
+                app: Some(&task_app),
+                model_id: &task_model,
+                image_ids: &task_image_ids,
+            },
+        )
+    })
+    .await
+    .map_err(|error| format!("Embedding worker join failed: {error}"))??;
     Ok(EmbeddingGenerationOutcome {
         generated: result.generated,
         cancelled: result.status == "cancelled",
     })
 }
 
-#[allow(clippy::too_many_arguments)]
-fn emit_embedding_job_event(
+fn emit_embedding_job_snapshot(
     app: &AppHandle,
-    job_id: &str,
+    snapshot: &crate::services::jobs::JobSnapshot,
     model: &str,
     mode: EmbeddingGenerationMode,
-    status: &str,
-    current: u32,
-    total: u32,
-    error: Option<&str>,
 ) {
-    let payload = serde_json::json!({
-        "job_id": job_id,
-        "model": model,
-        "mode": mode.as_str(),
-        "status": status,
-        "current": current,
-        "total": total,
-        "error": error,
-    });
+    let payload = embedding_job_snapshot_payload(snapshot, model, mode);
     let _ = app.emit("embedding-progress", payload.clone());
     let _ = app.emit("job-status-changed", payload);
+}
+
+fn embedding_job_snapshot_payload(
+    snapshot: &crate::services::jobs::JobSnapshot,
+    model: &str,
+    mode: EmbeddingGenerationMode,
+) -> serde_json::Value {
+    serde_json::json!({
+        "job_id": snapshot.job_id,
+        "kind": "embeddings",
+        "model": model,
+        "mode": mode.as_str(),
+        "status": snapshot.status,
+        "current": snapshot.current,
+        "total": snapshot.total,
+        "error": snapshot.error,
+    })
+}
+
+fn panic_payload_message(payload: &(dyn std::any::Any + Send)) -> String {
+    if let Some(message) = payload.downcast_ref::<&str>() {
+        (*message).to_string()
+    } else if let Some(message) = payload.downcast_ref::<String>() {
+        message.clone()
+    } else {
+        "unknown panic".to_string()
+    }
+}
+
+fn embedding_worker_terminal_outcome(
+    result: Result<Result<EmbeddingGenerationOutcome, String>, Box<dyn std::any::Any + Send>>,
+) -> crate::services::jobs::WorkerTerminalOutcome {
+    match result {
+        Ok(Ok(outcome)) if outcome.cancelled => {
+            crate::services::jobs::WorkerTerminalOutcome::Cancelled
+        }
+        Ok(Ok(_)) => crate::services::jobs::WorkerTerminalOutcome::Completed,
+        Ok(Err(error)) => crate::services::jobs::WorkerTerminalOutcome::Failed(error),
+        Err(payload) => crate::services::jobs::WorkerTerminalOutcome::Failed(format!(
+            "Embedding generation panicked: {}",
+            panic_payload_message(payload.as_ref())
+        )),
+    }
 }
 
 #[tauri::command]
@@ -767,6 +793,69 @@ mod tests {
         assert_eq!(json["job_id"], "job_123");
         assert!(json.get("jobId").is_none());
         assert_eq!(json["mode"], "missing");
+    }
+
+    #[test]
+    fn terminal_embedding_payload_uses_authoritative_job_snapshot() {
+        let snapshot = crate::services::jobs::JobSnapshot {
+            job_id: "job_123".to_string(),
+            kind: "embeddings".to_string(),
+            status: "failed".to_string(),
+            current: 3,
+            total: 5,
+            message: Some("image-3".to_string()),
+            error: Some("provider failed".to_string()),
+            created_at: "2026-08-08T00:00:00Z".to_string(),
+            updated_at: "2026-08-08T00:00:01Z".to_string(),
+        };
+
+        let payload =
+            embedding_job_snapshot_payload(&snapshot, "clip-vit-b32", EmbeddingGenerationMode::All);
+
+        assert_eq!(payload["job_id"], "job_123");
+        assert_eq!(payload["kind"], "embeddings");
+        assert_eq!(payload["status"], "failed");
+        assert_eq!(payload["current"], 3);
+        assert_eq!(payload["total"], 5);
+        assert_eq!(payload["error"], "provider failed");
+    }
+
+    #[test]
+    fn panic_payload_message_preserves_worker_panic_text() {
+        let payload: Box<dyn std::any::Any + Send> = Box::new("provider panic");
+        assert_eq!(panic_payload_message(payload.as_ref()), "provider panic");
+    }
+
+    #[test]
+    fn panicked_embedding_worker_seals_registered_job_as_failed() {
+        let jobs = crate::services::jobs::JobRegistry::default();
+        let (job_id, _) = jobs.create_job("embeddings", 4);
+        let panic_payload: Box<dyn std::any::Any + Send> = Box::new("provider panic");
+
+        jobs.finish_from_worker(
+            &job_id,
+            embedding_worker_terminal_outcome(Err(panic_payload)),
+        );
+
+        let snapshot = jobs.get(&job_id).unwrap();
+        assert_eq!(snapshot.status, "failed");
+        assert_eq!(
+            snapshot.error.as_deref(),
+            Some("Embedding generation panicked: provider panic")
+        );
+    }
+
+    #[test]
+    fn local_embedding_generation_dispatches_inference_to_blocking_pool() {
+        let source = include_str!("embeddings.rs");
+        let router = &source[source
+            .find("async fn generate_embeddings_for_model")
+            .unwrap()
+            ..source.find("fn emit_embedding_job_snapshot").unwrap()];
+
+        let blocking = router.find("spawn_blocking").unwrap();
+        let inference = router.find("run_embedding_model").unwrap();
+        assert!(blocking < inference);
     }
 
     #[test]
@@ -1201,7 +1290,7 @@ async fn generate_openai_text_embeddings(
     state: &AppState,
     model: &str,
     image_ids: &[String],
-    control: Option<EmbeddingJobControl<'_>>,
+    control: Option<EmbeddingJobControl>,
 ) -> Result<EmbeddingGenerationOutcome, String> {
     let api_key = state
         .secrets
@@ -1232,7 +1321,7 @@ async fn generate_cohere_image_embeddings(
     state: &AppState,
     model: &str,
     image_ids: &[String],
-    control: Option<EmbeddingJobControl<'_>>,
+    control: Option<EmbeddingJobControl>,
 ) -> Result<EmbeddingGenerationOutcome, String> {
     let api_key = state
         .secrets
@@ -1246,6 +1335,7 @@ async fn generate_cohere_image_embeddings(
 
     for (i, image_id) in image_ids.iter().enumerate() {
         if control
+            .as_ref()
             .map(|value| value.cancel.is_cancelled())
             .unwrap_or(false)
         {
@@ -1265,6 +1355,17 @@ async fn generate_cohere_image_embeddings(
             .map(|metadata| metadata.len() as i64)
             .unwrap_or(0);
         let dims = format!("{}x{}", img.image.width, img.image.height);
+
+        if control
+            .as_ref()
+            .map(|value| value.cancel.is_cancelled())
+            .unwrap_or(false)
+        {
+            return Ok(EmbeddingGenerationOutcome {
+                generated,
+                cancelled: true,
+            });
+        }
 
         match provider.generate_embedding(&ml_path).await {
             Ok(embedding) => {
@@ -1306,7 +1407,7 @@ async fn generate_cohere_image_embeddings(
 
         update_embedding_job_progress(
             app,
-            control,
+            control.as_ref(),
             "cohere",
             &storage_model_id,
             (i + 1) as u32,
@@ -1328,7 +1429,7 @@ async fn generate_ollama_text_embeddings(
     state: &AppState,
     model: &str,
     image_ids: &[String],
-    control: Option<EmbeddingJobControl<'_>>,
+    control: Option<EmbeddingJobControl>,
 ) -> Result<EmbeddingGenerationOutcome, String> {
     let (url, _) = ollama_embedding_config(state)?;
     let endpoint = crate::db_core::remote_embeddings::normalize_ollama_embed_url(&url);
@@ -1370,13 +1471,14 @@ async fn generate_text_embeddings_for(
     state: &AppState,
     image_ids: &[String],
     run: TextEmbeddingRun<'_>,
-    control: Option<EmbeddingJobControl<'_>>,
+    control: Option<EmbeddingJobControl>,
 ) -> Result<EmbeddingGenerationOutcome, String> {
     let total = image_ids.len() as u32;
     let mut generated = 0u32;
 
     for (i, image_id) in image_ids.iter().enumerate() {
         if control
+            .as_ref()
             .map(|value| value.cancel.is_cancelled())
             .unwrap_or(false)
         {
@@ -1401,6 +1503,17 @@ async fn generate_text_embeddings_for(
             .map_err(|e| e.to_string())?;
         let input = build_text_embedding_input(img, generation_run.as_ref(), &vision_metadata);
         let dims = format!("{}x{}", img.image.width, img.image.height);
+
+        if control
+            .as_ref()
+            .map(|value| value.cancel.is_cancelled())
+            .unwrap_or(false)
+        {
+            return Ok(EmbeddingGenerationOutcome {
+                generated,
+                cancelled: true,
+            });
+        }
 
         match run.provider.generate_embedding(&input).await {
             Ok(embedding) => {
@@ -1447,7 +1560,7 @@ async fn generate_text_embeddings_for(
 
         update_embedding_job_progress(
             app,
-            control,
+            control.as_ref(),
             run.provider_name,
             &run.storage_model_id,
             (i + 1) as u32,
@@ -1483,7 +1596,7 @@ async fn generate_gemini_embeddings_for(
     app: &AppHandle,
     state: &AppState,
     image_ids: &[String],
-    control: Option<EmbeddingJobControl<'_>>,
+    control: Option<EmbeddingJobControl>,
 ) -> Result<EmbeddingGenerationOutcome, String> {
     let api_key = state
         .secrets
@@ -1499,6 +1612,7 @@ async fn generate_gemini_embeddings_for(
 
     for (i, image_id) in image_ids.iter().enumerate() {
         if control
+            .as_ref()
             .map(|value| value.cancel.is_cancelled())
             .unwrap_or(false)
         {
@@ -1519,6 +1633,16 @@ async fn generate_gemini_embeddings_for(
             .map(|m| m.len() as i64)
             .unwrap_or(0);
         let dims = format!("{}x{}", img.image.width, img.image.height);
+        if control
+            .as_ref()
+            .map(|value| value.cancel.is_cancelled())
+            .unwrap_or(false)
+        {
+            return Ok(EmbeddingGenerationOutcome {
+                generated,
+                cancelled: true,
+            });
+        }
         match provider.generate_embedding(&ml_path).await {
             Ok(embedding) => {
                 let _ = crate::services::audit::log_api_call(
@@ -1550,7 +1674,7 @@ async fn generate_gemini_embeddings_for(
 
         update_embedding_job_progress(
             app,
-            control,
+            control.as_ref(),
             "gemini",
             GEMINI_EMBEDDING_MODEL_ID,
             (i + 1) as u32,
@@ -1570,7 +1694,7 @@ async fn generate_gemini_embeddings_for(
 
 fn update_embedding_job_progress(
     app: &AppHandle,
-    control: Option<EmbeddingJobControl<'_>>,
+    control: Option<&EmbeddingJobControl>,
     provider: &str,
     model: &str,
     current: u32,
@@ -1580,18 +1704,20 @@ fn update_embedding_job_progress(
     if let Some(control) = control {
         control
             .jobs
-            .update_progress(control.job_id, current, Some(image_id));
+            .update_progress(&control.job_id, current, Some(image_id));
     }
     let _ = app.emit(
         "embedding-progress",
         serde_json::json!({
-            "job_id": control.map(|value| value.job_id),
+            "job_id": control.map(|value| value.job_id.as_str()),
+            "kind": "embeddings",
             "current": current,
             "total": total,
             "provider": provider,
             "model": model,
             "mode": control.map(|value| value.mode.as_str()),
             "status": "running",
+            "error": null,
         }),
     );
 }

--- a/src-tauri/src/commands/embeddings.rs
+++ b/src-tauri/src/commands/embeddings.rs
@@ -1,8 +1,10 @@
 use crate::db_core::gemini::GeminiEmbeddingProvider;
 use crate::AppState;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
 use std::path::Path;
-use tauri::{AppHandle, Emitter, State};
+use tauri::{AppHandle, Emitter, Manager, State};
+use tokio_util::sync::CancellationToken;
 
 /// Google Generative Language "list models" endpoint used to validate a key.
 /// The key travels in the `x-goog-api-key` header, never as a query parameter,
@@ -82,6 +84,53 @@ pub struct EmbeddingModelDownloadInfo {
 }
 
 pub type ClipModelDownloadInfo = EmbeddingModelDownloadInfo;
+
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum EmbeddingGenerationMode {
+    Missing,
+    All,
+}
+
+impl EmbeddingGenerationMode {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Missing => "missing",
+            Self::All => "all",
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub struct StartModelEmbeddingGenerationResponse {
+    pub job_id: String,
+    pub total: u32,
+    pub mode: EmbeddingGenerationMode,
+    pub model: String,
+}
+
+#[derive(Clone, Copy)]
+struct EmbeddingJobControl<'a> {
+    jobs: &'a crate::services::jobs::JobRegistry,
+    job_id: &'a str,
+    cancel: &'a CancellationToken,
+    mode: EmbeddingGenerationMode,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct EmbeddingGenerationOutcome {
+    generated: u32,
+    cancelled: bool,
+}
+
+fn dedupe_embedding_targets(image_ids: &[String]) -> Vec<String> {
+    let mut seen = HashSet::with_capacity(image_ids.len());
+    image_ids
+        .iter()
+        .filter(|image_id| seen.insert(image_id.as_str()))
+        .cloned()
+        .collect()
+}
 
 #[derive(Debug, Clone, Copy, Default)]
 struct ProviderAvailability {
@@ -290,6 +339,7 @@ pub async fn generate_embeddings(
             jobs: None,
             job_id: None,
             cancel: None,
+            mode: None,
             app: Some(&app),
             image_ids: &image_ids,
         },
@@ -304,7 +354,91 @@ pub async fn generate_model_embeddings(
     model: String,
     image_ids: Vec<String>,
 ) -> Result<u32, String> {
-    generate_embeddings_for_model(&app, &state, &model, &image_ids).await
+    Ok(
+        generate_embeddings_for_model(&app, &state, &model, &image_ids, None)
+            .await?
+            .generated,
+    )
+}
+
+#[tauri::command]
+pub async fn start_model_embedding_generation(
+    app: AppHandle,
+    state: State<'_, AppState>,
+    model: String,
+    image_ids: Vec<String>,
+    mode: EmbeddingGenerationMode,
+) -> Result<StartModelEmbeddingGenerationResponse, String> {
+    let targets = match mode {
+        EmbeddingGenerationMode::Missing => state
+            .db
+            .image_ids_without_embedding(&image_ids, &model)
+            .map_err(|error| error.to_string())?,
+        EmbeddingGenerationMode::All => dedupe_embedding_targets(&image_ids),
+    };
+    let total = u32::try_from(targets.len()).map_err(|_| "Too many images selected")?;
+    let (job_id, cancel) = state.jobs.create_job("embeddings", total);
+    let response = StartModelEmbeddingGenerationResponse {
+        job_id: job_id.clone(),
+        total,
+        mode,
+        model: model.clone(),
+    };
+
+    if targets.is_empty() {
+        state.jobs.complete(&job_id);
+        state.jobs.persist_terminal(&job_id, &state.db);
+        emit_embedding_job_event(&app, &job_id, &model, mode, "completed", 0, 0, None);
+        return Ok(response);
+    }
+
+    emit_embedding_job_event(&app, &job_id, &model, mode, "running", 0, total, None);
+
+    let task_app = app.clone();
+    let task_job_id = job_id.clone();
+    let task_model = model;
+    let task_mode = mode;
+    crate::spawn_guarded(app, "embedding-generation", move || async move {
+        let state = task_app.state::<AppState>();
+        let control = EmbeddingJobControl {
+            jobs: &state.jobs,
+            job_id: &task_job_id,
+            cancel: &cancel,
+            mode: task_mode,
+        };
+        let result =
+            generate_embeddings_for_model(&task_app, &state, &task_model, &targets, Some(control))
+                .await;
+
+        let (status, error) = match result {
+            Ok(outcome) if outcome.cancelled || cancel.is_cancelled() => {
+                state.jobs.mark_cancelled(&task_job_id);
+                ("cancelled", None)
+            }
+            Ok(_) => {
+                state.jobs.complete(&task_job_id);
+                ("completed", None)
+            }
+            Err(error) => {
+                state.jobs.fail(&task_job_id, &error);
+                ("failed", Some(error))
+            }
+        };
+        state.jobs.persist_terminal(&task_job_id, &state.db);
+        let snapshot = state.jobs.get(&task_job_id);
+        emit_embedding_job_event(
+            &task_app,
+            &task_job_id,
+            &task_model,
+            task_mode,
+            status,
+            snapshot.as_ref().map(|job| job.current).unwrap_or(0),
+            total,
+            error.as_deref(),
+        );
+    });
+
+    Ok(response)
 }
 
 async fn generate_embeddings_for_model(
@@ -312,9 +446,10 @@ async fn generate_embeddings_for_model(
     state: &AppState,
     model_id: &str,
     image_ids: &[String],
-) -> Result<u32, String> {
+    control: Option<EmbeddingJobControl<'_>>,
+) -> Result<EmbeddingGenerationOutcome, String> {
     if model_id == GEMINI_EMBEDDING_MODEL_ID {
-        return generate_gemini_embeddings_for(app, state, image_ids).await;
+        return generate_gemini_embeddings_for(app, state, image_ids, control).await;
     }
     if let Some(model) = model_id.strip_prefix("openai:") {
         let model = if model.trim().is_empty() {
@@ -322,7 +457,7 @@ async fn generate_embeddings_for_model(
         } else {
             model.to_string()
         };
-        return generate_openai_text_embeddings(app, state, &model, image_ids).await;
+        return generate_openai_text_embeddings(app, state, &model, image_ids, control).await;
     }
     if let Some(model) = model_id.strip_prefix("cohere:") {
         let model = if model.trim().is_empty() {
@@ -330,7 +465,7 @@ async fn generate_embeddings_for_model(
         } else {
             model.to_string()
         };
-        return generate_cohere_image_embeddings(app, state, &model, image_ids).await;
+        return generate_cohere_image_embeddings(app, state, &model, image_ids, control).await;
     }
     if let Some(model) = model_id.strip_prefix("ollama:") {
         let (_, configured_model) = ollama_embedding_config(state)?;
@@ -339,7 +474,7 @@ async fn generate_embeddings_for_model(
         } else {
             model.to_string()
         };
-        return generate_ollama_text_embeddings(app, state, &model, image_ids).await;
+        return generate_ollama_text_embeddings(app, state, &model, image_ids, control).await;
     }
     if embedding_provider_for_model(model_id).is_none() {
         return Err(format!("Unsupported embedding model '{}'", model_id));
@@ -354,15 +489,43 @@ async fn generate_embeddings_for_model(
             db: &state.db,
             app_data_dir: &state.app_data_dir,
             embedding_engine: &state.embedding_engine,
-            jobs: None,
-            job_id: None,
-            cancel: None,
+            jobs: control.map(|value| value.jobs),
+            job_id: control.map(|value| value.job_id),
+            cancel: control.map(|value| value.cancel),
+            mode: control.map(|value| value.mode.as_str()),
             app: Some(app),
             model_id,
             image_ids,
         },
     )?;
-    Ok(result.generated)
+    Ok(EmbeddingGenerationOutcome {
+        generated: result.generated,
+        cancelled: result.status == "cancelled",
+    })
+}
+
+#[allow(clippy::too_many_arguments)]
+fn emit_embedding_job_event(
+    app: &AppHandle,
+    job_id: &str,
+    model: &str,
+    mode: EmbeddingGenerationMode,
+    status: &str,
+    current: u32,
+    total: u32,
+    error: Option<&str>,
+) {
+    let payload = serde_json::json!({
+        "job_id": job_id,
+        "model": model,
+        "mode": mode.as_str(),
+        "status": status,
+        "current": current,
+        "total": total,
+        "error": error,
+    });
+    let _ = app.emit("embedding-progress", payload.clone());
+    let _ = app.emit("job-status-changed", payload);
 }
 
 #[tauri::command]
@@ -572,6 +735,35 @@ pub async fn set_ollama_embedding_config(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn all_embedding_generation_targets_preserve_first_seen_order() {
+        let requested = vec![
+            "image-b".to_string(),
+            "image-a".to_string(),
+            "image-b".to_string(),
+        ];
+
+        assert_eq!(
+            dedupe_embedding_targets(&requested),
+            vec!["image-b".to_string(), "image-a".to_string()]
+        );
+    }
+
+    #[test]
+    fn embedding_generation_start_response_keeps_snake_case_job_id() {
+        let response = StartModelEmbeddingGenerationResponse {
+            job_id: "job_123".to_string(),
+            total: 4,
+            mode: EmbeddingGenerationMode::Missing,
+            model: "clip-vit-b32".to_string(),
+        };
+
+        let json = serde_json::to_value(response).unwrap();
+        assert_eq!(json["job_id"], "job_123");
+        assert!(json.get("jobId").is_none());
+        assert_eq!(json["mode"], "missing");
+    }
 
     #[test]
     fn clip_model_download_info_includes_real_model_path_and_curl_command() {
@@ -1005,7 +1197,8 @@ async fn generate_openai_text_embeddings(
     state: &AppState,
     model: &str,
     image_ids: &[String],
-) -> Result<u32, String> {
+    control: Option<EmbeddingJobControl<'_>>,
+) -> Result<EmbeddingGenerationOutcome, String> {
     let api_key = state
         .secrets
         .get("api_key_openai")?
@@ -1025,6 +1218,7 @@ async fn generate_openai_text_embeddings(
             storage_model_id: openai_storage_model_id(model),
             jurisdiction: "US - OpenAI Inc",
         },
+        control,
     )
     .await
 }
@@ -1034,7 +1228,8 @@ async fn generate_cohere_image_embeddings(
     state: &AppState,
     model: &str,
     image_ids: &[String],
-) -> Result<u32, String> {
+    control: Option<EmbeddingJobControl<'_>>,
+) -> Result<EmbeddingGenerationOutcome, String> {
     let api_key = state
         .secrets
         .get("api_key_cohere")?
@@ -1046,6 +1241,15 @@ async fn generate_cohere_image_embeddings(
     let mut generated = 0u32;
 
     for (i, image_id) in image_ids.iter().enumerate() {
+        if control
+            .map(|value| value.cancel.is_cancelled())
+            .unwrap_or(false)
+        {
+            return Ok(EmbeddingGenerationOutcome {
+                generated,
+                cancelled: true,
+            });
+        }
         let id_refs: Vec<&str> = vec![image_id.as_str()];
         let images = state
             .db
@@ -1096,20 +1300,23 @@ async fn generate_cohere_image_embeddings(
             }
         }
 
-        let _ = app.emit(
-            "embedding-progress",
-            serde_json::json!({
-                "current": i + 1,
-                "total": total,
-                "provider": "cohere",
-                "model": storage_model_id,
-            }),
+        update_embedding_job_progress(
+            app,
+            control,
+            "cohere",
+            &storage_model_id,
+            (i + 1) as u32,
+            total,
+            image_id,
         );
 
         tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
     }
 
-    Ok(generated)
+    Ok(EmbeddingGenerationOutcome {
+        generated,
+        cancelled: false,
+    })
 }
 
 async fn generate_ollama_text_embeddings(
@@ -1117,7 +1324,8 @@ async fn generate_ollama_text_embeddings(
     state: &AppState,
     model: &str,
     image_ids: &[String],
-) -> Result<u32, String> {
+    control: Option<EmbeddingJobControl<'_>>,
+) -> Result<EmbeddingGenerationOutcome, String> {
     let (url, _) = ollama_embedding_config(state)?;
     let endpoint = crate::db_core::remote_embeddings::normalize_ollama_embed_url(&url);
     let jurisdiction = if endpoint.contains("localhost") || endpoint.contains("127.0.0.1") {
@@ -1139,6 +1347,7 @@ async fn generate_ollama_text_embeddings(
             storage_model_id: ollama_storage_model_id(model),
             jurisdiction,
         },
+        control,
     )
     .await
 }
@@ -1157,11 +1366,21 @@ async fn generate_text_embeddings_for(
     state: &AppState,
     image_ids: &[String],
     run: TextEmbeddingRun<'_>,
-) -> Result<u32, String> {
+    control: Option<EmbeddingJobControl<'_>>,
+) -> Result<EmbeddingGenerationOutcome, String> {
     let total = image_ids.len() as u32;
     let mut generated = 0u32;
 
     for (i, image_id) in image_ids.iter().enumerate() {
+        if control
+            .map(|value| value.cancel.is_cancelled())
+            .unwrap_or(false)
+        {
+            return Ok(EmbeddingGenerationOutcome {
+                generated,
+                cancelled: true,
+            });
+        }
         let id_refs: Vec<&str> = vec![image_id.as_str()];
         let images = state
             .db
@@ -1222,14 +1441,14 @@ async fn generate_text_embeddings_for(
             }
         }
 
-        let _ = app.emit(
-            "embedding-progress",
-            serde_json::json!({
-                "current": i + 1,
-                "total": total,
-                "provider": run.provider_name,
-                "model": run.storage_model_id,
-            }),
+        update_embedding_job_progress(
+            app,
+            control,
+            run.provider_name,
+            &run.storage_model_id,
+            (i + 1) as u32,
+            total,
+            image_id,
         );
 
         if run.provider_name == "openai" {
@@ -1237,7 +1456,10 @@ async fn generate_text_embeddings_for(
         }
     }
 
-    Ok(generated)
+    Ok(EmbeddingGenerationOutcome {
+        generated,
+        cancelled: false,
+    })
 }
 
 #[tauri::command]
@@ -1246,14 +1468,19 @@ pub async fn generate_gemini_embeddings(
     state: State<'_, AppState>,
     image_ids: Vec<String>,
 ) -> Result<u32, String> {
-    generate_gemini_embeddings_for(&app, &state, &image_ids).await
+    Ok(
+        generate_gemini_embeddings_for(&app, &state, &image_ids, None)
+            .await?
+            .generated,
+    )
 }
 
 async fn generate_gemini_embeddings_for(
     app: &AppHandle,
     state: &AppState,
     image_ids: &[String],
-) -> Result<u32, String> {
+    control: Option<EmbeddingJobControl<'_>>,
+) -> Result<EmbeddingGenerationOutcome, String> {
     let api_key = state
         .secrets
         .get("api_key_google")?
@@ -1267,6 +1494,15 @@ async fn generate_gemini_embeddings_for(
     let mut generated = 0u32;
 
     for (i, image_id) in image_ids.iter().enumerate() {
+        if control
+            .map(|value| value.cancel.is_cancelled())
+            .unwrap_or(false)
+        {
+            return Ok(EmbeddingGenerationOutcome {
+                generated,
+                cancelled: true,
+            });
+        }
         let id_refs: Vec<&str> = vec![image_id.as_str()];
         let images = state
             .db
@@ -1308,19 +1544,50 @@ async fn generate_gemini_embeddings_for(
             }
         }
 
-        let _ = app.emit(
-            "embedding-progress",
-            serde_json::json!({
-                "current": i + 1,
-                "total": total,
-                "provider": "gemini",
-                "model": GEMINI_EMBEDDING_MODEL_ID,
-            }),
+        update_embedding_job_progress(
+            app,
+            control,
+            "gemini",
+            GEMINI_EMBEDDING_MODEL_ID,
+            (i + 1) as u32,
+            total,
+            image_id,
         );
 
         // Rate limiting
         tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
     }
 
-    Ok(generated)
+    Ok(EmbeddingGenerationOutcome {
+        generated,
+        cancelled: false,
+    })
+}
+
+fn update_embedding_job_progress(
+    app: &AppHandle,
+    control: Option<EmbeddingJobControl<'_>>,
+    provider: &str,
+    model: &str,
+    current: u32,
+    total: u32,
+    image_id: &str,
+) {
+    if let Some(control) = control {
+        control
+            .jobs
+            .update_progress(control.job_id, current, Some(image_id));
+    }
+    let _ = app.emit(
+        "embedding-progress",
+        serde_json::json!({
+            "job_id": control.map(|value| value.job_id),
+            "current": current,
+            "total": total,
+            "provider": provider,
+            "model": model,
+            "mode": control.map(|value| value.mode.as_str()),
+            "status": "running",
+        }),
+    );
 }

--- a/src-tauri/src/db_core/queries/embeddings.rs
+++ b/src-tauri/src/db_core/queries/embeddings.rs
@@ -9,6 +9,7 @@ use crate::db_core::smart_collections::FilterNode;
 use crate::db_core::visibility::RejectedVisibility;
 use rusqlite::types::Value;
 use rusqlite::{params, OptionalExtension, Result, ToSql};
+use std::collections::HashSet;
 
 fn scoped_where_clause(scope: &EmbeddingScope) -> Result<(String, Vec<Value>, RejectedVisibility)> {
     let default_visibility = RejectedVisibility::from_include_rejected(scope.include_rejected());
@@ -86,6 +87,46 @@ fn to_param_refs(params: &[Value]) -> Vec<&dyn ToSql> {
 }
 
 impl Database {
+    /// Returns the first occurrence of each requested image ID that does not
+    /// already have an embedding for `model_name`.
+    pub fn image_ids_without_embedding(
+        &self,
+        image_ids: &[String],
+        model_name: &str,
+    ) -> Result<Vec<String>> {
+        if image_ids.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let mut unique_ids = Vec::with_capacity(image_ids.len());
+        let mut seen = HashSet::with_capacity(image_ids.len());
+        for image_id in image_ids {
+            if seen.insert(image_id.as_str()) {
+                unique_ids.push(image_id.clone());
+            }
+        }
+
+        let conn = self.read_connection();
+        let mut existing = HashSet::new();
+        for chunk in unique_ids.chunks(500) {
+            let placeholders = (0..chunk.len()).map(|_| "?").collect::<Vec<_>>().join(",");
+            let sql = format!(
+                "SELECT image_id FROM embeddings WHERE model_name = ? AND image_id IN ({placeholders})"
+            );
+            let mut values = Vec::with_capacity(chunk.len() + 1);
+            values.push(Value::Text(model_name.to_string()));
+            values.extend(chunk.iter().cloned().map(Value::Text));
+            let mut stmt = conn.prepare(&sql)?;
+            let rows = stmt.query_map(to_param_refs(&values).as_slice(), |row| row.get(0))?;
+            existing.extend(rows.collect::<Result<Vec<String>>>()?);
+        }
+
+        Ok(unique_ids
+            .into_iter()
+            .filter(|image_id| !existing.contains(image_id))
+            .collect())
+    }
+
     pub fn store_embedding(&self, image_id: &str, model_name: &str, vector: &[f32]) -> Result<()> {
         self.store_embedding_with_model_run(image_id, model_name, vector, None)
             .map(|_| ())
@@ -625,6 +666,41 @@ mod tests {
         assert_eq!(neighbors[1], ("in-far".to_string(), 0.0));
         assert!(neighbors.iter().all(|(id, _)| id != "source"));
         assert!(neighbors.iter().all(|(id, _)| id != "outside-closest"));
+    }
+
+    #[test]
+    fn image_ids_without_embedding_preserves_order_dedupes_and_is_model_specific() {
+        let db = open_test_db();
+        for id in ["has-selected", "other-model", "missing", "missing-two"] {
+            insert_test_image(&db, id);
+        }
+        db.store_embedding("has-selected", "selected-model", &[1.0, 0.0])
+            .unwrap();
+        db.store_embedding("other-model", "different-model", &[0.0, 1.0])
+            .unwrap();
+
+        let requested = vec![
+            "has-selected".to_string(),
+            "missing".to_string(),
+            "other-model".to_string(),
+            "missing".to_string(),
+            "missing-two".to_string(),
+        ];
+
+        let missing = db
+            .image_ids_without_embedding(&requested, "selected-model")
+            .unwrap();
+
+        assert_eq!(missing, vec!["missing", "other-model", "missing-two"]);
+
+        let large_request = (0..505)
+            .map(|index| format!("unembedded-{index:03}"))
+            .collect::<Vec<_>>();
+        assert_eq!(
+            db.image_ids_without_embedding(&large_request, "selected-model")
+                .unwrap(),
+            large_request
+        );
     }
 
     #[test]

--- a/src-tauri/src/db_core/queries/jobs.rs
+++ b/src-tauri/src/db_core/queries/jobs.rs
@@ -116,6 +116,18 @@ impl Database {
         Ok(())
     }
 
+    pub fn fail_running_model_runs_for_job(&self, job_id: &str, error: &str) -> Result<u32> {
+        let now = chrono::Utc::now().to_rfc3339();
+        let conn = self.conn.lock();
+        let updated = conn.execute(
+            "UPDATE model_runs
+             SET status = 'failed', error = ?2, completed_at = ?3
+             WHERE job_id = ?1 AND status = 'running'",
+            params![job_id, error, now],
+        )?;
+        Ok(updated as u32)
+    }
+
     pub fn insert_model_run_item(&self, item: &NewModelRunItem) -> Result<()> {
         let conn = self.conn.lock();
         conn.execute(
@@ -176,5 +188,70 @@ impl Database {
             },
         )
         .optional()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+
+    fn model_run(id: &str, status: &str) -> NewModelRun {
+        let now = "2026-08-08T00:00:00Z".to_string();
+        NewModelRun {
+            id: id.to_string(),
+            job_id: Some("job-embedding".to_string()),
+            parent_run_id: None,
+            profile_id: None,
+            task: "embedding".to_string(),
+            provider: "local".to_string(),
+            model_id: "clip-vit-b32".to_string(),
+            model_revision: None,
+            status: status.to_string(),
+            input_scope_json: "{}".to_string(),
+            params_json: "{}".to_string(),
+            output_summary_json: if status == "completed" {
+                "{\"generated\":1}".to_string()
+            } else {
+                "{}".to_string()
+            },
+            cost_estimate_usd: None,
+            cost_actual_usd: None,
+            error: None,
+            created_at: now.clone(),
+            started_at: Some(now.clone()),
+            completed_at: (status == "completed").then_some(now),
+        }
+    }
+
+    #[test]
+    fn failing_running_model_runs_for_job_preserves_terminal_runs() {
+        let db = Database::open(Path::new(":memory:")).unwrap();
+        db.insert_model_run(&model_run("run-running", "running"))
+            .unwrap();
+        db.insert_model_run(&model_run("run-completed", "completed"))
+            .unwrap();
+
+        let updated = db
+            .fail_running_model_runs_for_job("job-embedding", "Embedding generation panicked")
+            .unwrap();
+
+        assert_eq!(updated, 1);
+        let failed = db.get_model_run("run-running").unwrap().unwrap();
+        assert_eq!(failed.status, "failed");
+        assert_eq!(
+            failed.error.as_deref(),
+            Some("Embedding generation panicked")
+        );
+        assert!(failed.completed_at.is_some());
+
+        let completed = db.get_model_run("run-completed").unwrap().unwrap();
+        assert_eq!(completed.status, "completed");
+        assert_eq!(completed.output_summary_json, "{\"generated\":1}");
+        assert_eq!(completed.error, None);
+        assert_eq!(
+            completed.completed_at.as_deref(),
+            Some("2026-08-08T00:00:00Z")
+        );
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -257,6 +257,18 @@ mod gui_launch_tests {
             .lines()
             .any(|line| line.trim() == permission_entry));
     }
+
+    #[test]
+    fn background_embedding_generation_command_is_registered_and_permitted() {
+        let command_registry = include_str!("lib.rs");
+        let ai_permissions = include_str!("../permissions/app-ai-processing.toml");
+        let command_name = "start_model_embedding_generation";
+
+        assert!(command_registry.contains(&format!("commands::embeddings::{command_name},")));
+        assert!(ai_permissions
+            .lines()
+            .any(|line| line.trim() == format!("\"{command_name}\",")));
+    }
 }
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
@@ -581,6 +593,7 @@ pub fn run() {
             commands::collections::delete_collection,
             commands::embeddings::generate_embeddings,
             commands::embeddings::generate_model_embeddings,
+            commands::embeddings::start_model_embedding_generation,
             commands::embeddings::get_embedding_page,
             commands::embeddings::get_scoped_embedding_page,
             commands::embeddings::list_scoped_image_ids,

--- a/src-tauri/src/mcp/tools/ml.rs
+++ b/src-tauri/src/mcp/tools/ml.rs
@@ -465,6 +465,7 @@ impl CullMcp {
                     jobs: Some(&state.jobs),
                     job_id: Some(&job_id),
                     cancel: Some(&cancel_token),
+                    mode: None,
                     app: Some(&app),
                     model_id: &model_id_for_task,
                     image_ids: &image_ids,

--- a/src-tauri/src/services/jobs.rs
+++ b/src-tauri/src/services/jobs.rs
@@ -25,6 +25,15 @@ pub struct JobState {
     pub pause: PauseController,
 }
 
+/// The terminal result observed by a background worker at its cancellation
+/// checkpoints. Unlike `complete`/`fail`, this deliberately does not infer
+/// status from a cancellation token that may have arrived after work ended.
+pub enum WorkerTerminalOutcome {
+    Completed,
+    Cancelled,
+    Failed(String),
+}
+
 #[derive(Clone)]
 pub struct JobRegistry {
     jobs: Arc<Mutex<HashMap<String, JobState>>>,
@@ -168,6 +177,28 @@ impl JobRegistry {
         let mut jobs = self.jobs.lock().unwrap();
         if let Some(state) = jobs.get_mut(job_id) {
             state.snapshot.status = "cancelled".to_string();
+            state.snapshot.updated_at = chrono::Utc::now().to_rfc3339();
+        }
+    }
+
+    pub fn finish_from_worker(&self, job_id: &str, outcome: WorkerTerminalOutcome) {
+        let mut jobs = self.jobs.lock().unwrap();
+        if let Some(state) = jobs.get_mut(job_id) {
+            match outcome {
+                WorkerTerminalOutcome::Completed => {
+                    state.snapshot.status = "completed".to_string();
+                    state.snapshot.current = state.snapshot.total;
+                    state.snapshot.error = None;
+                }
+                WorkerTerminalOutcome::Cancelled => {
+                    state.snapshot.status = "cancelled".to_string();
+                    state.snapshot.error = None;
+                }
+                WorkerTerminalOutcome::Failed(error) => {
+                    state.snapshot.status = "failed".to_string();
+                    state.snapshot.error = Some(error);
+                }
+            }
             state.snapshot.updated_at = chrono::Utc::now().to_rfc3339();
         }
     }
@@ -484,6 +515,21 @@ mod tests {
         registry.complete(&job_id);
         let snapshot = registry.get(&job_id).unwrap();
         assert_eq!(snapshot.status, "cancelled");
+    }
+
+    #[test]
+    fn worker_completed_outcome_wins_over_late_cancellation_request() {
+        let registry = JobRegistry::default();
+        let (job_id, _) = registry.create_job("embeddings", 2);
+        registry.update_progress(&job_id, 2, None);
+        registry.cancel(&job_id).unwrap();
+
+        registry.finish_from_worker(&job_id, WorkerTerminalOutcome::Completed);
+
+        let snapshot = registry.get(&job_id).unwrap();
+        assert_eq!(snapshot.status, "completed");
+        assert_eq!(snapshot.current, 2);
+        assert_eq!(snapshot.total, 2);
     }
 
     #[test]

--- a/src-tauri/src/services/model_pipeline.rs
+++ b/src-tauri/src/services/model_pipeline.rs
@@ -144,32 +144,7 @@ pub fn run_embedding_model(request: EmbeddingRunRequest<'_>) -> Result<Embedding
 
     for (i, image_id) in request.image_ids.iter().enumerate() {
         if request.cancel.map(|c| c.is_cancelled()).unwrap_or(false) {
-            let summary = serde_json::json!({
-                "generated": generated,
-                "failed": failed,
-                "total": total,
-                "cancelled_at": i,
-            })
-            .to_string();
-            request
-                .db
-                .update_model_run_terminal(&model_run_id, "cancelled", &summary, None)
-                .map_err(|e| e.to_string())?;
-            emit_model_run_event(
-                request.app,
-                &model_run_id,
-                request.job_id,
-                "cancelled",
-                i as u32,
-                total,
-            );
-            return Ok(EmbeddingRunResult {
-                model_run_id,
-                generated,
-                failed,
-                total,
-                status: "cancelled".to_string(),
-            });
+            return cancel_embedding_run(&request, model_run_id, generated, failed, total, i);
         }
 
         let current = (i + 1) as u32;
@@ -210,6 +185,9 @@ pub fn run_embedding_model(request: EmbeddingRunRequest<'_>) -> Result<Embedding
         };
 
         let ml_path = resolve_image_path_for_ml(&image, request.app_data_dir);
+        if request.cancel.map(|c| c.is_cancelled()).unwrap_or(false) {
+            return cancel_embedding_run(&request, model_run_id, generated, failed, total, i);
+        }
         let embedding = {
             let engine = request.embedding_engine.lock();
             engine.generate_embedding_for(spec.model_id, &ml_path)
@@ -288,6 +266,42 @@ pub fn run_embedding_model(request: EmbeddingRunRequest<'_>) -> Result<Embedding
     })
 }
 
+fn cancel_embedding_run(
+    request: &EmbeddingRunRequest<'_>,
+    model_run_id: String,
+    generated: u32,
+    failed: u32,
+    total: u32,
+    cancelled_at: usize,
+) -> Result<EmbeddingRunResult, String> {
+    let summary = serde_json::json!({
+        "generated": generated,
+        "failed": failed,
+        "total": total,
+        "cancelled_at": cancelled_at,
+    })
+    .to_string();
+    request
+        .db
+        .update_model_run_terminal(&model_run_id, "cancelled", &summary, None)
+        .map_err(|error| error.to_string())?;
+    emit_model_run_event(
+        request.app,
+        &model_run_id,
+        request.job_id,
+        "cancelled",
+        cancelled_at as u32,
+        total,
+    );
+    Ok(EmbeddingRunResult {
+        model_run_id,
+        generated,
+        failed,
+        total,
+        status: "cancelled".to_string(),
+    })
+}
+
 fn load_image(db: &Database, image_id: &str) -> Result<Option<ImageWithFile>, String> {
     let id_refs = vec![image_id];
     let images = db.get_images_by_ids(&id_refs).map_err(|e| e.to_string())?;
@@ -361,12 +375,14 @@ fn embedding_progress_payload(
 ) -> serde_json::Value {
     serde_json::json!({
         "job_id": job_id,
+        "kind": "embeddings",
         "current": current,
         "total": total,
         "model": model,
         "model_run_id": model_run_id,
         "mode": mode,
         "status": status,
+        "error": null,
     })
 }
 

--- a/src-tauri/src/services/model_pipeline.rs
+++ b/src-tauri/src/services/model_pipeline.rs
@@ -15,6 +15,7 @@ pub struct ClipEmbeddingRunRequest<'a> {
     pub jobs: Option<&'a JobRegistry>,
     pub job_id: Option<&'a str>,
     pub cancel: Option<&'a CancellationToken>,
+    pub mode: Option<&'a str>,
     pub app: Option<&'a AppHandle>,
     pub image_ids: &'a [String],
 }
@@ -26,6 +27,7 @@ pub struct EmbeddingRunRequest<'a> {
     pub jobs: Option<&'a JobRegistry>,
     pub job_id: Option<&'a str>,
     pub cancel: Option<&'a CancellationToken>,
+    pub mode: Option<&'a str>,
     pub app: Option<&'a AppHandle>,
     pub model_id: &'a str,
     pub image_ids: &'a [String],
@@ -75,6 +77,7 @@ pub fn run_clip_embeddings(
         jobs: request.jobs,
         job_id: request.job_id,
         cancel: request.cancel,
+        mode: request.mode,
         app: request.app,
         model_id: CLIP_MODEL_ID,
         image_ids: request.image_ids,
@@ -334,14 +337,37 @@ fn update_progress(
     if let Some(app) = request.app {
         let _ = app.emit(
             "embedding-progress",
-            serde_json::json!({
-                "current": current,
-                "total": total,
-                "model": request.model_id,
-                "model_run_id": model_run_id,
-            }),
+            embedding_progress_payload(
+                current,
+                total,
+                request.model_id,
+                model_run_id,
+                request.job_id,
+                request.mode,
+                "running",
+            ),
         );
     }
+}
+
+fn embedding_progress_payload(
+    current: u32,
+    total: u32,
+    model: &str,
+    model_run_id: &str,
+    job_id: Option<&str>,
+    mode: Option<&str>,
+    status: &str,
+) -> serde_json::Value {
+    serde_json::json!({
+        "job_id": job_id,
+        "current": current,
+        "total": total,
+        "model": model,
+        "model_run_id": model_run_id,
+        "mode": mode,
+        "status": status,
+    })
 }
 
 fn emit_model_run_event(
@@ -405,6 +431,7 @@ mod tests {
             jobs: None,
             job_id: None,
             cancel: None,
+            mode: None,
             app: None,
             image_ids: &image_ids,
         })
@@ -445,6 +472,7 @@ mod tests {
             jobs: None,
             job_id: None,
             cancel: None,
+            mode: None,
             app: None,
             model_id: "dinov2-vits14",
             image_ids: &image_ids,
@@ -458,5 +486,56 @@ mod tests {
         let run = db.get_model_run(&result.model_run_id).unwrap().unwrap();
         assert_eq!(run.model_id, "dinov2-vits14");
         assert!(run.params_json.contains("\"output_dims\":384"));
+    }
+
+    #[test]
+    fn embedding_pipeline_honors_pre_cancelled_registered_job() {
+        let tmp = tempfile::tempdir().unwrap();
+        let db = Database::open(std::path::Path::new(":memory:")).unwrap();
+        let app_data_dir = tmp.path().to_path_buf();
+        let model_dir = tmp.path().join("models");
+        let embedding_engine = Mutex::new(EmbeddingEngine::new(&model_dir));
+        let image_ids = vec!["never-processed".to_string()];
+        let jobs = JobRegistry::default();
+        let (job_id, cancel) = jobs.create_job("embeddings", 1);
+        cancel.cancel();
+
+        let result = run_embedding_model(EmbeddingRunRequest {
+            db: &db,
+            app_data_dir: &app_data_dir,
+            embedding_engine: &embedding_engine,
+            jobs: Some(&jobs),
+            job_id: Some(&job_id),
+            cancel: Some(&cancel),
+            mode: Some("missing"),
+            app: None,
+            model_id: "dinov2-vits14",
+            image_ids: &image_ids,
+        })
+        .unwrap();
+
+        assert_eq!(result.generated, 0);
+        assert_eq!(result.status, "cancelled");
+        assert_eq!(jobs.get(&job_id).unwrap().current, 0);
+    }
+
+    #[test]
+    fn embedding_progress_payload_identifies_background_job_and_mode() {
+        let payload = embedding_progress_payload(
+            2,
+            5,
+            "dinov2-vits14",
+            "run-1",
+            Some("job-1"),
+            Some("missing"),
+            "running",
+        );
+
+        assert_eq!(payload["job_id"], "job-1");
+        assert_eq!(payload["model"], "dinov2-vits14");
+        assert_eq!(payload["mode"], "missing");
+        assert_eq!(payload["status"], "running");
+        assert_eq!(payload["current"], 2);
+        assert_eq!(payload["total"], 5);
     }
 }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1037,6 +1037,29 @@ export async function generateModelEmbeddings(model: string, imageIds: string[])
     return invoke('generate_model_embeddings', { model, imageIds });
 }
 
+export type EmbeddingGenerationMode = 'missing' | 'all';
+
+export interface EmbeddingGenerationStart {
+    job_id: string;
+    total: number;
+    model: string;
+    mode: EmbeddingGenerationMode;
+}
+
+export interface EmbeddingGenerationProgress extends EmbeddingGenerationStart {
+    current: number;
+    status: 'running' | 'cancelling' | 'completed' | 'cancelled' | 'failed';
+    error?: string | null;
+}
+
+export async function startModelEmbeddingGeneration(
+    model: string,
+    imageIds: string[],
+    mode: EmbeddingGenerationMode,
+): Promise<EmbeddingGenerationStart> {
+    return invoke('start_model_embedding_generation', { model, imageIds, mode });
+}
+
 export interface EmbeddingPage {
     ids: string[];
     vectors: number[];

--- a/src/lib/components/EmbeddingExplorer.svelte
+++ b/src/lib/components/EmbeddingExplorer.svelte
@@ -30,7 +30,7 @@
         getEmbeddingModelDownloadInfo,
         listEmbeddingProviders,
         downloadEmbeddingModel,
-        generateModelEmbeddings,
+        startModelEmbeddingGeneration,
         hasApiKey,
         getImagesByIds,
         getGenerationRun,
@@ -39,7 +39,14 @@
         pauseJob,
         resumeJob,
     } from '$lib/api';
-    import type { EmbeddingModelDownloadInfo, EmbeddingPage, GenerationRun, ImageWithFile } from '$lib/api';
+    import type {
+        EmbeddingGenerationMode,
+        EmbeddingGenerationProgress,
+        EmbeddingModelDownloadInfo,
+        EmbeddingPage,
+        GenerationRun,
+        ImageWithFile,
+    } from '$lib/api';
     import { isAssetProtocolSafePath, safeAssetPreviewPath } from '$lib/view-utils';
     import { libraryScope, libraryScopeKey, type LibraryScope } from '$lib/library-scope';
     import {
@@ -52,8 +59,14 @@
 
     // State
     let downloading = $state(false);
-    let generating = $state(false);
-    let genProgress = $state({ current: 0, total: 0 });
+    type ActiveEmbeddingGeneration = EmbeddingGenerationProgress & {
+        provider: EmbeddingProvider;
+        scope: LibraryScope;
+        scopeKey: string;
+    };
+    let activeGeneration = $state<ActiveEmbeddingGeneration | null>(null);
+    let generationUnlisten: UnlistenFn | null = null;
+    let generating = $derived(activeGeneration?.status === 'running' || activeGeneration?.status === 'cancelling');
     let totalImages = $state(0);
     let regeneratingThumbs = $state(false);
     let staleEmbeddingCount = $state(0);
@@ -73,6 +86,7 @@
     let localModelDownloadInfo = $state<Record<LocalProvider, EmbeddingModelDownloadInfo | null>>({ clip: null, dinov2: null });
     let remoteEmbeddingCounts = $state<Record<RemoteProvider, number>>({ gemini: 0, cohere: 0, openai: 0, ollama: 0 });
     let currentEmbeddingCount = $derived(providerEmbeddingCount(selectedProvider));
+    let missingEmbeddingCount = $derived(Math.max(0, totalImages - currentEmbeddingCount));
     let selectedModel = $derived(modelOptions.find(option => option.id === selectedProvider) ?? modelOptions[0] ?? DEFAULT_MODEL_OPTIONS[0]);
     let selectedModelAvailable = $derived(providerReady(selectedProvider));
     let selectedDownloadInfo = $derived(isLocalProvider(selectedProvider) ? localModelDownloadInfo[selectedProvider] : null);
@@ -378,6 +392,8 @@
         })();
 
         return () => {
+            generationUnlisten?.();
+            generationUnlisten = null;
             resetProjectionWorker();
         };
     });
@@ -545,47 +561,102 @@
         saveViewState();
     }
 
-    async function generateForCurrentScope(modelName: string): Promise<number | null> {
-        const scope = get(libraryScope);
-        const requestedScopeKey = libraryScopeKey(scope);
-        const imageIds = await listImageIdsForScope(scope);
-        if (requestedScopeKey !== libraryScopeKey(get(libraryScope))) return null;
-        totalImages = imageIds.length;
-        await generateModelEmbeddings(modelName, imageIds);
-        if (requestedScopeKey !== libraryScopeKey(get(libraryScope))) return null;
-        const count = await getEmbeddingCountForScope(scope, modelName);
-        if (requestedScopeKey !== libraryScopeKey(get(libraryScope))) return null;
-        await loadProjection(scope);
-        if (requestedScopeKey !== libraryScopeKey(get(libraryScope))) return null;
-        return count;
-    }
-
-    async function handleGenerateRemote() {
-        if (!isRemoteProvider(selectedProvider)) return;
+    async function startGeneration(mode: EmbeddingGenerationMode) {
+        if (generating || !selectedModelAvailable) return;
         const provider = selectedProvider;
         const modelName = modelNameForProvider(provider);
-        generating = true;
-        genProgress = { current: 0, total: 0 };
-
-        const unlisten: UnlistenFn = await listen<{ current: number; total: number; provider: string; model?: string }>(
-            'embedding-progress',
-            (event) => {
-                if (event.payload.model && event.payload.model !== modelName) return;
-                genProgress = { current: event.payload.current, total: event.payload.total };
-            }
-        );
+        const scope = get(libraryScope);
+        const scopeKey = libraryScopeKey(scope);
+        activeGeneration = {
+            job_id: '',
+            total: mode === 'missing' ? missingEmbeddingCount : totalImages,
+            model: modelName,
+            mode,
+            current: 0,
+            status: 'running',
+            error: null,
+            provider,
+            scope,
+            scopeKey,
+        };
 
         try {
-            const count = await generateForCurrentScope(modelName);
-            if (count !== null) {
-                remoteEmbeddingCounts = { ...remoteEmbeddingCounts, [provider]: count };
+            const imageIds = await listImageIdsForScope(scope);
+            if (scopeKey !== libraryScopeKey(get(libraryScope))) {
+                activeGeneration = null;
+                return;
             }
-        } catch (e) {
-            console.error(`${provider} generate failed:`, e);
-        } finally {
-            unlisten();
-            generating = false;
+            totalImages = imageIds.length;
+
+            generationUnlisten?.();
+            generationUnlisten = await listen<EmbeddingGenerationProgress>('embedding-progress', event => {
+                const progress = event.payload;
+                const active = activeGeneration;
+                if (!active || progress.model !== modelName || progress.mode !== mode) return;
+                if (active.job_id && progress.job_id !== active.job_id) return;
+                activeGeneration = { ...active, ...progress };
+                if (progress.status === 'completed' || progress.status === 'cancelled' || progress.status === 'failed') {
+                    generationUnlisten?.();
+                    generationUnlisten = null;
+                    void refreshAfterGeneration({ ...active, ...progress });
+                }
+            });
+
+            const started = await startModelEmbeddingGeneration(modelName, imageIds, mode);
+            const active = activeGeneration;
+            if (!active) return;
+            if (!active.job_id || active.job_id === started.job_id) {
+                activeGeneration = { ...active, ...started };
+            }
+            if (started.total === 0) {
+                activeGeneration = { ...activeGeneration!, status: 'completed', current: 0 };
+                generationUnlisten?.();
+                generationUnlisten = null;
+                await refreshAfterGeneration(activeGeneration);
+            }
+        } catch (error) {
+            generationUnlisten?.();
+            generationUnlisten = null;
+            const message = error instanceof Error ? error.message : String(error);
+            if (activeGeneration) activeGeneration = { ...activeGeneration, status: 'failed', error: message };
         }
+    }
+
+    async function refreshAfterGeneration(generation: ActiveEmbeddingGeneration) {
+        if (generation.scopeKey !== libraryScopeKey(get(libraryScope))) return;
+        try {
+            const count = await getEmbeddingCountForScope(generation.scope, generation.model);
+            if (generation.scopeKey !== libraryScopeKey(get(libraryScope))) return;
+            if (isLocalProvider(generation.provider)) {
+                localEmbeddingCounts = { ...localEmbeddingCounts, [generation.provider]: count };
+            } else {
+                remoteEmbeddingCounts = { ...remoteEmbeddingCounts, [generation.provider]: count };
+            }
+            if (modelNameForProvider(selectedProvider) === generation.model) {
+                await loadProjection(generation.scope);
+            }
+        } catch (error) {
+            console.error('Failed to refresh embedding state after generation:', error);
+        }
+    }
+
+    async function cancelGeneration() {
+        const generation = activeGeneration;
+        if (!generation?.job_id || generation.status !== 'running') return;
+        activeGeneration = { ...generation, status: 'cancelling' };
+        try {
+            await cancelJob(generation.job_id);
+        } catch (error) {
+            activeGeneration = {
+                ...generation,
+                status: 'failed',
+                error: error instanceof Error ? error.message : String(error),
+            };
+        }
+    }
+
+    function generationModelLabel(model: string): string {
+        return modelOptions.find(option => option.modelName === model)?.shortLabel ?? model;
     }
 
     async function handleDownload() {
@@ -640,34 +711,6 @@
         if (!downloadJobId) return;
         await cancelJob(downloadJobId);
         downloadProgress = { ...downloadProgress, status: 'cancelled' };
-    }
-
-    async function handleGenerate() {
-        if (!isLocalProvider(selectedProvider)) return;
-        const provider = selectedProvider;
-        const modelName = modelNameForProvider(provider);
-        generating = true;
-        genProgress = { current: 0, total: 0 };
-
-        const unlisten: UnlistenFn = await listen<{ current: number; total: number; model?: string }>(
-            'embedding-progress',
-            (event) => {
-                if (event.payload.model && event.payload.model !== modelName) return;
-                genProgress = { current: event.payload.current, total: event.payload.total };
-            }
-        );
-
-        try {
-            const count = await generateForCurrentScope(modelName);
-            if (count !== null) {
-                localEmbeddingCounts = { ...localEmbeddingCounts, [provider]: count };
-            }
-        } catch (e) {
-            console.error('Generate failed:', e);
-        } finally {
-            unlisten();
-            generating = false;
-        }
     }
 
     async function handleRegenerateThumbnails() {
@@ -1973,8 +2016,7 @@
             </div>
         </div>
 
-        {#if isLocalProvider(selectedProvider)}
-            {#if !selectedModelAvailable}
+        {#if isLocalProvider(selectedProvider) && !selectedModelAvailable}
                 <div class="panel-section">
                     {#if downloading}
                         <div class="download-progress">
@@ -2051,52 +2093,84 @@
                         {/if}
                     </div>
                 </div>
-            {:else}
-                <div class="panel-section">
-                    <div class="stat-row">
-                        <span class="stat-label">Images</span>
-                        <span class="stat-value">{totalImages}</span>
-                    </div>
-                    <div class="stat-row">
-                        <span class="stat-label">Embeddings</span>
-                        <span class="stat-value">{currentEmbeddingCount}</span>
-                    </div>
+        {:else}
+            <div class="panel-section">
+                <div class="stat-row">
+                    <span class="stat-label">Images</span>
+                    <span class="stat-value">{totalImages}</span>
+                </div>
+                <div class="stat-row">
+                    <span class="stat-label">Embeddings</span>
+                    <span class="stat-value">{currentEmbeddingCount}</span>
+                </div>
+                <div class="stat-row">
+                    <span class="stat-label">Need embeddings</span>
+                    <span class="stat-value">{missingEmbeddingCount}</span>
+                </div>
+                {#if isLocalProvider(selectedProvider)}
                     <div class="stat-row">
                         <span class="stat-label">Model</span>
                         <span class="stat-value">{selectedModel.dims}</span>
                     </div>
-                    <button class="action-btn" onclick={handleGenerate} disabled={generating}>
-                        {#if generating}
-                            Generating {genProgress.current}/{genProgress.total}...
-                        {:else if currentEmbeddingCount < totalImages}
-                            Generate Embeddings ({Math.max(0, totalImages - currentEmbeddingCount)} remaining)
-                        {:else}
-                            Regenerate All
-                        {/if}
+                {/if}
+                <div class="generation-actions">
+                    <button
+                        class="action-btn"
+                        onclick={() => startGeneration('missing')}
+                        disabled={generating || !selectedModelAvailable || missingEmbeddingCount === 0}
+                        title={selectedModelAvailable ? '' : providerStatusLabel(selectedProvider)}
+                    >
+                        {missingEmbeddingCount === 0 ? 'Up to date' : `Generate missing (${missingEmbeddingCount})`}
+                    </button>
+                    <button
+                        class="action-btn secondary"
+                        onclick={() => startGeneration('all')}
+                        disabled={generating || !selectedModelAvailable || totalImages === 0}
+                        title={selectedModelAvailable ? '' : providerStatusLabel(selectedProvider)}
+                    >
+                        Regenerate all ({totalImages})
                     </button>
                 </div>
-            {/if}
-	        {:else}
-	            <div class="panel-section">
-	                <div class="stat-row">
-	                    <span class="stat-label">Images</span>
-	                    <span class="stat-value">{totalImages}</span>
-	                </div>
-	                <div class="stat-row">
-	                    <span class="stat-label">Embeddings</span>
-	                    <span class="stat-value">{currentEmbeddingCount}</span>
-	                </div>
-	                <button class="action-btn" onclick={handleGenerateRemote} disabled={generating || !selectedModelAvailable} title={selectedModelAvailable ? '' : providerStatusLabel(selectedProvider)}>
-	                    {#if generating}
-	                        Generating {genProgress.current}/{genProgress.total}...
-	                    {:else if !selectedModelAvailable}
-	                        {selectedProvider === 'ollama' ? 'Start Ollama First' : 'Set API Key First'}
-	                    {:else if currentEmbeddingCount < totalImages}
-	                        Generate Embeddings ({Math.max(0, totalImages - currentEmbeddingCount)} remaining)
-	                    {:else}
-	                        Regenerate All
-	                    {/if}
-                </button>
+            </div>
+        {/if}
+
+        {#if activeGeneration}
+            <div class="panel-section generation-status" aria-live="polite">
+                <div class="section-header">{generationModelLabel(activeGeneration.model).toUpperCase()} GENERATION</div>
+                {#if activeGeneration.status === 'running' || activeGeneration.status === 'cancelling'}
+                    <div class="progress-text">{activeGeneration.current}/{activeGeneration.total} images</div>
+                    <div
+                        class="progress-bar-track"
+                        role="progressbar"
+                        aria-label="{generationModelLabel(activeGeneration.model)} embedding progress"
+                        aria-valuemin="0"
+                        aria-valuenow={activeGeneration.current}
+                        aria-valuemax={Math.max(1, activeGeneration.total)}
+                    >
+                        <div
+                            class="progress-bar-fill"
+                            style="width: {activeGeneration.total > 0 ? (activeGeneration.current / activeGeneration.total) * 100 : 0}%"
+                        ></div>
+                    </div>
+                    <button
+                        class="action-btn secondary"
+                        onclick={cancelGeneration}
+                        disabled={!activeGeneration.job_id || activeGeneration.status === 'cancelling'}
+                        aria-label={!activeGeneration.job_id
+                            ? 'Starting embedding generation'
+                            : activeGeneration.status === 'cancelling'
+                                ? 'Cancelling embedding generation'
+                                : 'Cancel embedding generation'}
+                    >
+                        {!activeGeneration.job_id ? 'Starting…' : activeGeneration.status === 'cancelling' ? 'Cancelling…' : 'Cancel'}
+                    </button>
+                {:else if activeGeneration.status === 'completed'}
+                    <div class="generation-result">Generation completed: {activeGeneration.current}/{activeGeneration.total}</div>
+                {:else if activeGeneration.status === 'cancelled'}
+                    <div class="generation-result">Generation cancelled at {activeGeneration.current}/{activeGeneration.total}</div>
+                {:else}
+                    <div class="generation-result error">Generation failed{activeGeneration.error ? `: ${activeGeneration.error}` : ''}</div>
+                {/if}
             </div>
         {/if}
 
@@ -2492,6 +2566,39 @@
     .action-btn.small {
         font-size: 10px;
         padding: 4px 8px;
+    }
+
+    .generation-actions {
+        display: grid;
+        gap: var(--spacing);
+    }
+
+    .action-btn.secondary {
+        background: var(--surface);
+        color: var(--text-secondary);
+    }
+
+    .action-btn.secondary:hover:not(:disabled) {
+        color: var(--text);
+        border-color: var(--text-secondary);
+    }
+
+    .generation-status {
+        display: grid;
+        gap: var(--spacing);
+    }
+
+    .generation-status .action-btn {
+        margin-top: 0;
+    }
+
+    .generation-result {
+        color: var(--text);
+        font-size: 10px;
+    }
+
+    .generation-result.error {
+        color: var(--red);
     }
 
     .visual-embed-section {

--- a/src/lib/components/EmbeddingExplorer.svelte
+++ b/src/lib/components/EmbeddingExplorer.svelte
@@ -581,6 +581,7 @@
         };
 
         try {
+            const pendingProgress = new Map<string, EmbeddingGenerationProgress>();
             const imageIds = await listImageIdsForScope(scope);
             if (scopeKey !== libraryScopeKey(get(libraryScope))) {
                 activeGeneration = null;
@@ -593,7 +594,11 @@
                 const progress = event.payload;
                 const active = activeGeneration;
                 if (!active || progress.model !== modelName || progress.mode !== mode) return;
-                if (active.job_id && progress.job_id !== active.job_id) return;
+                if (!active.job_id) {
+                    pendingProgress.set(progress.job_id, progress);
+                    return;
+                }
+                if (progress.job_id !== active.job_id) return;
                 activeGeneration = { ...active, ...progress };
                 if (progress.status === 'completed' || progress.status === 'cancelled' || progress.status === 'failed') {
                     generationUnlisten?.();
@@ -605,8 +610,17 @@
             const started = await startModelEmbeddingGeneration(modelName, imageIds, mode);
             const active = activeGeneration;
             if (!active) return;
-            if (!active.job_id || active.job_id === started.job_id) {
-                activeGeneration = { ...active, ...started };
+            const bufferedProgress = pendingProgress.get(started.job_id);
+            activeGeneration = { ...active, ...started, ...bufferedProgress };
+            if (bufferedProgress && (
+                bufferedProgress.status === 'completed'
+                || bufferedProgress.status === 'cancelled'
+                || bufferedProgress.status === 'failed'
+            )) {
+                generationUnlisten?.();
+                generationUnlisten = null;
+                await refreshAfterGeneration(activeGeneration);
+                return;
             }
             if (started.total === 0) {
                 activeGeneration = { ...activeGeneration!, status: 'completed', current: 0 };

--- a/src/lib/components/embedding-explorer-scope.behavior.test.ts
+++ b/src/lib/components/embedding-explorer-scope.behavior.test.ts
@@ -11,13 +11,23 @@ const mocks = vi.hoisted(() => ({
     getImageCountForScope: vi.fn(),
     listImageIdsForScope: vi.fn(),
     getImagesByIds: vi.fn(),
-    generateModelEmbeddings: vi.fn(),
+    startModelEmbeddingGeneration: vi.fn(),
+    cancelJob: vi.fn(),
     loadEmbeddingNeighbors: vi.fn(),
+    eventListeners: new Map<string, Set<(event: { payload: Record<string, unknown> }) => void>>(),
     workerMessages: [] as Array<Record<string, unknown>>,
 }));
 
 vi.mock('@tauri-apps/api/event', () => ({
-    listen: vi.fn().mockResolvedValue(vi.fn()),
+    listen: vi.fn().mockImplementation(async (
+        eventName: string,
+        callback: (event: { payload: Record<string, unknown> }) => void,
+    ) => {
+        const listeners = mocks.eventListeners.get(eventName) ?? new Set();
+        listeners.add(callback);
+        mocks.eventListeners.set(eventName, listeners);
+        return () => listeners.delete(callback);
+    }),
 }));
 
 vi.mock('@tauri-apps/api/core', () => ({
@@ -47,12 +57,12 @@ vi.mock('$lib/api', () => ({
     getEmbeddingModelDownloadInfo: vi.fn().mockResolvedValue(null),
     listEmbeddingProviders: vi.fn().mockResolvedValue([]),
     downloadEmbeddingModel: vi.fn(),
-    generateModelEmbeddings: mocks.generateModelEmbeddings,
+    startModelEmbeddingGeneration: mocks.startModelEmbeddingGeneration,
     hasApiKey: vi.fn().mockResolvedValue(false),
     getImagesByIds: mocks.getImagesByIds,
     getGenerationRun: vi.fn().mockResolvedValue(null),
     regenerateThumbnails: vi.fn(),
-    cancelJob: vi.fn(),
+    cancelJob: mocks.cancelJob,
     pauseJob: vi.fn(),
     resumeJob: vi.fn(),
 }));
@@ -66,6 +76,7 @@ import {
     importBatchFilter,
     minSizeFilter,
     showRejected,
+    embeddingViewState,
     focusedImageOverride,
     viewMode,
 } from '$lib/stores';
@@ -132,10 +143,16 @@ function image(id: string) {
     };
 }
 
+function emit(eventName: string, payload: Record<string, unknown>) {
+    for (const listener of mocks.eventListeners.get(eventName) ?? []) listener({ payload });
+}
+
 afterEach(() => cleanup());
 
 beforeEach(() => {
     vi.clearAllMocks();
+    localStorage.clear();
+    mocks.eventListeners.clear();
     mocks.workerMessages.length = 0;
     activeFolder.set('/photos/scoped');
     activeCollection.set(null);
@@ -144,6 +161,7 @@ beforeEach(() => {
     importBatchFilter.set(null);
     minSizeFilter.set(512);
     showRejected.set(false);
+    embeddingViewState.update(state => ({ ...state, provider: 'clip' }));
     focusedImageOverride.set(null);
     viewMode.set('grid');
 
@@ -160,7 +178,12 @@ beforeEach(() => {
         has_more: false,
     });
     mocks.getImagesByIds.mockResolvedValue([image('in-b'), image('in-a')]);
-    mocks.generateModelEmbeddings.mockResolvedValue(2);
+    mocks.startModelEmbeddingGeneration.mockResolvedValue({
+        job_id: 'job_embed_1',
+        total: 1,
+        model: 'clip-vit-b32',
+        mode: 'missing',
+    });
     mocks.loadEmbeddingNeighbors.mockResolvedValue([
         { image: image('near-one'), score: 0.934 },
     ]);
@@ -224,21 +247,67 @@ describe('Embedding Explorer library scope', () => {
         ));
     });
 
-    it('does not let generation from an old scope overwrite the newly selected scope', async () => {
-        let finishGeneration!: () => void;
-        mocks.generateModelEmbeddings.mockImplementation(
-            () => new Promise<number>(resolve => {
-                finishGeneration = () => resolve(2);
-            }),
+    it('offers missing and full regeneration, reports job progress, and cancels the exact job', async () => {
+        mocks.getEmbeddingCountForScope.mockResolvedValue(1);
+        const user = userEvent.setup();
+        render(EmbeddingExplorer);
+
+        await user.click(await screen.findByRole('button', { name: 'Generate missing (1)' }));
+        await waitFor(() => expect(mocks.startModelEmbeddingGeneration).toHaveBeenCalledWith(
+            'clip-vit-b32',
+            ['in-a', 'in-b'],
+            'missing',
+        ));
+
+        emit('embedding-progress', {
+            job_id: 'job_embed_1',
+            model: 'clip-vit-b32',
+            mode: 'missing',
+            status: 'running',
+            current: 1,
+            total: 2,
+        });
+        const progress = await screen.findByRole('progressbar', { name: 'CLIP embedding progress' });
+        expect(progress).toHaveAttribute('aria-valuenow', '1');
+        expect(progress).toHaveAttribute('aria-valuemax', '2');
+
+        await user.click(screen.getByRole('button', { name: 'Cancel embedding generation' }));
+        expect(mocks.cancelJob).toHaveBeenCalledWith('job_embed_1');
+        expect(screen.getByRole('button', { name: 'Cancelling embedding generation' })).toBeDisabled();
+
+        emit('embedding-progress', {
+            job_id: 'job_embed_1',
+            model: 'clip-vit-b32',
+            mode: 'missing',
+            status: 'cancelled',
+            current: 1,
+            total: 2,
+        });
+        await waitFor(() => expect(screen.getByText('Generation cancelled at 1/2')).toBeInTheDocument());
+
+        mocks.startModelEmbeddingGeneration.mockResolvedValue({
+            job_id: 'job_embed_2',
+            total: 2,
+            model: 'clip-vit-b32',
+            mode: 'all',
+        });
+        await user.click(screen.getByRole('button', { name: 'Regenerate all (2)' }));
+        expect(mocks.startModelEmbeddingGeneration).toHaveBeenLastCalledWith(
+            'clip-vit-b32',
+            ['in-a', 'in-b'],
+            'all',
         );
+    });
+
+    it('does not let generation from an old scope overwrite the newly selected scope', async () => {
         mocks.getEmbeddingCountForScope.mockImplementation(
             (scope: { type: string }) => Promise.resolve(scope.type === 'collection' ? 0 : 1),
         );
 
         const user = userEvent.setup();
         const { container } = render(EmbeddingExplorer);
-        await user.click(await screen.findByRole('button', { name: /Generate Embeddings/ }));
-        await waitFor(() => expect(mocks.generateModelEmbeddings).toHaveBeenCalledOnce());
+        await user.click(await screen.findByRole('button', { name: 'Generate missing (1)' }));
+        await waitFor(() => expect(mocks.startModelEmbeddingGeneration).toHaveBeenCalledOnce());
 
         activeCollection.set('new-collection');
         await waitFor(() => {
@@ -247,12 +316,46 @@ describe('Embedding Explorer library scope', () => {
             expect(embeddingRow?.querySelector('.stat-value')).toHaveTextContent('0');
         });
 
-        finishGeneration();
-        await waitFor(() => expect(screen.getByRole('button', { name: /Generate Embeddings/ }))
-            .not.toBeDisabled());
+        emit('embedding-progress', {
+            job_id: 'job_embed_1',
+            model: 'clip-vit-b32',
+            mode: 'missing',
+            status: 'completed',
+            current: 1,
+            total: 1,
+        });
+        await waitFor(() => expect(screen.getByText('Generation completed: 1/1')).toBeInTheDocument());
         const embeddingRow = [...container.querySelectorAll('.stat-row')]
             .find(row => row.querySelector('.stat-label')?.textContent === 'Embeddings');
         expect(embeddingRow?.querySelector('.stat-value')).toHaveTextContent('0');
+    });
+
+    it('keeps an active job attributed to its model while another model shows its own missing count', async () => {
+        mocks.getEmbeddingCountForScope.mockImplementation(
+            (_scope: unknown, model: string) => Promise.resolve(model === 'clip-vit-b32' ? 1 : 0),
+        );
+        const user = userEvent.setup();
+        const { container } = render(EmbeddingExplorer);
+
+        await user.click(await screen.findByRole('button', { name: 'Generate missing (1)' }));
+        await waitFor(() => expect(mocks.startModelEmbeddingGeneration).toHaveBeenCalledOnce());
+        emit('embedding-progress', {
+            job_id: 'job_embed_1',
+            model: 'clip-vit-b32',
+            mode: 'missing',
+            status: 'running',
+            current: 1,
+            total: 2,
+        });
+
+        await user.click(screen.getByRole('radio', { name: /DINOv2/i }));
+        await waitFor(() => {
+            const missingRow = [...container.querySelectorAll('.stat-row')]
+                .find(row => row.querySelector('.stat-label')?.textContent === 'Need embeddings');
+            expect(missingRow?.querySelector('.stat-value')).toHaveTextContent('2');
+        });
+        expect(screen.getByText('CLIP GENERATION')).toBeInTheDocument();
+        expect(screen.getByRole('progressbar', { name: 'CLIP embedding progress' })).toHaveAttribute('aria-valuenow', '1');
     });
 
     it('loads ranked neighbors for the selected point in the current scope', async () => {

--- a/src/lib/components/embedding-explorer-scope.behavior.test.ts
+++ b/src/lib/components/embedding-explorer-scope.behavior.test.ts
@@ -299,6 +299,42 @@ describe('Embedding Explorer library scope', () => {
         );
     });
 
+    it('ignores unrelated progress before the start response identifies its job', async () => {
+        mocks.getEmbeddingCountForScope.mockResolvedValue(1);
+        let resolveStart!: (value: {
+            job_id: string;
+            total: number;
+            model: string;
+            mode: 'missing';
+        }) => void;
+        mocks.startModelEmbeddingGeneration.mockReturnValue(new Promise(resolve => {
+            resolveStart = resolve;
+        }));
+        const user = userEvent.setup();
+        render(EmbeddingExplorer);
+
+        await user.click(await screen.findByRole('button', { name: 'Generate missing (1)' }));
+        await waitFor(() => expect(mocks.startModelEmbeddingGeneration).toHaveBeenCalledOnce());
+        emit('embedding-progress', {
+            job_id: 'job_unrelated',
+            model: 'clip-vit-b32',
+            mode: 'missing',
+            status: 'running',
+            current: 1,
+            total: 9,
+        });
+        resolveStart({
+            job_id: 'job_embed_ours',
+            total: 1,
+            model: 'clip-vit-b32',
+            mode: 'missing',
+        });
+
+        await user.click(await screen.findByRole('button', { name: 'Cancel embedding generation' }));
+        expect(mocks.cancelJob).toHaveBeenCalledWith('job_embed_ours');
+        expect(mocks.cancelJob).not.toHaveBeenCalledWith('job_unrelated');
+    });
+
     it('does not let generation from an old scope overwrite the newly selected scope', async () => {
         mocks.getEmbeddingCountForScope.mockImplementation(
             (scope: { type: string }) => Promise.resolve(scope.type === 'collection' ? 0 : 1),


### PR DESCRIPTION
## Summary
- add separate Generate missing and Regenerate all actions for the active library scope and model
- run embedding generation as a tracked cancellable background job with job-scoped accessible progress
- harden panic, late-cancel, async blocking, terminal event, and model-run audit recovery paths

## Validation
- npm run check (0 errors, 0 warnings; existing nested-site config notice)
- full Vitest suite passed
- focused Explorer and Tauri contract tests: 14 passed
- cargo fmt --all -- --check
- cargo test --lib: 827 passed, 3 ignored
- cargo test --all-targets passed
- npm run build
- Spec review: PASS
- Standards/code-smell review: PASS

Closes imageview-lzw