### PR TITLE
feat: create collections from embedding map selections

### DIFF
--- a/src-tauri/permissions/app-curation.toml
+++ b/src-tauri/permissions/app-curation.toml
@@ -9,6 +9,7 @@ commands.allow = [
   "convert_session_to_collection",
   "create_canvas",
   "create_collection",
+  "create_collection_with_images",
   "create_lineage_group_manual",
   "create_action_proposal",
   "create_session",

--- a/src-tauri/src/commands/collections.rs
+++ b/src-tauri/src/commands/collections.rs
@@ -22,6 +22,31 @@ pub async fn create_collection(state: State<'_, AppState>, name: String) -> Resu
 }
 
 #[tauri::command]
+pub async fn create_collection_with_images(
+    state: State<'_, AppState>,
+    name: String,
+    image_ids: Vec<String>,
+) -> Result<String, String> {
+    let ctx = ServiceContext::from_app_state(&state, None);
+    let refs: Vec<&str> = image_ids.iter().map(String::as_str).collect();
+    let id = svc::create_collection_with_images(&ctx, &name, &refs).map_err(|e| e.to_string())?;
+    let _ = state.db.log_session_event(&NewSessionEvent {
+        session_id: None,
+        event_type: "collection_created".to_string(),
+        actor_type: "user".to_string(),
+        actor_id: None,
+        subject_type: Some("collection".to_string()),
+        subject_id: Some(id.clone()),
+        payload_json: serde_json::json!({
+            "name": name,
+            "image_count": image_ids.len(),
+        })
+        .to_string(),
+    });
+    Ok(id)
+}
+
+#[tauri::command]
 pub async fn list_collections(
     state: State<'_, AppState>,
     include_rejected: Option<bool>,

--- a/src-tauri/src/db_core/queries/collections.rs
+++ b/src-tauri/src/db_core/queries/collections.rs
@@ -18,6 +18,29 @@ impl Database {
         Ok(id)
     }
 
+    pub fn create_collection_with_images(&self, name: &str, image_ids: &[&str]) -> Result<String> {
+        let id = uuid::Uuid::new_v4().to_string();
+        let now = chrono::Utc::now().to_rfc3339();
+        let mut conn = self.conn.lock();
+        let tx = conn.transaction()?;
+        tx.execute(
+            "INSERT INTO projects (id, name, description, created_at) VALUES (?1, ?2, NULL, ?3)",
+            params![id, name, now],
+        )?;
+        for (position, image_id) in image_ids.iter().enumerate() {
+            let inserted = tx.execute(
+                "INSERT INTO collection_items (collection_id, image_id, position)
+                 SELECT ?1, id, ?3 FROM images WHERE id = ?2",
+                params![id, image_id, position as i64],
+            )?;
+            if inserted != 1 {
+                return Err(rusqlite::Error::QueryReturnedNoRows);
+            }
+        }
+        tx.commit()?;
+        Ok(id)
+    }
+
     pub fn list_collections(&self) -> Result<Vec<(String, String, u32)>> {
         self.list_collections_with_visibility(true)
     }
@@ -236,5 +259,82 @@ impl Database {
             Some(Err(err)) => Err(err),
             None => Ok(None),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn open_test_db() -> Database {
+        Database::open(std::path::Path::new(":memory:")).unwrap()
+    }
+
+    fn insert_test_image(db: &Database, id: &str) {
+        let conn = db.conn.lock();
+        conn.execute(
+            "INSERT INTO images (id, sha256_hash, width, height, format, file_size, created_at, imported_at, ai_prompt)
+             VALUES (?1, ?2, 100, 100, 'png', 1000, '2026-01-01', '2026-01-01', NULL)",
+            params![id, format!("hash_{id}")],
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn create_collection_with_images_rolls_back_everything_when_membership_fails() {
+        let db = open_test_db();
+        insert_test_image(&db, "valid-image");
+
+        let result =
+            db.create_collection_with_images("Atomic selection", &["valid-image", "missing-image"]);
+        assert!(result.is_err());
+
+        let conn = db.conn.lock();
+        let project_count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM projects WHERE name = 'Atomic selection'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        let item_count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM collection_items", [], |row| {
+                row.get(0)
+            })
+            .unwrap();
+        assert_eq!(project_count, 0);
+        assert_eq!(item_count, 0);
+    }
+
+    #[test]
+    fn create_collection_with_images_commits_name_membership_and_order_together() {
+        let db = open_test_db();
+        insert_test_image(&db, "first-image");
+        insert_test_image(&db, "second-image");
+
+        let collection_id = db
+            .create_collection_with_images("Map selection", &["second-image", "first-image"])
+            .unwrap();
+
+        let conn = db.conn.lock();
+        let name: String = conn
+            .query_row(
+                "SELECT name FROM projects WHERE id = ?1",
+                params![collection_id],
+                |row| row.get(0),
+            )
+            .unwrap();
+        let mut stmt = conn
+            .prepare(
+                "SELECT image_id FROM collection_items WHERE collection_id = ?1 ORDER BY position",
+            )
+            .unwrap();
+        let image_ids = stmt
+            .query_map(params![collection_id], |row| row.get::<_, String>(0))
+            .unwrap()
+            .collect::<Result<Vec<_>>>()
+            .unwrap();
+        assert_eq!(name, "Map selection");
+        assert_eq!(image_ids, vec!["second-image", "first-image"]);
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -585,6 +585,7 @@ pub fn run() {
             commands::agent_proposals::cancel_claude_agent_chat_turn,
             commands::deeplink::open_with_params,
             commands::collections::create_collection,
+            commands::collections::create_collection_with_images,
             commands::collections::list_collections,
             commands::collections::rename_collection,
             commands::collections::add_to_collection,

--- a/src-tauri/src/services/curation.rs
+++ b/src-tauri/src/services/curation.rs
@@ -19,6 +19,25 @@ pub fn create_collection(ctx: &ServiceContext, name: &str) -> Result<String, Ser
     Ok(ctx.db.create_collection(name)?)
 }
 
+pub fn create_collection_with_images(
+    ctx: &ServiceContext,
+    name: &str,
+    image_ids: &[&str],
+) -> Result<String, ServiceError> {
+    let name = name.trim();
+    if name.is_empty() {
+        return Err(ServiceError::InvalidInput(
+            "Collection name cannot be empty".to_string(),
+        ));
+    }
+    if image_ids.is_empty() || image_ids.iter().any(|image_id| image_id.is_empty()) {
+        return Err(ServiceError::InvalidInput(
+            "At least one valid image ID is required".to_string(),
+        ));
+    }
+    Ok(ctx.db.create_collection_with_images(name, image_ids)?)
+}
+
 pub fn list_collections(ctx: &ServiceContext) -> Result<Vec<(String, String, u32)>, ServiceError> {
     Ok(ctx.db.list_collections()?)
 }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -764,6 +764,12 @@ export async function createCollection(name: string): Promise<string> {
     return result;
 }
 
+export async function createCollectionWithImages(name: string, imageIds: string[]): Promise<string> {
+    const result = await invoke<string>('create_collection_with_images', { name, imageIds });
+    emitSessionEventsRefresh();
+    return result;
+}
+
 export async function listCollections(includeRejected = false): Promise<[string, string, number][]> {
     return invoke('list_collections', { includeRejected });
 }

--- a/src/lib/components/EmbeddingExplorer.svelte
+++ b/src/lib/components/EmbeddingExplorer.svelte
@@ -10,6 +10,10 @@
         navigateTo,
         embeddingViewState,
         settingsOpen,
+        collections,
+        requestTextInput,
+        showRejected,
+        showToast,
         type EmbeddingViewState,
         type EmbeddingProvider,
         type EmbeddingInteractionMode,
@@ -42,6 +46,8 @@
         cancelJob,
         pauseJob,
         resumeJob,
+        createCollectionWithImages,
+        listCollections,
     } from '$lib/api';
     import type {
         EmbeddingGenerationMode,
@@ -208,6 +214,12 @@
     let dragStartY = 0;
     let dragStartPanX = 0;
     let dragStartPanY = 0;
+    type AreaSelectionRect = { startX: number; startY: number; currentX: number; currentY: number };
+    let areaSelectionMode = $state(false);
+    let areaSelectionRect = $state<AreaSelectionRect | null>(null);
+    let areaSelectedIds = $state<Set<string>>(new Set());
+    let creatingAreaCollection = $state(false);
+    let areaSelectedCount = $derived(areaSelectedIds.size);
 
     // Projection identity for view state validation
     let projectionKey = $state<string | null>(null);
@@ -645,6 +657,7 @@
         clusters = [];
         selectedPoint = null;
         highlightedCluster = null;
+        resetAreaSelection();
         resetThumbnailCache();
         void loadEmbeddingState();
     });
@@ -655,6 +668,7 @@
         clusters = [];
         selectedPoint = null;
         highlightedCluster = null;
+        resetAreaSelection();
         activeZLayerKey = null;
         resetThumbnailCache();
         await loadEmbeddingState();
@@ -1331,14 +1345,25 @@
     }
 
     function handleExplorerKeydown(e: KeyboardEvent) {
+        if (e.key === 'Escape' && areaSelectionMode) {
+            e.preventDefault();
+            resetAreaSelection();
+            explorerEl?.focus();
+            return;
+        }
         if (isInteractiveTarget(e.target)) return;
         if (points.length === 0) return;
-        if (e.key === 'ArrowRight') {
+        if ((e.key === ' ' || e.code === 'Space') && areaSelectionMode && selectedPoint) {
+            e.preventDefault();
+            togglePointInAreaSelection(selectedPoint.id);
+        } else if (e.key === 'ArrowRight') {
             e.preventDefault();
             selectRelativePoint(1);
+            if (areaSelectionMode && e.shiftKey && selectedPoint) addPointToAreaSelection(selectedPoint.id);
         } else if (e.key === 'ArrowLeft') {
             e.preventDefault();
             selectRelativePoint(-1);
+            if (areaSelectionMode && e.shiftKey && selectedPoint) addPointToAreaSelection(selectedPoint.id);
         } else if (e.key === 'ArrowDown') {
             e.preventDefault();
             navigateZLayer(1);
@@ -1479,6 +1504,7 @@
             if (loadSeq !== projectionLoadSeq) return;
             if (requestedScopeKey !== libraryScopeKey(get(libraryScope))) return;
             if (embeddingPage.ids.length < 2) {
+                resetAreaSelection();
                 points = [];
                 clusters = [];
                 resetThumbnailCache();
@@ -1501,6 +1527,7 @@
             const projection = await runProjectionInWorker(embeddingPage, embeddingImages);
             if (loadSeq !== projectionLoadSeq) return;
 
+            resetAreaSelection();
             points = projection.points;
             clusters = projection.clusters.map(cluster => ({
                 id: cluster.id,
@@ -1628,7 +1655,7 @@
             if (sx < -margin || sx > canvasWidth + margin || sy < -margin || sy > canvasHeight + margin) continue;
 
             const color = CLUSTER_COLORS[p.cluster % CLUSTER_COLORS.length];
-            const isSelected = selectedPoint && selectedPoint.id === p.id;
+            const isSelected = areaSelectedIds.has(p.id) || (selectedPoint && selectedPoint.id === p.id);
             const isHovered = hoveredPoint && hoveredPoint.id === p.id;
             const dimmed = pointIsDimmed(p);
 
@@ -1731,6 +1758,21 @@
                 ctx.fillText(name, tx, ty);
             }
         }
+
+        if (areaSelectionRect) {
+            const left = Math.min(areaSelectionRect.startX, areaSelectionRect.currentX);
+            const top = Math.min(areaSelectionRect.startY, areaSelectionRect.currentY);
+            const width = Math.abs(areaSelectionRect.currentX - areaSelectionRect.startX);
+            const height = Math.abs(areaSelectionRect.currentY - areaSelectionRect.startY);
+            const selectionColor = getComputedStyle(canvas).getPropertyValue('--blue').trim();
+            if (selectionColor) {
+                ctx.save();
+                ctx.strokeStyle = selectionColor;
+                ctx.lineWidth = 2;
+                ctx.strokeRect(left, top, width, height);
+                ctx.restore();
+            }
+        }
     }
 
     function saveViewState() {
@@ -1776,6 +1818,16 @@
 
     function handleMouseDown(e: MouseEvent) {
         explorerEl?.focus();
+        if (areaSelectionMode) {
+            if (e.button !== 0) return;
+            const rect = canvas.getBoundingClientRect();
+            const x = e.clientX - rect.left;
+            const y = e.clientY - rect.top;
+            areaSelectionRect = { startX: x, startY: y, currentX: x, currentY: y };
+            hoveredPoint = null;
+            requestDraw();
+            return;
+        }
         dragging = true;
         dragStartX = e.clientX;
         dragStartY = e.clientY;
@@ -1784,6 +1836,21 @@
     }
 
     function handleMouseMove(e: MouseEvent) {
+        if (areaSelectionRect) {
+            const rect = canvas.getBoundingClientRect();
+            areaSelectionRect = {
+                ...areaSelectionRect,
+                currentX: e.clientX - rect.left,
+                currentY: e.clientY - rect.top,
+            };
+            requestDraw();
+            return;
+        }
+        if (areaSelectionMode) {
+            hoveredPoint = null;
+            canvas.style.cursor = 'crosshair';
+            return;
+        }
         if (dragging) {
             panX = dragStartPanX + (e.clientX - dragStartX);
             panY = dragStartPanY + (e.clientY - dragStartY);
@@ -1817,6 +1884,24 @@
     }
 
     function handleMouseUp(e: MouseEvent) {
+        if (areaSelectionRect) {
+            const rect = canvas.getBoundingClientRect();
+            const endX = e.clientX - rect.left;
+            const endY = e.clientY - rect.top;
+            const left = Math.min(areaSelectionRect.startX, endX);
+            const right = Math.max(areaSelectionRect.startX, endX);
+            const top = Math.min(areaSelectionRect.startY, endY);
+            const bottom = Math.max(areaSelectionRect.startY, endY);
+            areaSelectedIds = new Set(getRenderPoints()
+                .filter(point => {
+                    const { sx, sy } = projectPointForCanvas(point);
+                    return sx >= left && sx <= right && sy >= top && sy <= bottom;
+                })
+                .map(point => point.id));
+            areaSelectionRect = null;
+            requestDraw();
+            return;
+        }
         if (dragging) {
             const moved = Math.abs(e.clientX - dragStartX) + Math.abs(e.clientY - dragStartY);
             if (moved < 4 && hoveredPoint) {
@@ -1825,6 +1910,84 @@
         }
         dragging = false;
         saveViewState();
+    }
+
+    function toggleAreaSelection() {
+        areaSelectionMode = !areaSelectionMode;
+        areaSelectionRect = null;
+        if (!areaSelectionMode) areaSelectedIds = new Set();
+        hoveredPoint = null;
+        requestDraw();
+        if (areaSelectionMode) explorerEl?.focus();
+    }
+
+    function addPointToAreaSelection(imageId: string) {
+        areaSelectedIds = new Set([...areaSelectedIds, imageId]);
+        requestDraw();
+    }
+
+    function togglePointInAreaSelection(imageId: string) {
+        const next = new Set(areaSelectedIds);
+        if (next.has(imageId)) {
+            next.delete(imageId);
+        } else {
+            next.add(imageId);
+        }
+        areaSelectedIds = next;
+        requestDraw();
+    }
+
+    function clearAreaSelection() {
+        areaSelectionRect = null;
+        areaSelectedIds = new Set();
+        requestDraw();
+    }
+
+    function resetAreaSelection() {
+        areaSelectionMode = false;
+        clearAreaSelection();
+    }
+
+    function cancelAreaSelectionDrag() {
+        dragging = false;
+        areaSelectionRect = null;
+        hoveredPoint = null;
+        requestDraw();
+    }
+
+    async function createCollectionFromAreaSelection() {
+        const imageIds = getRenderPoints()
+            .filter(point => areaSelectedIds.has(point.id))
+            .map(point => point.id);
+        if (imageIds.length === 0 || creatingAreaCollection) return;
+        const imageLabel = imageIds.length === 1 ? '1 selected image' : `${imageIds.length} selected images`;
+        const name = await requestTextInput({
+            title: 'New Collection from Embedding Map',
+            label: 'Collection name',
+            description: `${imageLabel} will be added.`,
+            placeholder: 'Collection name',
+            confirmLabel: 'Create Collection',
+        });
+        if (!name?.trim()) return;
+
+        creatingAreaCollection = true;
+        try {
+            await createCollectionWithImages(name.trim(), imageIds);
+            areaSelectedIds = new Set();
+            areaSelectionMode = false;
+            showToast(`Collection "${name.trim()}" created`, { type: 'success', duration: 5000 });
+            try {
+                collections.set(await listCollections($showRejected));
+            } catch (refreshError) {
+                console.error('Collection created, but the collection list could not refresh:', refreshError);
+            }
+        } catch (error) {
+            console.error('Failed to create collection from embedding selection:', error);
+            showToast('Failed to create collection', { type: 'error' });
+        } finally {
+            creatingAreaCollection = false;
+            requestDraw();
+        }
     }
 
     function focusImageForLoupe(imageId: string): boolean {
@@ -1877,6 +2040,7 @@
     }
 
     function handleCanvasDblClick(e: MouseEvent) {
+        if (areaSelectionMode) return;
         if (!hoveredPoint) return;
         if (focusImageForLoupe(hoveredPoint.id)) {
             navigateTo('loupe');
@@ -2164,6 +2328,35 @@
                 <button class="layer-step-btn" onclick={() => selectRelativePoint(-1)} disabled={navigationPoints.length === 0} title="Previous image">←</button>
                 <span class="selection-position">{selectedNavigationLabel}</span>
                 <button class="layer-step-btn" onclick={() => selectRelativePoint(1)} disabled={navigationPoints.length === 0} title="Next image">→</button>
+            </div>
+
+            <div class="area-selection-controls" aria-live="polite">
+                <button
+                    class="toggle-pill area-select-toggle"
+                    class:active={areaSelectionMode}
+                    onclick={toggleAreaSelection}
+                    aria-pressed={areaSelectionMode}
+                    aria-label={areaSelectionMode ? 'Exit embedding map area selection' : 'Select an area of the embedding map'}
+                >
+                    {areaSelectionMode ? 'Selecting area' : 'Select area'}
+                </button>
+                <span class="area-selection-status">
+                    {areaSelectedCount} {areaSelectedCount === 1 ? 'image' : 'images'} selected
+                </span>
+                {#if areaSelectionMode}
+                    <span class="area-selection-hint">Drag on the map, or use arrows and Space.</span>
+                {/if}
+                {#if areaSelectedCount > 0}
+                    <button
+                        class="settings-link-btn"
+                        onclick={createCollectionFromAreaSelection}
+                        disabled={creatingAreaCollection}
+                        aria-label={`Create collection from ${areaSelectedCount} selected ${areaSelectedCount === 1 ? 'image' : 'images'}`}
+                    >
+                        {creatingAreaCollection ? 'Creating…' : 'Create collection'}
+                    </button>
+                    <button class="settings-link-btn secondary-link" onclick={clearAreaSelection}>Clear selection</button>
+                {/if}
             </div>
         </div>
 
@@ -2481,9 +2674,9 @@
             onmousemove={handleMouseMove}
             onmouseup={handleMouseUp}
             ondblclick={handleCanvasDblClick}
-            onmouseleave={() => { dragging = false; hoveredPoint = null; requestDraw(); }}
+            onmouseleave={cancelAreaSelectionDrag}
             class:hidden={points.length === 0}
-            style="cursor: grab"
+            style:cursor={areaSelectionMode ? 'crosshair' : 'grab'}
         ></canvas>
 
         {#if (largePreviewOpen && selectedImage) || textOutputOpen}
@@ -2896,6 +3089,29 @@
         white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;
+    }
+
+    .area-selection-controls {
+        display: grid;
+        gap: var(--spacing);
+        margin-top: var(--spacing);
+    }
+
+    .area-select-toggle {
+        width: 100%;
+    }
+
+    .area-selection-status {
+        color: var(--text-secondary);
+        font-size: 10px;
+        text-align: center;
+    }
+
+    .area-selection-hint {
+        color: var(--text-secondary);
+        font-size: 9px;
+        line-height: 1.4;
+        text-align: center;
     }
 
     .cluster-item {

--- a/src/lib/components/embedding-explorer-scope.behavior.test.ts
+++ b/src/lib/components/embedding-explorer-scope.behavior.test.ts
@@ -1,8 +1,9 @@
 // @vitest-environment jsdom
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import '@testing-library/jest-dom/vitest';
-import { cleanup, render, screen, waitFor } from '@testing-library/svelte';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
+import { tick } from 'svelte';
 import { get } from 'svelte/store';
 
 const mocks = vi.hoisted(() => ({
@@ -20,6 +21,8 @@ const mocks = vi.hoisted(() => ({
     isEmbeddingModelAvailable: vi.fn(),
     listEmbeddingProviders: vi.fn(),
     loadEmbeddingNeighbors: vi.fn(),
+    createCollectionWithImages: vi.fn(),
+    listCollections: vi.fn(),
     eventListeners: new Map<string, Set<(event: { payload: Record<string, unknown> }) => void>>(),
     workerMessages: [] as Array<Record<string, unknown>>,
 }));
@@ -75,6 +78,8 @@ vi.mock('$lib/api', () => ({
     cancelJob: mocks.cancelJob,
     pauseJob: vi.fn(),
     resumeJob: vi.fn(),
+    createCollectionWithImages: mocks.createCollectionWithImages,
+    listCollections: mocks.listCollections,
 }));
 
 import EmbeddingExplorer from './EmbeddingExplorer.svelte';
@@ -88,6 +93,10 @@ import {
     showRejected,
     embeddingViewState,
     focusedImageOverride,
+    collections,
+    resolveTextInputDialog,
+    settingsOpen,
+    textInputDialog,
     viewMode,
 } from '$lib/stores';
 
@@ -171,7 +180,29 @@ beforeEach(() => {
     importBatchFilter.set(null);
     minSizeFilter.set(512);
     showRejected.set(false);
-    embeddingViewState.update(state => ({ ...state, provider: 'clip' }));
+    settingsOpen.set(false);
+    embeddingViewState.set({
+        panX: 0,
+        panY: 0,
+        scale: 1,
+        selectedPointId: null,
+        highlightedCluster: null,
+        provider: 'clip',
+        projectionKey: null,
+        hasUserView: false,
+        interactionMode: 'map',
+        zPreset: 'cluster',
+        activeZLayerKey: null,
+        focusActiveLayer: false,
+        largePreviewOpen: true,
+        textOutputOpen: false,
+        canvasLabelsOpen: false,
+        spacePreset: 'balanced',
+        spaceSpacing: 1,
+        spaceDepth: 0.35,
+        spaceScale: 1,
+        spacePerspective: 0.3,
+    });
     focusedImageOverride.set(null);
     viewMode.set('grid');
 
@@ -198,6 +229,8 @@ beforeEach(() => {
     mocks.getOllamaEmbeddingConfig.mockResolvedValue(['http://localhost:11434/api/embed', 'embeddinggemma']);
     mocks.isEmbeddingModelAvailable.mockResolvedValue(true);
     mocks.listEmbeddingProviders.mockResolvedValue([]);
+    mocks.createCollectionWithImages.mockResolvedValue('collection-from-map');
+    mocks.listCollections.mockResolvedValue([['collection-from-map', 'Map picks', 1]]);
     mocks.loadEmbeddingNeighbors.mockResolvedValue([
         { image: image('near-one'), score: 0.934 },
     ]);
@@ -215,6 +248,7 @@ beforeEach(() => {
         arc: vi.fn(),
         fill: vi.fn(),
         stroke: vi.fn(),
+        strokeRect: vi.fn(),
         save: vi.fn(),
         restore: vi.fn(),
         translate: vi.fn(),
@@ -640,6 +674,69 @@ describe('Embedding Explorer library scope', () => {
         }));
         expect(get(viewMode)).toBe('loupe');
         expect(get(focusedImageOverride)?.image.id).toBe('near-one');
+    });
+
+    it('creates a collection from exactly the points inside a dragged rectangle', async () => {
+        const user = userEvent.setup();
+        const { container } = render(EmbeddingExplorer);
+        await waitFor(() => expect(mocks.workerMessages).toHaveLength(1));
+
+        await user.click(await screen.findByRole('button', { name: 'Select an area of the embedding map' }));
+        const canvas = container.querySelector('canvas')!;
+        await fireEvent.mouseDown(canvas, { clientX: 100, clientY: 20 });
+        await fireEvent.mouseMove(canvas, { clientX: 300, clientY: 200 });
+        await fireEvent.mouseUp(canvas, { clientX: 300, clientY: 200 });
+
+        expect(await screen.findByText('1 image selected')).toBeInTheDocument();
+        await user.click(screen.getByRole('button', { name: 'Create collection from 1 selected image' }));
+        expect(get(textInputDialog)?.description).toBe('1 selected image will be added.');
+        resolveTextInputDialog('Map picks');
+
+        await waitFor(() => expect(mocks.createCollectionWithImages).toHaveBeenCalledWith(
+            'Map picks',
+            ['in-a'],
+        ));
+        await waitFor(() => expect(get(collections)).toEqual([['collection-from-map', 'Map picks', 1]]));
+        expect(await screen.findByText('0 images selected')).toBeInTheDocument();
+    });
+
+    it('supports keyboard point selection and Escape from a focused selection control', async () => {
+        const user = userEvent.setup();
+        render(EmbeddingExplorer);
+        await waitFor(() => expect(mocks.workerMessages).toHaveLength(1));
+
+        await user.click(await screen.findByRole('button', { name: 'Select an area of the embedding map' }));
+        const explorer = screen.getByRole('application', { name: 'Visual embeddings' });
+        expect(explorer).toHaveFocus();
+        await user.keyboard('{ArrowRight} {Shift>}{ArrowRight}{/Shift}');
+        expect(await screen.findByText('2 images selected')).toBeInTheDocument();
+
+        const clearButton = screen.getByRole('button', { name: 'Clear selection' });
+        clearButton.focus();
+        await user.keyboard('{Escape}');
+        expect(screen.getByRole('button', { name: 'Select an area of the embedding map' })).toHaveAttribute('aria-pressed', 'false');
+        expect(screen.getByText('0 images selected')).toBeInTheDocument();
+        expect(screen.queryByRole('button', { name: 'Clear selection' })).not.toBeInTheDocument();
+        expect(explorer).toHaveFocus();
+    });
+
+    it('clears an area selection when the same scope receives a replacement projection', async () => {
+        const user = userEvent.setup();
+        const { container } = render(EmbeddingExplorer);
+        await waitFor(() => expect(mocks.workerMessages).toHaveLength(1));
+        await user.click(await screen.findByRole('button', { name: 'Select an area of the embedding map' }));
+        const canvas = container.querySelector('canvas')!;
+        await fireEvent.mouseDown(canvas, { clientX: 100, clientY: 20 });
+        await fireEvent.mouseMove(canvas, { clientX: 300, clientY: 200 });
+        await fireEvent.mouseUp(canvas, { clientX: 300, clientY: 200 });
+        expect(await screen.findByText('1 image selected')).toBeInTheDocument();
+
+        settingsOpen.set(true);
+        await tick();
+        settingsOpen.set(false);
+        await waitFor(() => expect(mocks.workerMessages).toHaveLength(2));
+        expect(screen.getByText('0 images selected')).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Select an area of the embedding map' })).toHaveAttribute('aria-pressed', 'false');
     });
 
 });


### PR DESCRIPTION
## Summary
- add explicit rectangle and keyboard selection in Embedding Explorer
- create a named manual collection from the exact selected image IDs
- make collection creation and membership insertion one atomic SQLite transaction
- reset selection safely across Escape, scope/provider changes, and projection replacement

## Verification
- Spec review: PASS
- Standards/accessibility review: PASS
- focused Embedding Explorer tests: 16/16 twice consecutively
- frontend full test suite: PASS
- `npm run check`: 0 errors, 0 warnings (existing nested-site config notice only)
- production build: PASS
- Rust `cargo test --lib`: 829 passed, 3 ignored
- `cargo fmt --all -- --check`: PASS
- `cargo clippy --all-targets`: PASS (pre-existing warnings only)
- `git diff --check`: PASS

Closes imageview-ayk