### PR TITLE
feat(cli): add search_by_object parity command

### DIFF
--- a/docs/cli-and-url-scheme.md
+++ b/docs/cli-and-url-scheme.md
@@ -4,7 +4,7 @@ Version: 0.1.0 — Draft, 2026-05-07
 
 Cull ships a single `cull` binary. With no subcommand it launches the GUI. With a subcommand it runs headless and exits. Every operation available in the GUI has a CLI equivalent and a URL scheme equivalent.
 
-> Current implementation note: the shipped headless slice is MCP-aligned. Implemented commands use MCP tool names and JSON parameter field names: `get_library_stats`, `list_images`, `list_folders`, `list_collections`, `import_folder`, `import_files`, `list_export_presets`, `export_images`, embedding/model commands, quality commands, and `set_rating`. The broader CLI below remains the draft target.
+> Current implementation note: the shipped headless slice is MCP-aligned. Implemented commands use MCP tool names and JSON parameter field names: `get_library_stats`, `list_images`, `list_folders`, `list_collections`, `import_folder`, `import_files`, `list_export_presets`, `export_images`, embedding/model commands, quality commands, `search_by_object`, and `set_rating`. The broader CLI below remains the draft target.
 >
 > CLI implementation standards and module ownership rules live in [agent-cli-standards.md](agent-cli-standards.md).
 
@@ -23,6 +23,7 @@ cull --json list_export_presets
 cull --json export_images --image_ids id1,id2 --output_dir /tmp/cull-export --format original
 cull --json export_images --collection_id <collection-id> --output_dir /tmp/cull-export --format webp
 cull --json export_images --folder_path /path/to/images --output_dir /tmp/cull-export --format png --flatten false
+cull --json search_by_object --class_name person --limit 20
 cull --json set_rating --image_id id1 --rating 4
 ```
 
@@ -31,7 +32,10 @@ For agents that already have MCP-shaped params, `call_tool` accepts the same too
 ```bash
 cull --json call_tool import_folder --params_json '{"folder_path":"/path/to/images"}'
 cull --json call_tool export_images --params_json '{"collection_id":"<collection-id>","output_dir":"/tmp/cull-export","format":"original"}'
+cull --json call_tool search_by_object --params_json '{"class_name":"person","limit":20}'
 ```
+
+`search_by_object` queries detections already stored in the library; it does not run a detector or download model weights. Results are ordered by highest confidence and contain `image_id` plus `confidence`.
 
 ### Invocation
 

--- a/src-tauri/src/cli/mod.rs
+++ b/src-tauri/src/cli/mod.rs
@@ -162,6 +162,15 @@ pub enum CliCommand {
     #[command(name = "get_quality_count")]
     GetQualityCount,
 
+    /// Search images by an object class already detected in the library
+    #[command(name = "search_by_object")]
+    SearchByObject {
+        #[arg(long = "class_name", visible_alias = "class-name")]
+        class_name: String,
+        #[arg(long)]
+        limit: Option<u32>,
+    },
+
     /// Set a 0-5 star rating on a library image
     #[command(name = "set_rating")]
     SetRating {
@@ -277,6 +286,11 @@ fn execute_headless(args: &CliArgs) -> Result<Value, String> {
         CliCommand::GetQualityCount => {
             tools::execute_named_tool(&ctx, "get_quality_count", serde_json::json!({}))
         }
+        CliCommand::SearchByObject { class_name, limit } => tools::execute_named_tool(
+            &ctx,
+            "search_by_object",
+            serde_json::json!({ "class_name": class_name, "limit": limit }),
+        ),
         CliCommand::SetRating { image_id, rating } => tools::execute_named_tool(
             &ctx,
             "set_rating",
@@ -528,6 +542,74 @@ mod tests {
             "6",
         ])
         .is_err());
+    }
+
+    #[test]
+    fn test_search_by_object_subcommand_accepts_mcp_field_names() {
+        let args = CliArgs::try_parse_from([
+            "cull",
+            "search_by_object",
+            "--class_name",
+            "person",
+            "--limit",
+            "12",
+        ])
+        .unwrap();
+
+        match args.command {
+            Some(CliCommand::SearchByObject { class_name, limit }) => {
+                assert_eq!(class_name, "person");
+                assert_eq!(limit, Some(12));
+            }
+            other => panic!("expected search_by_object command, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_search_by_object_typed_dispatch_reads_temporary_database() {
+        let tmp = tempfile::tempdir().unwrap();
+        let db_path = tmp.path().join("cull.db");
+        let db = crate::db_core::db::Database::open(&db_path).unwrap();
+        db.conn
+            .lock()
+            .execute(
+                "INSERT INTO images (id, sha256_hash, width, height, format, file_size, created_at, imported_at)
+                 VALUES ('img1', 'hash-img1', 100, 100, 'png', 1000, '2026-01-01', '2026-01-01')",
+                [],
+            )
+            .unwrap();
+        db.store_detections(
+            "img1",
+            "yolo11m",
+            &[crate::db_core::detection::Detection {
+                class_name: "person".to_string(),
+                confidence: 0.88,
+                x: 0.0,
+                y: 0.0,
+                width: 1.0,
+                height: 1.0,
+            }],
+        )
+        .unwrap();
+        drop(db);
+
+        let args = CliArgs::try_parse_from([
+            "cull",
+            "--db",
+            db_path.to_str().unwrap(),
+            "--app-data-dir",
+            tmp.path().to_str().unwrap(),
+            "search_by_object",
+            "--class_name",
+            "person",
+        ])
+        .unwrap();
+
+        let result = execute_headless(&args).unwrap();
+        let matches = result.as_array().unwrap();
+        assert_eq!(matches.len(), 1);
+        assert_eq!(matches[0]["image_id"], "img1");
+        assert!((matches[0]["confidence"].as_f64().unwrap() - 0.88).abs() < 0.000_001);
     }
 
     #[test]

--- a/src-tauri/src/cli/output.rs
+++ b/src-tauri/src/cli/output.rs
@@ -43,6 +43,23 @@ mod tests {
         assert!(human.contains("\"rating\""));
         assert!(human.contains('\n'));
     }
+
+    #[test]
+    fn success_output_reports_object_matches_in_json_and_human_modes() {
+        let value = serde_json::json!([
+            { "image_id": "img-high", "confidence": 0.93 },
+            { "image_id": "img-low", "confidence": 0.71 }
+        ]);
+
+        let json = success_output(true, &value);
+        assert_eq!(serde_json::from_str::<Value>(&json).unwrap(), value);
+        assert!(!json.contains('\n'));
+
+        let human = success_output(false, &value);
+        assert!(human.contains("\"img-high\""));
+        assert!(human.contains("\"confidence\""));
+        assert!(human.contains('\n'));
+    }
 }
 
 pub fn print_error(json: bool, message: &str) {

--- a/src-tauri/src/cli/tools/mod.rs
+++ b/src-tauri/src/cli/tools/mod.rs
@@ -9,6 +9,7 @@ mod export;
 mod import;
 mod library;
 mod quality;
+mod search;
 
 pub const SUPPORTED_TOOLS: &[&str] = &[
     "approve_catalog_values",
@@ -33,6 +34,7 @@ pub const SUPPORTED_TOOLS: &[&str] = &[
     "import_files",
     "reject_catalog_values",
     "set_rating",
+    "search_by_object",
     "set_catalog_draft_value",
     "set_catalog_draft_values",
     "suggest_catalog_values",
@@ -73,6 +75,7 @@ pub fn execute_named_tool(
         "import_files" => import::import_files(ctx, params),
         "reject_catalog_values" => catalog::reject_catalog_values(ctx, params),
         "set_rating" => curation::set_rating(ctx, params),
+        "search_by_object" => search::search_by_object(ctx, params),
         "set_catalog_draft_value" => catalog::set_catalog_draft_value(ctx, params),
         "set_catalog_draft_values" => catalog::set_catalog_draft_values(ctx, params),
         "suggest_catalog_values" => catalog::suggest_catalog_values(ctx, params),
@@ -92,5 +95,58 @@ pub fn execute_named_tool(
             other,
             SUPPORTED_TOOLS.join(", ")
         )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db_core::db::Database;
+
+    #[test]
+    fn named_search_by_object_dispatches_with_mcp_shaped_params() {
+        let tmp = tempfile::tempdir().unwrap();
+        let db = Database::open(std::path::Path::new(":memory:")).unwrap();
+        for (id, confidence) in [("lower", 0.61), ("higher", 0.94)] {
+            db.conn
+                .lock()
+                .execute(
+                    "INSERT INTO images (id, sha256_hash, width, height, format, file_size, created_at, imported_at)
+                     VALUES (?1, ?2, 100, 100, 'png', 1000, '2026-01-01', '2026-01-01')",
+                    rusqlite::params![id, format!("hash-{id}")],
+                )
+                .unwrap();
+            db.store_detections(
+                id,
+                "yolo11m",
+                &[crate::db_core::detection::Detection {
+                    class_name: "person".to_string(),
+                    confidence,
+                    x: 0.0,
+                    y: 0.0,
+                    width: 1.0,
+                    height: 1.0,
+                }],
+            )
+            .unwrap();
+        }
+        let ctx = HeadlessContext {
+            db,
+            app_data_dir: tmp.path().to_path_buf(),
+        };
+
+        let result = execute_named_tool(
+            &ctx,
+            "search_by_object",
+            serde_json::json!({ "class_name": "person", "limit": 10 }),
+        )
+        .unwrap();
+
+        let matches = result.as_array().unwrap();
+        assert_eq!(matches.len(), 2);
+        assert_eq!(matches[0]["image_id"], "higher");
+        assert!((matches[0]["confidence"].as_f64().unwrap() - 0.94).abs() < 0.000_001);
+        assert_eq!(matches[1]["image_id"], "lower");
+        assert!((matches[1]["confidence"].as_f64().unwrap() - 0.61).abs() < 0.000_001);
     }
 }

--- a/src-tauri/src/cli/tools/search.rs
+++ b/src-tauri/src/cli/tools/search.rs
@@ -1,0 +1,13 @@
+use serde_json::Value;
+
+use crate::services::ai::{self as ai_service, SearchByObjectParams};
+
+use super::HeadlessContext;
+
+pub fn search_by_object(ctx: &HeadlessContext, params: Value) -> Result<Value, String> {
+    let parsed: SearchByObjectParams = serde_json::from_value(params)
+        .map_err(|error| format!("Invalid search_by_object params: {error}"))?;
+    let matches = ai_service::search_by_object_in_database(&ctx.db, &parsed)
+        .map_err(|error| error.to_string())?;
+    serde_json::to_value(matches).map_err(|error| error.to_string())
+}

--- a/src-tauri/src/db_core/queries/detection.rs
+++ b/src-tauri/src/db_core/queries/detection.rs
@@ -3,7 +3,9 @@
 
 use crate::db_core::db::{row_u64, Database};
 use crate::db_core::models::*;
+use crate::db_core::queries::images::image_scope_filter;
 use crate::db_core::visibility::RejectedVisibility;
+use rusqlite::types::Value;
 use rusqlite::{params, Result};
 
 impl Database {
@@ -84,13 +86,48 @@ impl Database {
     }
 
     pub fn search_by_class(&self, class_name: &str, limit: u32) -> Result<Vec<(String, f32)>> {
-        let conn = self.conn.lock();
+        let conn = self.read_connection();
         let mut stmt = conn.prepare(
             "SELECT DISTINCT image_id, MAX(confidence) as max_conf
              FROM detections WHERE class_name = ?1
-             GROUP BY image_id ORDER BY max_conf DESC LIMIT ?2",
+             GROUP BY image_id ORDER BY max_conf DESC, image_id ASC LIMIT ?2",
         )?;
         let rows = stmt.query_map(params![class_name, limit], |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, f32>(1)?))
+        })?;
+        rows.collect::<Result<Vec<_>>>()
+    }
+
+    pub fn search_by_class_in_scope(
+        &self,
+        class_name: &str,
+        folders: &[String],
+        collections: &[String],
+        tag_norms: &[String],
+        limit: u32,
+    ) -> Result<Vec<(String, f32)>> {
+        let Some((scope_filter, scope_args)) = image_scope_filter(folders, collections, tag_norms)
+        else {
+            return Ok(Vec::new());
+        };
+        let sql = format!(
+            "SELECT d.image_id, MAX(d.confidence) AS max_conf
+             FROM detections d
+             JOIN images i ON i.id = d.image_id
+             JOIN image_files f ON f.image_id = i.id AND f.missing_at IS NULL
+             WHERE d.class_name = ? AND ({scope_filter})
+             GROUP BY d.image_id
+             ORDER BY max_conf DESC, d.image_id ASC
+             LIMIT ?"
+        );
+        let mut args = Vec::with_capacity(scope_args.len() + 2);
+        args.push(Value::Text(class_name.to_string()));
+        args.extend(scope_args);
+        args.push(Value::Integer(limit as i64));
+
+        let conn = self.read_connection();
+        let mut stmt = conn.prepare(&sql)?;
+        let rows = stmt.query_map(rusqlite::params_from_iter(args), |row| {
             Ok((row.get::<_, String>(0)?, row.get::<_, f32>(1)?))
         })?;
         rows.collect::<Result<Vec<_>>>()

--- a/src-tauri/src/db_core/queries/images.rs
+++ b/src-tauri/src/db_core/queries/images.rs
@@ -9,6 +9,7 @@ use crate::db_core::db::{
 use crate::db_core::db::Database;
 use crate::db_core::models::*;
 use crate::db_core::visibility::RejectedVisibility;
+use rusqlite::types::Value;
 use rusqlite::{params, OptionalExtension, Result, Transaction};
 use std::collections::HashSet;
 use std::path::{Component, Path};
@@ -20,6 +21,45 @@ pub struct FolderPathMigration {
     pub sessions: usize,
     pub canvases: usize,
     pub generation_runs: usize,
+}
+
+pub(crate) fn image_scope_filter(
+    folders: &[String],
+    collections: &[String],
+    tag_norms: &[String],
+) -> Option<(String, Vec<Value>)> {
+    let mut clauses = Vec::new();
+    let mut args = Vec::new();
+
+    for folder in folders {
+        let folder = folder.trim_end_matches('/');
+        let prefix = format!("{folder}/");
+        // Use a binary substr prefix rather than LIKE so `%`, `_`, and path
+        // casing remain literal, matching folder browsing semantics.
+        clauses.push(
+            "(f.path = ? OR substr(f.path, 1, ?) COLLATE BINARY = ? COLLATE BINARY)".to_string(),
+        );
+        args.push(Value::Text(folder.to_string()));
+        args.push(Value::Integer(prefix.chars().count() as i64));
+        args.push(Value::Text(prefix));
+    }
+    if !collections.is_empty() {
+        let placeholders = vec!["?"; collections.len()].join(",");
+        clauses.push(format!(
+            "i.id IN (SELECT image_id FROM collection_items WHERE collection_id IN ({placeholders}))"
+        ));
+        args.extend(collections.iter().cloned().map(Value::Text));
+    }
+    if !tag_norms.is_empty() {
+        let placeholders = vec!["?"; tag_norms.len()].join(",");
+        clauses.push(format!(
+            "i.id IN (SELECT it.image_id FROM image_tags it JOIN tags t ON t.id = it.tag_id \
+             WHERE t.normalized_name IN ({placeholders}))"
+        ));
+        args.extend(tag_norms.iter().cloned().map(Value::Text));
+    }
+
+    (!clauses.is_empty()).then(|| (clauses.join(" OR "), args))
 }
 
 fn invalid_path(message: impl Into<String>) -> rusqlite::Error {
@@ -393,55 +433,10 @@ impl Database {
         limit: u32,
         offset: u32,
     ) -> Result<Vec<ImageWithFile>> {
-        use rusqlite::types::Value;
-
-        if folders.is_empty() && collections.is_empty() && tag_norms.is_empty() {
+        let Some((scope_filter, mut args)) = image_scope_filter(folders, collections, tag_norms)
+        else {
             return Ok(Vec::new());
-        }
-
-        let mut clauses: Vec<String> = Vec::new();
-        let mut args: Vec<Value> = Vec::new();
-
-        for folder in folders {
-            let folder = folder.trim_end_matches('/');
-            // Exact folder OR any descendant. The descendant test is a substr
-            // prefix comparison rather than LIKE: `_` and `%` are LIKE
-            // wildcards, so a folder named `2025_Trips` would also pull in
-            // `2025XTrips`, and LIKE is ASCII-case-insensitive, which would
-            // merge `/lib/Art` and `/lib/art` into one result set even though
-            // the sidebar shows them as two folders with separate counts.
-            // COLLATE BINARY keeps both distinctions. Matches
-            // list_images_by_folder and delete_images_by_folder.
-            let prefix = format!("{}/", folder);
-            clauses.push(
-                "(f.path = ? OR substr(f.path, 1, ?) COLLATE BINARY = ? COLLATE BINARY)"
-                    .to_string(),
-            );
-            args.push(Value::Text(folder.to_string()));
-            args.push(Value::Integer(prefix.chars().count() as i64));
-            args.push(Value::Text(prefix));
-        }
-        if !collections.is_empty() {
-            let placeholders = vec!["?"; collections.len()].join(",");
-            clauses.push(format!(
-                "i.id IN (SELECT image_id FROM collection_items WHERE collection_id IN ({}))",
-                placeholders
-            ));
-            for c in collections {
-                args.push(Value::Text(c.clone()));
-            }
-        }
-        if !tag_norms.is_empty() {
-            let placeholders = vec!["?"; tag_norms.len()].join(",");
-            clauses.push(format!(
-                "i.id IN (SELECT it.image_id FROM image_tags it JOIN tags t ON t.id = it.tag_id \
-                 WHERE t.normalized_name IN ({}))",
-                placeholders
-            ));
-            for t in tag_norms {
-                args.push(Value::Text(t.clone()));
-            }
-        }
+        };
 
         let sql = format!(
             "SELECT i.id, i.sha256_hash, i.width, i.height, i.format, i.file_size,
@@ -455,7 +450,7 @@ impl Database {
              GROUP BY i.id
              ORDER BY i.imported_at DESC, i.id ASC
              LIMIT ? OFFSET ?",
-            clauses.join(" OR ")
+            scope_filter
         );
         args.push(Value::Integer(limit as i64));
         args.push(Value::Integer(offset as i64));

--- a/src-tauri/src/mcp/tools.rs
+++ b/src-tauri/src/mcp/tools.rs
@@ -13,6 +13,7 @@ use tauri::{Emitter, Manager};
 use super::auth::{require_capability, AuthContext};
 use crate::db_core::canvas_document::CanvasDocument;
 use crate::db_core::models::{Canvas, TokenScope};
+use crate::services::ai::{self as ai_service, SearchByObjectParams};
 use crate::services::curation::{self as curation_service, SetRatingParams};
 use crate::services::tokens;
 use crate::AppState;
@@ -695,14 +696,6 @@ pub struct FindSimilarParams {
     pub limit: Option<u32>,
     #[schemars(description = "Embedding model: 'clip-vit-b32' or 'dinov2-vits14'")]
     pub model: Option<String>,
-}
-
-#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
-pub struct SearchByObjectParams {
-    #[schemars(description = "Object class to search for, e.g. 'person', 'car', 'dog'")]
-    pub class_name: String,
-    #[schemars(description = "Max results (default 50)")]
-    pub limit: Option<u32>,
 }
 
 #[derive(Debug, serde::Deserialize, schemars::JsonSchema)]

--- a/src-tauri/src/mcp/tools/vision.rs
+++ b/src-tauri/src/mcp/tools/vision.rs
@@ -7,17 +7,21 @@ impl CullMcp {
     )]
     fn search_by_object(&self, Parameters(params): Parameters<SearchByObjectParams>) -> String {
         let state = self.app_handle.state::<AppState>();
-        let limit = clamp_limit(params.limit.unwrap_or(50));
-        match state.db.search_by_class(&params.class_name, limit * 2) {
-            Ok(results) => {
-                let r: Vec<serde_json::Value> = results.iter()
-                .filter(|(id, _)| self.check_image_id_scope(id).unwrap_or(false))
-                .take(limit as usize)
-                .map(|(id, confidence)| {
-                    serde_json::json!({"image_id": id, "confidence": confidence})
-                }).collect();
-                serde_json::to_string(&r).unwrap_or_else(|_| "[]".to_string())
+        let result = match self.token_scope() {
+            Some(scope) => {
+                let (folders, collections, tag_norms) = Self::scope_dimensions(&scope);
+                ai_service::search_by_object_in_scope_database(
+                    &state.db,
+                    &params,
+                    &folders,
+                    &collections,
+                    &tag_norms,
+                )
             }
+            None => ai_service::search_by_object_in_database(&state.db, &params),
+        };
+        match result {
+            Ok(results) => serde_json::to_string(&results).unwrap_or_else(|_| "[]".to_string()),
             Err(e) => format!("Error: {}", e),
         }
     }

--- a/src-tauri/src/services/ai.rs
+++ b/src-tauri/src/services/ai.rs
@@ -1,4 +1,5 @@
 use crate::db_core::color;
+use crate::db_core::db::Database;
 use crate::db_core::detection::Detection;
 use crate::db_core::models::{
     EmbeddingClusterMembership, EmbeddingClusterName, EmbeddingPage, EmbeddingScope,
@@ -14,6 +15,67 @@ use std::collections::HashSet;
 const MAX_EMBEDDING_PAGE_SIZE: u32 = 5000;
 const MAX_SIMILAR_IMAGES: usize = 100;
 const SIMILARITY_GROUPING_METHOD: &str = "greedy_threshold_v1";
+
+#[derive(Debug, Clone, serde::Deserialize, schemars::JsonSchema)]
+pub struct SearchByObjectParams {
+    #[schemars(description = "Object class to search for, e.g. 'person', 'car', 'dog'")]
+    pub class_name: String,
+    #[schemars(description = "Max results (default 50, max 100)")]
+    pub limit: Option<u32>,
+}
+
+#[derive(Debug, Clone, PartialEq, serde::Serialize)]
+pub struct SearchByObjectMatch {
+    pub image_id: String,
+    pub confidence: f32,
+}
+
+pub fn search_by_object_in_database(
+    db: &Database,
+    params: &SearchByObjectParams,
+) -> Result<Vec<SearchByObjectMatch>, ServiceError> {
+    let (class_name, limit) = validate_object_search(params)?;
+    Ok(object_search_matches(
+        db.search_by_class(class_name, limit)?,
+    ))
+}
+
+pub fn search_by_object_in_scope_database(
+    db: &Database,
+    params: &SearchByObjectParams,
+    folders: &[String],
+    collections: &[String],
+    tag_norms: &[String],
+) -> Result<Vec<SearchByObjectMatch>, ServiceError> {
+    let (class_name, limit) = validate_object_search(params)?;
+    Ok(object_search_matches(db.search_by_class_in_scope(
+        class_name,
+        folders,
+        collections,
+        tag_norms,
+        limit,
+    )?))
+}
+
+fn validate_object_search(params: &SearchByObjectParams) -> Result<(&str, u32), ServiceError> {
+    let class_name = params.class_name.trim();
+    if class_name.is_empty() {
+        return Err(ServiceError::InvalidInput(
+            "class_name must not be empty".to_string(),
+        ));
+    }
+    Ok((class_name, params.limit.unwrap_or(50).clamp(1, 100)))
+}
+
+fn object_search_matches(results: Vec<(String, f32)>) -> Vec<SearchByObjectMatch> {
+    results
+        .into_iter()
+        .map(|(image_id, confidence)| SearchByObjectMatch {
+            image_id,
+            confidence,
+        })
+        .collect()
+}
 
 /// Upper bound on the number of embeddings `generate_similarity_groups` will
 /// process in a single call. Grouping is O(N^2) pairwise comparisons, so at
@@ -707,6 +769,176 @@ mod tests {
         let c = ctx(&db, &s, &d, &ee, &de, &se);
         let result = search_by_detected_class(&c, "person", 50).unwrap();
         assert!(result.is_empty());
+    }
+
+    #[test]
+    fn search_by_object_returns_ranked_matches_from_shared_params() {
+        let (db, _s, _d, _ee, _de, _se, _tmp) = make_ctx_parts();
+        insert_test_image(&db, "lower");
+        insert_test_image(&db, "higher");
+        db.store_detections(
+            "lower",
+            "yolo11m",
+            &[Detection {
+                class_name: "person".to_string(),
+                confidence: 0.72,
+                x: 0.0,
+                y: 0.0,
+                width: 1.0,
+                height: 1.0,
+            }],
+        )
+        .unwrap();
+        db.store_detections(
+            "higher",
+            "yolo11m",
+            &[Detection {
+                class_name: "person".to_string(),
+                confidence: 0.96,
+                x: 0.0,
+                y: 0.0,
+                width: 1.0,
+                height: 1.0,
+            }],
+        )
+        .unwrap();
+
+        let matches = search_by_object_in_database(
+            &db,
+            &SearchByObjectParams {
+                class_name: "person".to_string(),
+                limit: Some(10),
+            },
+        )
+        .unwrap();
+
+        assert_eq!(matches.len(), 2);
+        assert_eq!(matches[0].image_id, "higher");
+        assert_eq!(matches[0].confidence, 0.96);
+        assert_eq!(matches[1].image_id, "lower");
+        assert_eq!(matches[1].confidence, 0.72);
+    }
+
+    #[test]
+    fn search_by_object_rejects_an_empty_class_name_before_querying() {
+        let (db, _s, _d, _ee, _de, _se, _tmp) = make_ctx_parts();
+
+        let error = search_by_object_in_database(
+            &db,
+            &SearchByObjectParams {
+                class_name: "   ".to_string(),
+                limit: None,
+            },
+        )
+        .unwrap_err();
+
+        assert!(matches!(error, ServiceError::InvalidInput(_)));
+        assert!(error.to_string().contains("class_name"));
+    }
+
+    #[test]
+    fn search_by_object_filters_candidates_before_applying_the_result_limit() {
+        let (db, _s, _d, _ee, _de, _se, _tmp) = make_ctx_parts();
+        for index in 0..105 {
+            let id = format!("outside-{index:03}");
+            insert_test_image(&db, &id);
+            db.store_detections(
+                &id,
+                "yolo11m",
+                &[Detection {
+                    class_name: "person".to_string(),
+                    confidence: 1.0 - index as f32 / 1_000.0,
+                    x: 0.0,
+                    y: 0.0,
+                    width: 1.0,
+                    height: 1.0,
+                }],
+            )
+            .unwrap();
+        }
+        insert_test_image(&db, "inside");
+        db.store_detections(
+            "inside",
+            "yolo11m",
+            &[Detection {
+                class_name: "person".to_string(),
+                confidence: 0.25,
+                x: 0.0,
+                y: 0.0,
+                width: 1.0,
+                height: 1.0,
+            }],
+        )
+        .unwrap();
+        let collection_id = db
+            .create_collection_with_images("Allowed", &["inside"])
+            .unwrap();
+
+        let matches = search_by_object_in_scope_database(
+            &db,
+            &SearchByObjectParams {
+                class_name: "person".to_string(),
+                limit: Some(2),
+            },
+            &[],
+            &[collection_id],
+            &[],
+        )
+        .unwrap();
+
+        assert_eq!(matches.len(), 1);
+        assert_eq!(matches[0].image_id, "inside");
+    }
+
+    #[test]
+    fn search_by_object_defaults_to_fifty_and_clamps_to_standard_bounds() {
+        let (db, _s, _d, _ee, _de, _se, _tmp) = make_ctx_parts();
+        for index in 0..105 {
+            let id = format!("image-{index:03}");
+            insert_test_image(&db, &id);
+            db.store_detections(
+                &id,
+                "yolo11m",
+                &[Detection {
+                    class_name: "person".to_string(),
+                    confidence: index as f32 / 105.0,
+                    x: 0.0,
+                    y: 0.0,
+                    width: 1.0,
+                    height: 1.0,
+                }],
+            )
+            .unwrap();
+        }
+
+        let default_results = search_by_object_in_database(
+            &db,
+            &SearchByObjectParams {
+                class_name: "person".to_string(),
+                limit: None,
+            },
+        )
+        .unwrap();
+        let maximum_results = search_by_object_in_database(
+            &db,
+            &SearchByObjectParams {
+                class_name: "person".to_string(),
+                limit: Some(u32::MAX),
+            },
+        )
+        .unwrap();
+        let minimum_results = search_by_object_in_database(
+            &db,
+            &SearchByObjectParams {
+                class_name: "person".to_string(),
+                limit: Some(0),
+            },
+        )
+        .unwrap();
+
+        assert_eq!(default_results.len(), 50);
+        assert_eq!(maximum_results.len(), 100);
+        assert_eq!(minimum_results.len(), 1);
     }
 
     fn insert_test_image(db: &Database, id: &str) {


### PR DESCRIPTION
## Summary
- add typed `cull search_by_object` and named `call_tool search_by_object` dispatch
- share MCP/CLI parameter validation and ranked result formatting
- apply MCP folder/collection/tag scope filtering in SQL before ordering and limiting
- document the stored-detection-only headless command

Closes imageview-24x.2 after Beads reconciliation.

## Validation
- `npm run preflight -- full` (exact HEAD): frontend 170 files / 1280 tests; Rust 848 passed / 3 ignored plus integration targets; Svelte check 0 errors / 0 warnings; clippy warnings pre-existing/non-fatal
- focused search/list-scope tests: 13/13
- independent Spec review: PASS
- independent Standards/correctness/security/performance review: PASS
- `git diff --check origin/main...HEAD`

## Push note
The pre-push hook rerun was skipped with `CULL_HOOK_SKIP_CHECKS=1` only after the exact-head full preflight completed successfully.