### PR TITLE
feat: compact embedding provider settings

### DIFF
--- a/src/lib/components/EmbeddingExplorer.svelte
+++ b/src/lib/components/EmbeddingExplorer.svelte
@@ -32,6 +32,10 @@
         downloadEmbeddingModel,
         startModelEmbeddingGeneration,
         hasApiKey,
+        setApiKey,
+        validateApiKey,
+        getOllamaEmbeddingConfig,
+        setOllamaEmbeddingConfig,
         getImagesByIds,
         getGenerationRun,
         regenerateThumbnails,
@@ -81,6 +85,11 @@
     let hasCohereKey = $state(false);
     let hasOpenAiKey = $state(false);
     let ollamaEmbeddingReady = $state(false);
+    let providerKeyInput = $state('');
+    let providerConfigStatus = $state<'idle' | 'loading' | 'saving' | 'saved' | 'invalid' | 'error'>('idle');
+    let providerConfigLoadSeq = 0;
+    let ollamaEmbeddingUrl = $state('http://localhost:11434/api/embed');
+    let ollamaEmbeddingModel = $state('embeddinggemma');
     let localModelAvailable = $state<Record<LocalProvider, boolean>>({ clip: false, dinov2: false });
     let localEmbeddingCounts = $state<Record<LocalProvider, number>>({ clip: 0, dinov2: 0 });
     let localModelDownloadInfo = $state<Record<LocalProvider, EmbeddingModelDownloadInfo | null>>({ clip: null, dinov2: null });
@@ -358,8 +367,99 @@
 
     async function selectProvider(provider: EmbeddingProvider) {
         if (provider === selectedProvider) return;
+        providerConfigLoadSeq += 1;
+        providerKeyInput = '';
+        providerConfigStatus = 'idle';
         selectedProvider = provider;
         await handleProviderChange();
+        if (configOpen) await loadSelectedProviderConfig();
+    }
+
+    function handleProviderSelection(event: Event) {
+        const provider = (event.currentTarget as HTMLSelectElement).value as EmbeddingProvider;
+        void selectProvider(provider);
+    }
+
+    function embeddingApiKeyProvider(provider: EmbeddingProvider): 'google' | 'cohere' | 'openai' | null {
+        if (provider === 'gemini') return 'google';
+        if (provider === 'cohere' || provider === 'openai') return provider;
+        return null;
+    }
+
+    async function toggleEmbeddingConfig() {
+        configOpen = !configOpen;
+        if (configOpen) {
+            await loadSelectedProviderConfig();
+        } else {
+            providerConfigLoadSeq += 1;
+            providerKeyInput = '';
+            providerConfigStatus = 'idle';
+        }
+    }
+
+    async function loadSelectedProviderConfig() {
+        const provider = selectedProvider;
+        const requestSeq = ++providerConfigLoadSeq;
+        providerKeyInput = '';
+        providerConfigStatus = provider === 'ollama' ? 'loading' : 'idle';
+        if (provider !== 'ollama') return;
+        try {
+            const [url, model] = await getOllamaEmbeddingConfig();
+            if (requestSeq !== providerConfigLoadSeq || !configOpen || selectedProvider !== provider) return;
+            ollamaEmbeddingUrl = url;
+            ollamaEmbeddingModel = model;
+            providerConfigStatus = 'idle';
+        } catch {
+            if (requestSeq !== providerConfigLoadSeq || !configOpen || selectedProvider !== provider) return;
+            providerConfigStatus = 'error';
+        }
+    }
+
+    async function saveSelectedProviderConfig() {
+        const provider = selectedProvider;
+        const requestSeq = providerConfigLoadSeq;
+        providerConfigStatus = 'saving';
+        try {
+            if (provider === 'ollama') {
+                const url = ollamaEmbeddingUrl.trim() || 'http://localhost:11434/api/embed';
+                const model = ollamaEmbeddingModel.trim() || 'embeddinggemma';
+                ollamaEmbeddingUrl = url;
+                ollamaEmbeddingModel = model;
+                await setOllamaEmbeddingConfig(
+                    url,
+                    model,
+                );
+                await loadProviderOptions();
+                if (selectedProvider === provider) await loadEmbeddingState();
+                if (selectedProvider !== provider) return;
+                providerConfigStatus = 'saved';
+                return;
+            }
+
+            const apiProvider = embeddingApiKeyProvider(provider);
+            const key = providerKeyInput.trim();
+            if (!apiProvider || !key) {
+                providerConfigStatus = 'invalid';
+                return;
+            }
+            const valid = await validateApiKey(apiProvider, key);
+            if (requestSeq !== providerConfigLoadSeq || selectedProvider !== provider) return;
+            if (!valid) {
+                providerConfigStatus = 'invalid';
+                return;
+            }
+            await setApiKey(apiProvider, key);
+            if (apiProvider === 'google') hasGoogleKey = true;
+            if (apiProvider === 'cohere') hasCohereKey = true;
+            if (apiProvider === 'openai') hasOpenAiKey = true;
+            await loadProviderOptions();
+            if (selectedProvider !== provider) return;
+            providerKeyInput = '';
+            providerConfigStatus = 'saved';
+        } catch {
+            if (selectedProvider !== provider) return;
+            providerConfigStatus = 'error';
+        }
     }
 
     function restoreInteractionState(savedState: Partial<EmbeddingViewState>) {
@@ -1830,46 +1930,83 @@
         <div class="panel-section">
             <div class="section-header-row">
                 <div class="section-header">MODEL</div>
-                <button class="gear-btn" onclick={() => configOpen = !configOpen} title="Settings">
+                <button
+                    class="gear-btn"
+                    onclick={toggleEmbeddingConfig}
+                    aria-label={configOpen ? 'Close embedding configuration' : 'Configure embedding model'}
+                    aria-expanded={configOpen}
+                    title={configOpen ? 'Close configuration' : 'Configure embedding model'}
+                >
                     &#9881;
                 </button>
             </div>
-            <div class="model-list" role="radiogroup" aria-label="Embedding model">
-                {#each modelOptions as option}
-                    <button
-                        class="model-option"
-                        class:active={selectedProvider === option.id}
-                        onclick={() => selectProvider(option.id)}
-                        role="radio"
-                        aria-checked={selectedProvider === option.id}
-                        title={option.label}
-                    >
-                        <span class="model-option-main">
-                            <span class="model-name">{option.shortLabel}</span>
-                            <span class="model-count">{providerEmbeddingCount(option.id)}/{totalImages}</span>
-                        </span>
-                        <span class="model-option-meta">
-                            <span>{option.scope}</span>
-                            <span>{option.dims}</span>
-                            <span class:ready={providerReady(option.id)}>{providerStatusLabel(option.id)}</span>
-                        </span>
-                    </button>
-                {/each}
+            <div class="model-summary">
+                <span class="model-summary-name">{selectedModel.label}</span>
+                <span class="model-summary-count">{currentEmbeddingCount}/{totalImages} images embedded</span>
             </div>
+
+            {#if configOpen}
+                <label class="provider-config-row" for="embedding-provider">
+                    <span>Provider</span>
+                    <select
+                        id="embedding-provider"
+                        class="provider-select"
+                        value={selectedProvider}
+                        onchange={handleProviderSelection}
+                        aria-label="Embedding provider"
+                    >
+                        {#each modelOptions as option}
+                            <option value={option.id}>{option.label}</option>
+                        {/each}
+                    </select>
+                </label>
+                <div class="provider-config-meta">
+                    <span>{selectedModel.scope}</span>
+                    <span>{selectedModel.dims}</span>
+                    <span class:ready={selectedModelAvailable}>{providerStatusLabel(selectedProvider)}</span>
+                </div>
+            {/if}
         </div>
 
-        {#if configOpen && ((selectedProvider === 'gemini' && !hasGoogleKey) || (selectedProvider === 'cohere' && !hasCohereKey) || (selectedProvider === 'openai' && !hasOpenAiKey) || (selectedProvider === 'ollama' && !ollamaEmbeddingReady))}
+        {#if configOpen && !isLocalProvider(selectedProvider)}
             <div class="panel-section config-section">
                 {#if selectedProvider === 'ollama'}
-                    <div class="section-header">OLLAMA EMBEDDINGS OFFLINE</div>
-                    <p class="key-missing-text">Start Ollama and pull an embedding model such as embeddinggemma.</p>
+                    <div class="section-header">OLLAMA EMBEDDINGS</div>
+                    <label class="provider-field">
+                        <span>URL</span>
+                        <input aria-label="Ollama embedding URL" bind:value={ollamaEmbeddingUrl} disabled={providerConfigStatus === 'loading'} />
+                    </label>
+                    <label class="provider-field">
+                        <span>Model</span>
+                        <input aria-label="Ollama embedding model" bind:value={ollamaEmbeddingModel} disabled={providerConfigStatus === 'loading'} />
+                    </label>
                 {:else}
-                    <div class="section-header">{selectedModel.shortLabel.toUpperCase()} API KEY REQUIRED</div>
-                    <p class="key-missing-text">Set your {selectedModel.shortLabel} API key in Settings.</p>
-                    <button class="settings-link-btn" onclick={() => openSettings('ai')}>
-                        Open Settings
-                    </button>
+                    <div class="section-header">{selectedModel.shortLabel.toUpperCase()} CREDENTIALS</div>
+                    <label class="provider-field">
+                        <span>API key</span>
+                        <input
+                            type="password"
+                            aria-label="{selectedModel.shortLabel} API key"
+                            placeholder={selectedModelAvailable ? 'Connected · enter to replace' : 'Enter API key'}
+                            bind:value={providerKeyInput}
+                        />
+                    </label>
                 {/if}
+                <button
+                    class="settings-link-btn"
+                    onclick={saveSelectedProviderConfig}
+                    disabled={providerConfigStatus === 'loading' || providerConfigStatus === 'saving'}
+                >
+                    {providerConfigStatus === 'loading' ? 'Loading…' : providerConfigStatus === 'saving' ? 'Saving…' : selectedProvider === 'ollama' ? 'Save Ollama config' : 'Save API key'}
+                </button>
+                {#if providerConfigStatus === 'saved'}
+                    <p class="provider-config-message ready" role="status">Configuration saved.</p>
+                {:else if providerConfigStatus === 'invalid'}
+                    <p class="provider-config-message error" role="alert">Enter a valid API key.</p>
+                {:else if providerConfigStatus === 'error'}
+                    <p class="provider-config-message error" role="alert">Could not save provider configuration.</p>
+                {/if}
+                <button class="settings-link-btn secondary-link" onclick={() => openSettings('ai')}>More AI settings</button>
             </div>
         {/if}
 
@@ -2031,6 +2168,7 @@
         </div>
 
         {#if isLocalProvider(selectedProvider) && !selectedModelAvailable}
+            {#if configOpen}
                 <div class="panel-section">
                     {#if downloading}
                         <div class="download-progress">
@@ -2107,25 +2245,28 @@
                         {/if}
                     </div>
                 </div>
+            {/if}
         {:else}
             <div class="panel-section">
-                <div class="stat-row">
-                    <span class="stat-label">Images</span>
-                    <span class="stat-value">{totalImages}</span>
-                </div>
-                <div class="stat-row">
-                    <span class="stat-label">Embeddings</span>
-                    <span class="stat-value">{currentEmbeddingCount}</span>
-                </div>
-                <div class="stat-row">
-                    <span class="stat-label">Need embeddings</span>
-                    <span class="stat-value">{missingEmbeddingCount}</span>
-                </div>
-                {#if isLocalProvider(selectedProvider)}
+                {#if configOpen}
                     <div class="stat-row">
-                        <span class="stat-label">Model</span>
-                        <span class="stat-value">{selectedModel.dims}</span>
+                        <span class="stat-label">Images</span>
+                        <span class="stat-value">{totalImages}</span>
                     </div>
+                    <div class="stat-row">
+                        <span class="stat-label">Embeddings</span>
+                        <span class="stat-value">{currentEmbeddingCount}</span>
+                    </div>
+                    <div class="stat-row">
+                        <span class="stat-label">Need embeddings</span>
+                        <span class="stat-value">{missingEmbeddingCount}</span>
+                    </div>
+                    {#if isLocalProvider(selectedProvider)}
+                        <div class="stat-row">
+                            <span class="stat-label">Model</span>
+                            <span class="stat-value">{selectedModel.dims}</span>
+                        </div>
+                    {/if}
                 {/if}
                 <div class="generation-actions">
                     <button
@@ -2136,14 +2277,16 @@
                     >
                         {missingEmbeddingCount === 0 ? 'Up to date' : `Generate missing (${missingEmbeddingCount})`}
                     </button>
-                    <button
-                        class="action-btn secondary"
-                        onclick={() => startGeneration('all')}
-                        disabled={generating || !selectedModelAvailable || totalImages === 0}
-                        title={selectedModelAvailable ? '' : providerStatusLabel(selectedProvider)}
-                    >
-                        Regenerate all ({totalImages})
-                    </button>
+                    {#if configOpen}
+                        <button
+                            class="action-btn secondary"
+                            onclick={() => startGeneration('all')}
+                            disabled={generating || !selectedModelAvailable || totalImages === 0}
+                            title={selectedModelAvailable ? '' : providerStatusLabel(selectedProvider)}
+                        >
+                            Regenerate all ({totalImages})
+                        </button>
+                    {/if}
                 </div>
             </div>
         {/if}
@@ -2464,46 +2607,12 @@
         margin-bottom: 8px;
     }
 
-    .model-list {
+    .model-summary {
         display: grid;
-        gap: 5px;
+        gap: 4px;
     }
 
-    .model-option {
-        display: grid;
-        gap: 3px;
-        width: 100%;
-        min-height: 46px;
-        padding: 7px 8px;
-        background: var(--bg);
-        color: var(--text-secondary);
-        border: 1px solid var(--border);
-        border-radius: var(--radius);
-        font-family: var(--font);
-        cursor: pointer;
-        text-align: left;
-        transition: border-color 0.15s, background 0.15s, color 0.15s;
-    }
-
-    .model-option:hover {
-        border-color: var(--blue);
-        color: var(--text);
-    }
-
-    .model-option.active {
-        background: color-mix(in srgb, var(--blue) 12%, var(--bg));
-        border-color: var(--blue);
-        color: var(--text);
-    }
-
-    .model-option-main,
-    .model-option-meta {
-        display: flex;
-        align-items: center;
-        min-width: 0;
-    }
-
-    .model-name {
+    .model-summary-name {
         min-width: 0;
         overflow: hidden;
         text-overflow: ellipsis;
@@ -2513,27 +2622,28 @@
         color: var(--text);
     }
 
-    .model-count {
-        margin-left: auto;
-        flex-shrink: 0;
+    .model-summary-count {
         font-size: 10px;
         color: var(--text-secondary);
     }
 
-    .model-option-meta {
-        gap: 6px;
-        font-size: 9px;
+    .provider-config-row {
+        display: grid;
+        gap: 4px;
+        margin-top: var(--spacing);
+        font-size: 10px;
         color: var(--text-secondary);
     }
 
-    .model-option-meta span {
-        min-width: 0;
-        overflow: hidden;
-        text-overflow: ellipsis;
-        white-space: nowrap;
+    .provider-config-meta {
+        display: flex;
+        gap: var(--spacing);
+        margin-top: 4px;
+        color: var(--text-secondary);
+        font-size: 9px;
     }
 
-    .model-option-meta span.ready {
+    .provider-config-meta .ready {
         color: var(--green);
     }
 
@@ -3333,23 +3443,62 @@
         background: color-mix(in srgb, var(--bg) 55%, var(--surface));
     }
 
-    .key-missing-text {
-        font-size: 12px;
+    .provider-field {
+        display: grid;
+        gap: 4px;
+        margin-bottom: var(--spacing);
+        font-size: 10px;
         color: var(--text-secondary);
-        margin: 0 0 8px 0;
     }
+
+    .provider-field input {
+        box-sizing: border-box;
+        width: 100%;
+        background: var(--bg);
+        color: var(--text);
+        border: 1px solid var(--border);
+        border-radius: var(--radius);
+        padding: 6px 8px;
+        font: 11px var(--font);
+    }
+
     .settings-link-btn {
         background: none;
         border: 1px solid var(--blue);
-        border-radius: var(--radius, 4px);
+        border-radius: var(--radius);
         padding: 4px 12px;
         font-size: 12px;
-        font-family: inherit;
+        font-family: var(--font);
         color: var(--blue);
         cursor: pointer;
     }
+
     .settings-link-btn:hover {
         background: color-mix(in srgb, var(--blue) 10%, transparent);
+    }
+
+    .settings-link-btn:disabled {
+        opacity: 0.5;
+        cursor: not-allowed;
+    }
+
+    .secondary-link {
+        margin-left: 4px;
+        color: var(--text-secondary);
+        border-color: var(--border);
+    }
+
+    .provider-config-message {
+        margin: var(--spacing) 0 0;
+        font-size: 10px;
+    }
+
+    .provider-config-message.ready {
+        color: var(--green);
+    }
+
+    .provider-config-message.error {
+        color: var(--red);
     }
 
     @media (max-width: 920px) {

--- a/src/lib/components/embedding-explorer-scope.behavior.test.ts
+++ b/src/lib/components/embedding-explorer-scope.behavior.test.ts
@@ -13,6 +13,12 @@ const mocks = vi.hoisted(() => ({
     getImagesByIds: vi.fn(),
     startModelEmbeddingGeneration: vi.fn(),
     cancelJob: vi.fn(),
+    setApiKey: vi.fn(),
+    validateApiKey: vi.fn(),
+    getOllamaEmbeddingConfig: vi.fn(),
+    setOllamaEmbeddingConfig: vi.fn(),
+    isEmbeddingModelAvailable: vi.fn(),
+    listEmbeddingProviders: vi.fn(),
     loadEmbeddingNeighbors: vi.fn(),
     eventListeners: new Map<string, Set<(event: { payload: Record<string, unknown> }) => void>>(),
     workerMessages: [] as Array<Record<string, unknown>>,
@@ -53,12 +59,16 @@ vi.mock('$lib/embedding-neighbors', () => ({
 }));
 
 vi.mock('$lib/api', () => ({
-    isEmbeddingModelAvailable: vi.fn().mockResolvedValue(true),
+    isEmbeddingModelAvailable: mocks.isEmbeddingModelAvailable,
     getEmbeddingModelDownloadInfo: vi.fn().mockResolvedValue(null),
-    listEmbeddingProviders: vi.fn().mockResolvedValue([]),
+    listEmbeddingProviders: mocks.listEmbeddingProviders,
     downloadEmbeddingModel: vi.fn(),
     startModelEmbeddingGeneration: mocks.startModelEmbeddingGeneration,
     hasApiKey: vi.fn().mockResolvedValue(false),
+    setApiKey: mocks.setApiKey,
+    validateApiKey: mocks.validateApiKey,
+    getOllamaEmbeddingConfig: mocks.getOllamaEmbeddingConfig,
+    setOllamaEmbeddingConfig: mocks.setOllamaEmbeddingConfig,
     getImagesByIds: mocks.getImagesByIds,
     getGenerationRun: vi.fn().mockResolvedValue(null),
     regenerateThumbnails: vi.fn(),
@@ -184,6 +194,10 @@ beforeEach(() => {
         model: 'clip-vit-b32',
         mode: 'missing',
     });
+    mocks.validateApiKey.mockResolvedValue(true);
+    mocks.getOllamaEmbeddingConfig.mockResolvedValue(['http://localhost:11434/api/embed', 'embeddinggemma']);
+    mocks.isEmbeddingModelAvailable.mockResolvedValue(true);
+    mocks.listEmbeddingProviders.mockResolvedValue([]);
     mocks.loadEmbeddingNeighbors.mockResolvedValue([
         { image: image('near-one'), score: 0.934 },
     ]);
@@ -213,6 +227,214 @@ beforeEach(() => {
 });
 
 describe('Embedding Explorer library scope', () => {
+    it('keeps provider configuration hidden until the gear is opened', async () => {
+        mocks.getEmbeddingCountForScope.mockResolvedValue(1);
+        const user = userEvent.setup();
+        const { container } = render(EmbeddingExplorer);
+
+        expect(await screen.findByText('CLIP ViT-B/32')).toBeInTheDocument();
+        expect(await screen.findByText('1/2 images embedded')).toBeInTheDocument();
+        expect([...container.querySelectorAll('.stat-label')]).toHaveLength(0);
+        expect(screen.queryByRole('combobox', { name: 'Embedding provider' })).not.toBeInTheDocument();
+        expect(screen.queryByRole('button', { name: 'Regenerate all (2)' })).not.toBeInTheDocument();
+
+        await user.click(screen.getByRole('button', { name: 'Configure embedding model' }));
+        const provider = screen.getByRole('combobox', { name: 'Embedding provider' });
+        expect(provider).toBeInTheDocument();
+        expect([...container.querySelectorAll('.stat-label')].map(label => label.textContent)).toEqual([
+            'Images', 'Embeddings', 'Need embeddings', 'Model',
+        ]);
+        expect(screen.getByRole('button', { name: 'Regenerate all (2)' })).toBeInTheDocument();
+
+        await user.selectOptions(provider, 'gemini');
+        const keyInput = await screen.findByLabelText('Gemini API key');
+        expect(screen.queryByLabelText('OpenAI API key')).not.toBeInTheDocument();
+        await user.type(keyInput, 'google-secret');
+        await user.click(screen.getByRole('button', { name: 'Save API key' }));
+        await waitFor(() => expect(mocks.validateApiKey).toHaveBeenCalledWith('google', 'google-secret'));
+        expect(mocks.setApiKey).toHaveBeenCalledWith('google', 'google-secret');
+        expect(await screen.findByText('Configuration saved.')).toBeInTheDocument();
+
+        await user.selectOptions(provider, 'ollama');
+        const ollamaUrl = await screen.findByLabelText('Ollama embedding URL');
+        const ollamaModel = screen.getByLabelText('Ollama embedding model');
+        await user.clear(ollamaUrl);
+        await user.type(ollamaUrl, 'http://localhost:11434/api/embed-v2');
+        await user.clear(ollamaModel);
+        await user.type(ollamaModel, 'nomic-embed-text');
+        mocks.listEmbeddingProviders.mockResolvedValue([{
+            id: 'ollama',
+            label: 'Ollama · nomic-embed-text',
+            shortLabel: 'Ollama',
+            modelName: 'ollama:nomic-embed-text',
+            dimensions: 0,
+            dimensionsLabel: 'model',
+            scope: 'local',
+            runtime: 'ollama',
+            status: 'offline',
+            available: false,
+            downloadable: false,
+            downloadLabel: null,
+            expectedSha256: null,
+            expectedSizeBytes: null,
+            spdxLicense: null,
+            sourceRepo: null,
+            modelCardUrl: null,
+            apiKeyProvider: null,
+        }]);
+        await user.click(screen.getByRole('button', { name: 'Save Ollama config' }));
+        await waitFor(() => expect(mocks.setOllamaEmbeddingConfig).toHaveBeenCalledWith(
+            'http://localhost:11434/api/embed-v2',
+            'nomic-embed-text',
+        ));
+        await waitFor(() =>
+            expect(container.querySelector('.model-summary-name')).toHaveTextContent(
+                'Ollama · nomic-embed-text',
+            ),
+        );
+        expect(screen.getByText('offline')).toBeInTheDocument();
+
+        await user.click(screen.getByRole('button', { name: 'Close embedding configuration' }));
+        expect(screen.queryByRole('combobox', { name: 'Embedding provider' })).not.toBeInTheDocument();
+    });
+
+    it('clears unsaved credentials synchronously when the provider changes', async () => {
+        mocks.getEmbeddingCountForScope.mockResolvedValue(1);
+        const user = userEvent.setup();
+        render(EmbeddingExplorer);
+
+        await user.click(await screen.findByRole('button', { name: 'Configure embedding model' }));
+        const provider = screen.getByRole('combobox', { name: 'Embedding provider' });
+        await user.selectOptions(provider, 'gemini');
+        await user.type(await screen.findByLabelText('Gemini API key'), 'google-secret-not-saved');
+
+        await user.selectOptions(provider, 'openai');
+        expect(await screen.findByLabelText('OpenAI API key')).toHaveValue('');
+        await user.click(screen.getByRole('button', { name: 'Save API key' }));
+        expect(mocks.validateApiKey).not.toHaveBeenCalled();
+        expect(mocks.setApiKey).not.toHaveBeenCalled();
+    });
+
+    it('ignores a delayed invalid-key result after switching providers', async () => {
+        let resolveValidation!: (value: boolean) => void;
+        mocks.validateApiKey.mockReturnValue(new Promise(resolve => {
+            resolveValidation = resolve;
+        }));
+        const user = userEvent.setup();
+        render(EmbeddingExplorer);
+
+        await user.click(await screen.findByRole('button', { name: 'Configure embedding model' }));
+        const provider = screen.getByRole('combobox', { name: 'Embedding provider' });
+        await user.selectOptions(provider, 'gemini');
+        await user.type(await screen.findByLabelText('Gemini API key'), 'pending-google-key');
+        void user.click(screen.getByRole('button', { name: 'Save API key' }));
+        await waitFor(() => expect(mocks.validateApiKey).toHaveBeenCalledWith('google', 'pending-google-key'));
+
+        await user.selectOptions(provider, 'openai');
+        resolveValidation(false);
+        await waitFor(() => expect(screen.getByLabelText('OpenAI API key')).toHaveValue(''));
+        expect(screen.queryByText('Enter a valid API key.')).not.toBeInTheDocument();
+        expect(mocks.setApiKey).not.toHaveBeenCalled();
+    });
+
+    it('keeps Ollama configuration disabled until the current load resolves', async () => {
+        let resolveConfig!: (value: [string, string]) => void;
+        mocks.getOllamaEmbeddingConfig.mockReturnValue(new Promise(resolve => {
+            resolveConfig = resolve;
+        }));
+        const user = userEvent.setup();
+        render(EmbeddingExplorer);
+
+        await user.click(await screen.findByRole('button', { name: 'Configure embedding model' }));
+        await user.selectOptions(screen.getByRole('combobox', { name: 'Embedding provider' }), 'ollama');
+        const urlInput = await screen.findByLabelText('Ollama embedding URL');
+        expect(urlInput).toBeDisabled();
+        expect(screen.getByRole('button', { name: 'Loading…' })).toBeDisabled();
+
+        resolveConfig(['http://127.0.0.1:11434/api/embed', 'snowflake-arctic-embed']);
+        await waitFor(() => expect(urlInput).toBeEnabled());
+        expect(urlInput).toHaveValue('http://127.0.0.1:11434/api/embed');
+        expect(screen.getByLabelText('Ollama embedding model')).toHaveValue('snowflake-arctic-embed');
+    });
+
+    it('saves explicit Ollama defaults when cleared fields are submitted', async () => {
+        const user = userEvent.setup();
+        render(EmbeddingExplorer);
+
+        await user.click(await screen.findByRole('button', { name: 'Configure embedding model' }));
+        await user.selectOptions(screen.getByRole('combobox', { name: 'Embedding provider' }), 'ollama');
+        const urlInput = await screen.findByLabelText('Ollama embedding URL');
+        const modelInput = screen.getByLabelText('Ollama embedding model');
+        await user.clear(urlInput);
+        await user.clear(modelInput);
+        await user.click(screen.getByRole('button', { name: 'Save Ollama config' }));
+
+        await waitFor(() => expect(mocks.setOllamaEmbeddingConfig).toHaveBeenCalledWith(
+            'http://localhost:11434/api/embed',
+            'embeddinggemma',
+        ));
+        expect(urlInput).toHaveValue('http://localhost:11434/api/embed');
+        expect(modelInput).toHaveValue('embeddinggemma');
+    });
+
+    it('uses the newly saved Ollama model for generation', async () => {
+        mocks.getEmbeddingCountForScope.mockResolvedValue(1);
+        mocks.listEmbeddingProviders.mockResolvedValue([{
+            id: 'ollama',
+            label: 'Ollama · nomic-embed-text',
+            shortLabel: 'Ollama',
+            modelName: 'ollama:nomic-embed-text',
+            dimensions: 0,
+            dimensionsLabel: 'model',
+            scope: 'local',
+            runtime: 'ollama',
+            status: 'ready',
+            available: true,
+            downloadable: false,
+            downloadLabel: null,
+            expectedSha256: null,
+            expectedSizeBytes: null,
+            spdxLicense: null,
+            sourceRepo: null,
+            modelCardUrl: null,
+            apiKeyProvider: null,
+        }]);
+        mocks.startModelEmbeddingGeneration.mockResolvedValue({
+            job_id: 'job_ollama_new_model',
+            total: 1,
+            model: 'ollama:nomic-embed-text',
+            mode: 'missing',
+        });
+        const user = userEvent.setup();
+        render(EmbeddingExplorer);
+
+        await user.click(await screen.findByRole('button', { name: 'Configure embedding model' }));
+        await user.selectOptions(screen.getByRole('combobox', { name: 'Embedding provider' }), 'ollama');
+        const modelInput = await screen.findByLabelText('Ollama embedding model');
+        await user.clear(modelInput);
+        await user.type(modelInput, 'nomic-embed-text');
+        await user.click(screen.getByRole('button', { name: 'Save Ollama config' }));
+        await waitFor(() => expect(screen.getByRole('button', { name: 'Generate missing (1)' })).toBeEnabled());
+
+        await user.click(screen.getByRole('button', { name: 'Generate missing (1)' }));
+        await waitFor(() => expect(mocks.startModelEmbeddingGeneration).toHaveBeenCalledWith(
+            'ollama:nomic-embed-text',
+            ['in-a', 'in-b'],
+            'missing',
+        ));
+    });
+
+    it('reveals local model download controls only in configuration', async () => {
+        mocks.isEmbeddingModelAvailable.mockResolvedValue(false);
+        const user = userEvent.setup();
+        render(EmbeddingExplorer);
+
+        await screen.findByText('CLIP ViT-B/32');
+        expect(screen.queryByRole('button', { name: /Download CLIP/i })).not.toBeInTheDocument();
+        await user.click(screen.getByRole('button', { name: 'Configure embedding model' }));
+        expect(await screen.findByRole('button', { name: /Download CLIP/i })).toBeInTheDocument();
+    });
+
     it('projects the full active scope and keeps embedding vectors paired with their IDs', async () => {
         render(EmbeddingExplorer);
 
@@ -291,6 +513,7 @@ describe('Embedding Explorer library scope', () => {
             model: 'clip-vit-b32',
             mode: 'all',
         });
+        await user.click(screen.getByRole('button', { name: 'Configure embedding model' }));
         await user.click(screen.getByRole('button', { name: 'Regenerate all (2)' }));
         expect(mocks.startModelEmbeddingGeneration).toHaveBeenLastCalledWith(
             'clip-vit-b32',
@@ -341,16 +564,12 @@ describe('Embedding Explorer library scope', () => {
         );
 
         const user = userEvent.setup();
-        const { container } = render(EmbeddingExplorer);
+        render(EmbeddingExplorer);
         await user.click(await screen.findByRole('button', { name: 'Generate missing (1)' }));
         await waitFor(() => expect(mocks.startModelEmbeddingGeneration).toHaveBeenCalledOnce());
 
         activeCollection.set('new-collection');
-        await waitFor(() => {
-            const embeddingRow = [...container.querySelectorAll('.stat-row')]
-                .find(row => row.querySelector('.stat-label')?.textContent === 'Embeddings');
-            expect(embeddingRow?.querySelector('.stat-value')).toHaveTextContent('0');
-        });
+        await waitFor(() => expect(screen.getByText('0/2 images embedded')).toBeInTheDocument());
 
         emit('embedding-progress', {
             job_id: 'job_embed_1',
@@ -361,9 +580,7 @@ describe('Embedding Explorer library scope', () => {
             total: 1,
         });
         await waitFor(() => expect(screen.getByText('Generation completed: 1/1')).toBeInTheDocument());
-        const embeddingRow = [...container.querySelectorAll('.stat-row')]
-            .find(row => row.querySelector('.stat-label')?.textContent === 'Embeddings');
-        expect(embeddingRow?.querySelector('.stat-value')).toHaveTextContent('0');
+        expect(screen.getByText('0/2 images embedded')).toBeInTheDocument();
     });
 
     it('keeps an active job attributed to its model while another model shows its own missing count', async () => {
@@ -384,7 +601,8 @@ describe('Embedding Explorer library scope', () => {
             total: 2,
         });
 
-        await user.click(screen.getByRole('radio', { name: /DINOv2/i }));
+        await user.click(screen.getByRole('button', { name: 'Configure embedding model' }));
+        await user.selectOptions(screen.getByRole('combobox', { name: 'Embedding provider' }), 'dinov2');
         await waitFor(() => {
             const missingRow = [...container.querySelectorAll('.stat-row')]
                 .find(row => row.querySelector('.stat-label')?.textContent === 'Need embeddings');


### PR DESCRIPTION
## Summary
- keep the Embedding Explorer default panel compact and actionable
- move provider, credential, Ollama, download, and full-regeneration controls behind a gear
- guard provider credentials and async configuration against cross-provider races
- refresh exact Ollama model readiness before generation

## Verification
- focused Embedding Explorer behavior: 13/13
- Spec review: PASS
- Standards review: PASS
- svelte-check: 0 errors, 0 warnings
- full Vitest: 167 files, 1253 tests passed (15s timeout for load-sensitive release fixtures)
- release CLI/gate fixtures: 102/102 passed under default timeout
- production build: PASS

Closes imageview-ez0