### PR TITLE
feat: auto-name embedding clusters

### DIFF
--- a/src-tauri/permissions/app-ai-processing.toml
+++ b/src-tauri/permissions/app-ai-processing.toml
@@ -57,6 +57,7 @@ commands.allow = [
   "list_images_by_color_bucket",
   "list_images_by_detected_class",
   "list_scoped_image_ids",
+  "name_embedding_clusters",
   "list_similarity_group_images",
   "list_similarity_groups",
   "rescan_sidecars",

--- a/src-tauri/src/commands/embeddings.rs
+++ b/src-tauri/src/commands/embeddings.rs
@@ -625,6 +625,15 @@ pub async fn list_scoped_image_ids(
 }
 
 #[tauri::command]
+pub async fn name_embedding_clusters(
+    state: State<'_, AppState>,
+    clusters: Vec<crate::db_core::models::EmbeddingClusterMembership>,
+) -> Result<Vec<crate::db_core::models::EmbeddingClusterName>, String> {
+    let ctx = crate::services::ServiceContext::from_app_state(&state, None);
+    crate::services::ai::name_embedding_clusters(&ctx, &clusters).map_err(|e| e.to_string())
+}
+
+#[tauri::command]
 pub async fn find_similar_images(
     state: State<'_, AppState>,
     image_id: String,

--- a/src-tauri/src/db_core/models.rs
+++ b/src-tauri/src/db_core/models.rs
@@ -396,6 +396,19 @@ pub enum EmbeddingScope {
     },
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EmbeddingClusterMembership {
+    pub cluster_id: u32,
+    pub image_ids: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EmbeddingClusterName {
+    pub cluster_id: u32,
+    pub label: String,
+    pub source: String,
+}
+
 impl EmbeddingScope {
     pub fn include_rejected(&self) -> bool {
         match self {

--- a/src-tauri/src/db_core/queries/embeddings.rs
+++ b/src-tauri/src/db_core/queries/embeddings.rs
@@ -6,10 +6,61 @@ use crate::db_core::db::{cosine_similarity, decode_embedding_bytes};
 
 use crate::db_core::models::*;
 use crate::db_core::smart_collections::FilterNode;
+use crate::db_core::tags::normalize_tag_name;
 use crate::db_core::visibility::RejectedVisibility;
 use rusqlite::types::Value;
 use rusqlite::{params, OptionalExtension, Result, ToSql};
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
+
+fn title_case_label(value: &str) -> String {
+    normalize_tag_name(value)
+        .unwrap_or_else(|| value.trim().to_lowercase())
+        .split('-')
+        .filter(|part| !part.is_empty())
+        .map(|part| {
+            let mut chars = part.chars();
+            match chars.next() {
+                Some(first) => first.to_uppercase().collect::<String>() + chars.as_str(),
+                None => String::new(),
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn filename_candidates(path: &str) -> Vec<String> {
+    const STOP_WORDS: &[&str] = &[
+        "copy",
+        "dsc",
+        "export",
+        "final",
+        "frame",
+        "generated",
+        "image",
+        "img",
+        "output",
+        "photo",
+        "screenshot",
+        "untitled",
+    ];
+    let stem = std::path::Path::new(path)
+        .file_stem()
+        .and_then(|value| value.to_str())
+        .unwrap_or_default();
+    stem.split(|character: char| !character.is_alphabetic())
+        .map(str::to_lowercase)
+        .filter(|token| token.chars().count() >= 3 && !STOP_WORDS.contains(&token.as_str()))
+        .collect()
+}
+
+fn source_priority(source: &str) -> u8 {
+    match source {
+        "tag" => 3,
+        "yolo" => 2,
+        "filename" => 1,
+        _ => 0,
+    }
+}
 
 fn scoped_where_clause(scope: &EmbeddingScope) -> Result<(String, Vec<Value>, RejectedVisibility)> {
     let default_visibility = RejectedVisibility::from_include_rejected(scope.include_rejected());
@@ -87,6 +138,154 @@ fn to_param_refs(params: &[Value]) -> Vec<&dyn ToSql> {
 }
 
 impl Database {
+    pub fn name_embedding_clusters(
+        &self,
+        clusters: &[EmbeddingClusterMembership],
+    ) -> Result<Vec<EmbeddingClusterName>> {
+        let conn = self.read_connection();
+        let mut result = Vec::with_capacity(clusters.len());
+
+        for cluster in clusters {
+            let mut unique_ids = Vec::with_capacity(cluster.image_ids.len());
+            let mut seen = HashSet::with_capacity(cluster.image_ids.len());
+            for image_id in &cluster.image_ids {
+                if seen.insert(image_id.as_str()) {
+                    unique_ids.push(image_id.clone());
+                }
+            }
+            if unique_ids.is_empty() {
+                continue;
+            }
+
+            // Each image contributes at most once to a candidate. The weight
+            // records the strongest available evidence for that image/name.
+            let mut by_image: HashMap<String, HashMap<String, (String, String, u32)>> =
+                HashMap::new();
+            for chunk in unique_ids.chunks(400) {
+                let placeholders = (0..chunk.len()).map(|_| "?").collect::<Vec<_>>().join(",");
+                let values = chunk.iter().cloned().map(Value::Text).collect::<Vec<_>>();
+
+                let tag_sql = format!(
+                    "SELECT it.image_id, t.name, t.tag_type, it.source
+                     FROM image_tags it
+                     JOIN tags t ON t.id = it.tag_id
+                     WHERE it.image_id IN ({placeholders})"
+                );
+                let mut stmt = conn.prepare(&tag_sql)?;
+                let rows = stmt.query_map(to_param_refs(&values).as_slice(), |row| {
+                    Ok((
+                        row.get::<_, String>(0)?,
+                        row.get::<_, String>(1)?,
+                        row.get::<_, String>(2)?,
+                        row.get::<_, String>(3)?,
+                    ))
+                })?;
+                for row in rows {
+                    let (image_id, name, tag_type, source) = row?;
+                    let Some(key) = normalize_tag_name(&name) else {
+                        continue;
+                    };
+                    let weight = if source == "manual" || tag_type == "user" {
+                        6
+                    } else if tag_type == "object" {
+                        5
+                    } else {
+                        4
+                    };
+                    let candidates = by_image.entry(image_id).or_default();
+                    let next = (title_case_label(&key), "tag".to_string(), weight);
+                    if candidates
+                        .get(&key)
+                        .is_none_or(|current| current.2 < weight)
+                    {
+                        candidates.insert(key, next);
+                    }
+                }
+
+                let detection_sql = format!(
+                    "SELECT image_id, class_name, MAX(confidence)
+                     FROM detections
+                     WHERE image_id IN ({placeholders})
+                       AND model_name GLOB 'yolo*' AND confidence >= 0.35
+                     GROUP BY image_id, class_name"
+                );
+                let mut stmt = conn.prepare(&detection_sql)?;
+                let rows = stmt.query_map(to_param_refs(&values).as_slice(), |row| {
+                    Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+                })?;
+                for row in rows {
+                    let (image_id, name) = row?;
+                    let Some(key) = normalize_tag_name(&name) else {
+                        continue;
+                    };
+                    let candidates = by_image.entry(image_id).or_default();
+                    if candidates.get(&key).is_none_or(|current| current.2 < 5) {
+                        candidates.insert(key, (title_case_label(&name), "yolo".to_string(), 5));
+                    }
+                }
+
+                let file_sql = format!(
+                    "SELECT image_id, path FROM image_files
+                     WHERE image_id IN ({placeholders}) AND missing_at IS NULL
+                     ORDER BY image_id, path"
+                );
+                let mut stmt = conn.prepare(&file_sql)?;
+                let rows = stmt.query_map(to_param_refs(&values).as_slice(), |row| {
+                    Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+                })?;
+                for row in rows {
+                    let (image_id, path) = row?;
+                    let candidates = by_image.entry(image_id).or_default();
+                    for (index, key) in filename_candidates(&path).into_iter().enumerate() {
+                        let weight = if index == 0 { 2 } else { 1 };
+                        candidates.entry(key.clone()).or_insert_with(|| {
+                            (title_case_label(&key), "filename".to_string(), weight)
+                        });
+                    }
+                }
+            }
+
+            let mut scores: HashMap<String, (String, String, u32, u32, u32)> = HashMap::new();
+            for candidates in by_image.values() {
+                for (key, (label, source, weight)) in candidates {
+                    let score = scores
+                        .entry(key.clone())
+                        .or_insert_with(|| (label.clone(), source.clone(), 0, 0, 0));
+                    score.2 += weight;
+                    score.3 += 1;
+                    if *weight > score.4
+                        || (*weight == score.4
+                            && source_priority(source) > source_priority(&score.1))
+                    {
+                        score.0 = label.clone();
+                        score.1 = source.clone();
+                        score.4 = *weight;
+                    }
+                }
+            }
+
+            let best = scores.into_iter().max_by(
+                |(a_key, (_, _, a_score, a_coverage, _)),
+                 (b_key, (_, _, b_score, b_coverage, _))| {
+                    a_score
+                        .cmp(b_score)
+                        .then_with(|| a_coverage.cmp(b_coverage))
+                        .then_with(|| b_key.cmp(a_key))
+                },
+            );
+            if let Some((_, (label, source, _, _, _))) = best {
+                result.push(EmbeddingClusterName {
+                    cluster_id: cluster.cluster_id,
+                    label,
+                    source,
+                });
+            }
+        }
+
+        result.sort_by_key(|item| item.cluster_id);
+        Ok(result)
+    }
+
     /// Returns the first occurrence of each requested image ID that does not
     /// already have an embedding for `model_name`.
     pub fn image_ids_without_embedding(
@@ -883,5 +1082,143 @@ mod tests {
             include_rejected: false,
         };
         assert_eq!(ids_for_scope(&db, &smart_rejected), vec!["c-reject"]);
+    }
+
+    #[test]
+    fn cluster_names_prioritize_shared_tags_then_yolo_then_filenames() {
+        let db = open_test_db();
+        for (id, path) in [
+            ("tag-a", "/library/sunset_001.png"),
+            ("tag-b", "/library/sunset_002.png"),
+            ("dog-a", "/library/frame_101.png"),
+            ("dog-b", "/library/frame_102.png"),
+            ("file-a", "/library/mountain_mist_01.png"),
+            ("file-b", "/library/mountain_mist_02.png"),
+        ] {
+            insert_scoped_image(&db, id, path, 500, 500, None);
+        }
+        db.add_image_tag("tag-a", "Golden Hour", "user", "manual", None)
+            .unwrap();
+        db.add_image_tag("tag-b", "Golden Hour", "user", "manual", None)
+            .unwrap();
+        db.conn
+            .lock()
+            .execute(
+                "INSERT INTO detections (
+                    id, image_id, model_name, class_name, confidence,
+                    x, y, width, height, created_at
+                 ) VALUES ('det-tag', 'tag-a', 'yolo11m', 'golden_hour', 0.9, 0, 0, 1, 1, '2026-01-01')",
+                [],
+            )
+            .unwrap();
+        for (index, id) in ["dog-a", "dog-b"].iter().enumerate() {
+            db.conn
+                .lock()
+                .execute(
+                    "INSERT INTO detections (
+                        id, image_id, model_name, class_name, confidence,
+                        x, y, width, height, created_at
+                     ) VALUES (?1, ?2, 'yolo11m', 'dog', 0.9, 0, 0, 1, 1, '2026-01-01')",
+                    params![format!("det-{index}"), id],
+                )
+                .unwrap();
+        }
+
+        let names = db
+            .name_embedding_clusters(&[
+                EmbeddingClusterMembership {
+                    cluster_id: 0,
+                    image_ids: vec!["tag-a".into(), "tag-b".into()],
+                },
+                EmbeddingClusterMembership {
+                    cluster_id: 1,
+                    image_ids: vec!["dog-a".into(), "dog-b".into()],
+                },
+                EmbeddingClusterMembership {
+                    cluster_id: 2,
+                    image_ids: vec!["file-a".into(), "file-b".into()],
+                },
+            ])
+            .unwrap();
+
+        assert_eq!(
+            names,
+            vec![
+                EmbeddingClusterName {
+                    cluster_id: 0,
+                    label: "Golden Hour".into(),
+                    source: "tag".into(),
+                },
+                EmbeddingClusterName {
+                    cluster_id: 1,
+                    label: "Dog".into(),
+                    source: "yolo".into(),
+                },
+                EmbeddingClusterName {
+                    cluster_id: 2,
+                    label: "Mountain".into(),
+                    source: "filename".into(),
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn cluster_names_dedupe_ids_and_break_equal_scores_alphabetically() {
+        let db = open_test_db();
+        insert_scoped_image(&db, "apple", "/library/apple_01.png", 500, 500, None);
+        insert_scoped_image(&db, "zebra", "/library/zebra_01.png", 500, 500, None);
+
+        let first = db
+            .name_embedding_clusters(&[EmbeddingClusterMembership {
+                cluster_id: 7,
+                image_ids: vec!["zebra".into(), "apple".into(), "apple".into()],
+            }])
+            .unwrap();
+        let second = db
+            .name_embedding_clusters(&[EmbeddingClusterMembership {
+                cluster_id: 7,
+                image_ids: vec!["apple".into(), "zebra".into()],
+            }])
+            .unwrap();
+
+        assert_eq!(first, second);
+        assert_eq!(first[0].label, "Apple");
+        assert_eq!(first[0].source, "filename");
+    }
+
+    #[test]
+    fn cluster_names_canonicalize_equal_weight_tag_and_yolo_evidence() {
+        let db = open_test_db();
+        insert_scoped_image(&db, "tagged", "/library/a.png", 500, 500, None);
+        insert_scoped_image(&db, "detected", "/library/b.png", 500, 500, None);
+        db.add_image_tag(
+            "tagged",
+            "golden_hour",
+            "object",
+            "metadata:vision",
+            Some(0.8),
+        )
+        .unwrap();
+        db.conn
+            .lock()
+            .execute(
+                "INSERT INTO detections (
+                    id, image_id, model_name, class_name, confidence,
+                    x, y, width, height, created_at
+                 ) VALUES ('det-mixed', 'detected', 'yolo11m', 'golden hour', 0.9, 0, 0, 1, 1, '2026-01-01')",
+                [],
+            )
+            .unwrap();
+
+        let names = db
+            .name_embedding_clusters(&[EmbeddingClusterMembership {
+                cluster_id: 3,
+                image_ids: vec!["detected".into(), "tagged".into()],
+            }])
+            .unwrap();
+
+        assert_eq!(names[0].label, "Golden Hour");
+        assert_eq!(names[0].source, "tag");
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -598,6 +598,7 @@ pub fn run() {
             commands::embeddings::get_embedding_page,
             commands::embeddings::get_scoped_embedding_page,
             commands::embeddings::list_scoped_image_ids,
+            commands::embeddings::name_embedding_clusters,
             commands::embeddings::find_similar_images,
             commands::embeddings::find_similar_images_in_scope,
             commands::embeddings::generate_similarity_groups,

--- a/src-tauri/src/services/ai.rs
+++ b/src-tauri/src/services/ai.rs
@@ -1,9 +1,9 @@
 use crate::db_core::color;
 use crate::db_core::detection::Detection;
 use crate::db_core::models::{
-    EmbeddingPage, EmbeddingScope, ImageColorMetrics, ImageIdPage, ImagePerceptualHash,
-    ImageQualityMetrics, ImageWithFile, NearDuplicateImage, SimilarityGroupSummary,
-    SimilarityGroupingResult,
+    EmbeddingClusterMembership, EmbeddingClusterName, EmbeddingPage, EmbeddingScope,
+    ImageColorMetrics, ImageIdPage, ImagePerceptualHash, ImageQualityMetrics, ImageWithFile,
+    NearDuplicateImage, SimilarityGroupSummary, SimilarityGroupingResult,
 };
 use crate::db_core::perceptual_hash::{self, PHASH_ALGORITHM};
 use crate::db_core::quality;
@@ -90,6 +90,35 @@ pub fn list_scoped_image_ids(
 ) -> Result<ImageIdPage, ServiceError> {
     let limit = page.limit.clamp(1, 100);
     Ok(ctx.db.list_scoped_image_ids(scope, limit, page.offset)?)
+}
+
+fn validate_embedding_cluster_memberships(
+    clusters: &[EmbeddingClusterMembership],
+) -> Result<(), ServiceError> {
+    if clusters.len() > 16 {
+        return Err(ServiceError::InvalidInput(
+            "At most 16 embedding clusters can be named at once".to_string(),
+        ));
+    }
+    let total_ids = clusters.iter().try_fold(0usize, |total, cluster| {
+        total
+            .checked_add(cluster.image_ids.len())
+            .ok_or_else(|| ServiceError::InvalidInput("Too many cluster image IDs".to_string()))
+    })?;
+    if total_ids > 5000 {
+        return Err(ServiceError::InvalidInput(
+            "At most 5000 projected image IDs can be named at once".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+pub fn name_embedding_clusters(
+    ctx: &ServiceContext,
+    clusters: &[EmbeddingClusterMembership],
+) -> Result<Vec<EmbeddingClusterName>, ServiceError> {
+    validate_embedding_cluster_memberships(clusters)?;
+    Ok(ctx.db.name_embedding_clusters(clusters)?)
 }
 
 pub fn get_embedding_count(ctx: &ServiceContext, model: Option<&str>) -> Result<u32, ServiceError> {
@@ -466,6 +495,29 @@ mod tests {
     use crate::db_core::secrets::MemoryStore;
     use parking_lot::Mutex;
     use std::path::PathBuf;
+
+    #[test]
+    fn cluster_naming_request_bounds_match_projection_limits() {
+        let too_many_clusters = (0..17)
+            .map(|cluster_id| EmbeddingClusterMembership {
+                cluster_id,
+                image_ids: Vec::new(),
+            })
+            .collect::<Vec<_>>();
+        assert!(matches!(
+            validate_embedding_cluster_memberships(&too_many_clusters),
+            Err(ServiceError::InvalidInput(_))
+        ));
+
+        let too_many_ids = vec![EmbeddingClusterMembership {
+            cluster_id: 0,
+            image_ids: (0..5001).map(|index| format!("image-{index}")).collect(),
+        }];
+        assert!(matches!(
+            validate_embedding_cluster_memberships(&too_many_ids),
+            Err(ServiceError::InvalidInput(_))
+        ));
+    }
 
     fn make_ctx_parts() -> (
         Database,

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1105,6 +1105,23 @@ export async function listScopedImageIds(
     return invoke('list_scoped_image_ids', { scope, limit, offset });
 }
 
+export interface EmbeddingClusterMembership {
+    cluster_id: number;
+    image_ids: string[];
+}
+
+export interface EmbeddingClusterName {
+    cluster_id: number;
+    label: string;
+    source: 'tag' | 'yolo' | 'filename';
+}
+
+export async function nameEmbeddingClusters(
+    clusters: EmbeddingClusterMembership[],
+): Promise<EmbeddingClusterName[]> {
+    return invoke('name_embedding_clusters', { clusters });
+}
+
 export async function findSimilarImages(imageId: string, topK: number, model?: string): Promise<[string, number][]> {
     return invoke('find_similar_images', { imageId, topK, model: model ?? null });
 }

--- a/src/lib/components/EmbeddingExplorer.svelte
+++ b/src/lib/components/EmbeddingExplorer.svelte
@@ -48,6 +48,7 @@
         resumeJob,
         createCollectionWithImages,
         listCollections,
+        nameEmbeddingClusters,
     } from '$lib/api';
     import type {
         EmbeddingGenerationMode,
@@ -380,6 +381,7 @@
     async function selectProvider(provider: EmbeddingProvider) {
         if (provider === selectedProvider) return;
         providerConfigLoadSeq += 1;
+        projectionLoadSeq += 1;
         providerKeyInput = '';
         providerConfigStatus = 'idle';
         selectedProvider = provider;
@@ -1490,6 +1492,36 @@
         projectionWorker = null;
     }
 
+    async function applyAutomaticClusterNames(
+        projection: ProjectionWorkerResponse,
+        loadSeq: number,
+        requestedScopeKey: string,
+        requestedProvider: EmbeddingProvider,
+        requestedModelName: string,
+    ) {
+        try {
+            const memberships = projection.clusters.map(cluster => ({
+                cluster_id: cluster.id,
+                image_ids: projection.points
+                    .filter(point => point.cluster === cluster.id)
+                    .map(point => point.id),
+            }));
+            const names = await nameEmbeddingClusters(memberships);
+            if (loadSeq !== projectionLoadSeq) return;
+            if (requestedScopeKey !== libraryScopeKey(get(libraryScope))) return;
+            if (selectedProvider !== requestedProvider) return;
+            if (modelNameForProvider(selectedProvider) !== requestedModelName) return;
+            const namedClusters = new Map(names.map(item => [item.cluster_id, item.label]));
+            clusters = clusters.map(cluster => ({
+                ...cluster,
+                label: namedClusters.get(cluster.id) ?? cluster.label,
+            }));
+            requestDraw();
+        } catch (error) {
+            console.warn('Failed to auto-name embedding clusters:', error);
+        }
+    }
+
     async function loadProjection(scope: LibraryScope = get(libraryScope)) {
         const loadSeq = ++projectionLoadSeq;
         try {
@@ -1559,6 +1591,13 @@
 
             resetThumbnailCache();
             requestDraw();
+            void applyAutomaticClusterNames(
+                projection,
+                loadSeq,
+                requestedScopeKey,
+                selectedProvider,
+                modelName,
+            );
         } catch (e) {
             if (e instanceof Error && e.message === 'Projection cancelled') return;
             console.error('Failed to load projection:', e);

--- a/src/lib/components/embedding-explorer-scope.behavior.test.ts
+++ b/src/lib/components/embedding-explorer-scope.behavior.test.ts
@@ -23,6 +23,7 @@ const mocks = vi.hoisted(() => ({
     loadEmbeddingNeighbors: vi.fn(),
     createCollectionWithImages: vi.fn(),
     listCollections: vi.fn(),
+    nameEmbeddingClusters: vi.fn(),
     eventListeners: new Map<string, Set<(event: { payload: Record<string, unknown> }) => void>>(),
     workerMessages: [] as Array<Record<string, unknown>>,
 }));
@@ -80,6 +81,7 @@ vi.mock('$lib/api', () => ({
     resumeJob: vi.fn(),
     createCollectionWithImages: mocks.createCollectionWithImages,
     listCollections: mocks.listCollections,
+    nameEmbeddingClusters: mocks.nameEmbeddingClusters,
 }));
 
 import EmbeddingExplorer from './EmbeddingExplorer.svelte';
@@ -231,6 +233,7 @@ beforeEach(() => {
     mocks.listEmbeddingProviders.mockResolvedValue([]);
     mocks.createCollectionWithImages.mockResolvedValue('collection-from-map');
     mocks.listCollections.mockResolvedValue([['collection-from-map', 'Map picks', 1]]);
+    mocks.nameEmbeddingClusters.mockResolvedValue([]);
     mocks.loadEmbeddingNeighbors.mockResolvedValue([
         { image: image('near-one'), score: 0.934 },
     ]);
@@ -698,6 +701,42 @@ describe('Embedding Explorer library scope', () => {
         ));
         await waitFor(() => expect(get(collections)).toEqual([['collection-from-map', 'Map picks', 1]]));
         expect(await screen.findByText('0 images selected')).toBeInTheDocument();
+    });
+
+    it('uses backend tag and detection evidence to auto-name projected clusters', async () => {
+        mocks.nameEmbeddingClusters.mockResolvedValue([
+            { cluster_id: 0, label: 'Golden Hour', source: 'tag' },
+        ]);
+        render(EmbeddingExplorer);
+
+        expect(await screen.findByText('Golden Hour')).toBeInTheDocument();
+        expect(mocks.nameEmbeddingClusters).toHaveBeenCalledWith([
+            { cluster_id: 0, image_ids: ['in-a', 'in-b'] },
+        ]);
+    });
+
+    it('renders the projection before naming completes and ignores a stale provider label', async () => {
+        const user = userEvent.setup();
+        let resolveOldName!: (value: Array<{ cluster_id: number; label: string; source: string }>) => void;
+        mocks.nameEmbeddingClusters
+            .mockReturnValueOnce(new Promise(resolve => {
+                resolveOldName = resolve;
+            }))
+            .mockResolvedValueOnce([
+                { cluster_id: 0, label: 'New Provider Cluster', source: 'filename' },
+            ]);
+
+        render(EmbeddingExplorer);
+        expect(await screen.findByText('Cluster 1')).toBeInTheDocument();
+
+        await user.click(screen.getByRole('button', { name: 'Configure embedding model' }));
+        await user.selectOptions(screen.getByRole('combobox', { name: 'Embedding provider' }), 'dinov2');
+        expect(await screen.findByText('New Provider Cluster')).toBeInTheDocument();
+
+        resolveOldName([{ cluster_id: 0, label: 'Old Provider Cluster', source: 'tag' }]);
+        await tick();
+        expect(screen.queryByText('Old Provider Cluster')).not.toBeInTheDocument();
+        expect(screen.getByText('New Provider Cluster')).toBeInTheDocument();
     });
 
     it('supports keyboard point selection and Escape from a focused selection control', async () => {


### PR DESCRIPTION
## Summary
- auto-name Embedding Explorer clusters from canonical tags, YOLO detections, and filename tokens
- keep existing folder labels as an immediate fallback, then enrich labels asynchronously
- make scoring, source precedence, ID deduplication, and tie-breaking deterministic
- guard delayed labels across projection, scope, provider, and model changes

## Verification
- Spec review: PASS
- Standards/correctness review: PASS
- focused frontend/API: 26/26
- focused Rust cluster naming: 4/4
- full frontend: 167 files, 1258 tests passed
- full Rust: 833 passed, 3 ignored
- `npm run check`: 0 errors, 0 warnings (known nested-site notice only)
- `cargo fmt --all -- --check`: PASS
- `cargo clippy --all-targets`: PASS (pre-existing warnings only)
- production build: PASS
- `git diff --check`: PASS

Closes imageview-eus