### PR TITLE
feat(cli): add find_similar parity command

### DIFF
--- a/docs/cli-and-url-scheme.md
+++ b/docs/cli-and-url-scheme.md
@@ -4,7 +4,7 @@ Version: 0.1.0 — Draft, 2026-05-07
 
 Cull ships a single `cull` binary. With no subcommand it launches the GUI. With a subcommand it runs headless and exits. Every operation available in the GUI has a CLI equivalent and a URL scheme equivalent.
 
-> Current implementation note: the shipped headless slice is MCP-aligned. Implemented commands use MCP tool names and JSON parameter field names: `get_library_stats`, `list_images`, `list_folders`, `list_collections`, `import_folder`, `import_files`, `list_export_presets`, `export_images`, embedding/model commands, quality commands, `search_by_object`, and `set_rating`. The broader CLI below remains the draft target.
+> Current implementation note: the shipped headless slice is MCP-aligned. Implemented commands use MCP tool names and JSON parameter field names: `get_library_stats`, `list_images`, `list_folders`, `list_collections`, `import_folder`, `import_files`, `list_export_presets`, `export_images`, embedding/model commands, quality commands, `find_similar`, `search_by_object`, and `set_rating`. The broader CLI below remains the draft target.
 >
 > CLI implementation standards and module ownership rules live in [agent-cli-standards.md](agent-cli-standards.md).
 
@@ -23,6 +23,7 @@ cull --json list_export_presets
 cull --json export_images --image_ids id1,id2 --output_dir /tmp/cull-export --format original
 cull --json export_images --collection_id <collection-id> --output_dir /tmp/cull-export --format webp
 cull --json export_images --folder_path /path/to/images --output_dir /tmp/cull-export --format png --flatten false
+cull --json find_similar --image_id id1 --limit 10 --model clip-vit-b32
 cull --json search_by_object --class_name person --limit 20
 cull --json set_rating --image_id id1 --rating 4
 ```
@@ -32,10 +33,13 @@ For agents that already have MCP-shaped params, `call_tool` accepts the same too
 ```bash
 cull --json call_tool import_folder --params_json '{"folder_path":"/path/to/images"}'
 cull --json call_tool export_images --params_json '{"collection_id":"<collection-id>","output_dir":"/tmp/cull-export","format":"original"}'
+cull --json call_tool find_similar --params_json '{"image_id":"id1","limit":10,"model":"clip-vit-b32"}'
 cull --json call_tool search_by_object --params_json '{"class_name":"person","limit":20}'
 ```
 
 `search_by_object` queries detections already stored in the library; it does not run a detector or download model weights. Results are ordered by highest confidence and contain `image_id` plus `confidence`.
+
+`find_similar` reads stored CLIP or DINOv2 embeddings only; it does not download a model or generate missing embeddings. Results exclude the source image, are ordered by similarity, and contain `image_id`, `similarity`, and `model`.
 
 ### Invocation
 

--- a/src-tauri/src/cli/mod.rs
+++ b/src-tauri/src/cli/mod.rs
@@ -162,6 +162,17 @@ pub enum CliCommand {
     #[command(name = "get_quality_count")]
     GetQualityCount,
 
+    /// Find visually similar images using stored CLIP or DINOv2 embeddings
+    #[command(name = "find_similar")]
+    FindSimilar {
+        #[arg(long = "image_id", visible_alias = "image-id")]
+        image_id: String,
+        #[arg(long)]
+        limit: Option<u32>,
+        #[arg(long)]
+        model: Option<String>,
+    },
+
     /// Search images by an object class already detected in the library
     #[command(name = "search_by_object")]
     SearchByObject {
@@ -286,6 +297,15 @@ fn execute_headless(args: &CliArgs) -> Result<Value, String> {
         CliCommand::GetQualityCount => {
             tools::execute_named_tool(&ctx, "get_quality_count", serde_json::json!({}))
         }
+        CliCommand::FindSimilar {
+            image_id,
+            limit,
+            model,
+        } => tools::execute_named_tool(
+            &ctx,
+            "find_similar",
+            serde_json::json!({ "image_id": image_id, "limit": limit, "model": model }),
+        ),
         CliCommand::SearchByObject { class_name, limit } => tools::execute_named_tool(
             &ctx,
             "search_by_object",
@@ -563,6 +583,85 @@ mod tests {
             }
             other => panic!("expected search_by_object command, got {:?}", other),
         }
+    }
+
+    #[test]
+    fn test_find_similar_subcommand_accepts_mcp_field_names() {
+        let args = CliArgs::try_parse_from([
+            "cull",
+            "find_similar",
+            "--image_id",
+            "img1",
+            "--limit",
+            "12",
+            "--model",
+            "dinov2-vits14",
+        ])
+        .unwrap();
+
+        match args.command {
+            Some(CliCommand::FindSimilar {
+                image_id,
+                limit,
+                model,
+            }) => {
+                assert_eq!(image_id, "img1");
+                assert_eq!(limit, Some(12));
+                assert_eq!(model.as_deref(), Some("dinov2-vits14"));
+            }
+            other => panic!("expected find_similar command, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_find_similar_typed_dispatch_reads_temporary_database() {
+        let tmp = tempfile::tempdir().unwrap();
+        let db_path = tmp.path().join("cull.db");
+        let db = crate::db_core::db::Database::open(&db_path).unwrap();
+        for (id, vector) in [
+            ("source", vec![1.0, 0.0]),
+            ("near", vec![0.8, 0.6]),
+            ("far", vec![0.0, 1.0]),
+        ] {
+            db.conn
+                .lock()
+                .execute(
+                    "INSERT INTO images (id, sha256_hash, width, height, format, file_size, created_at, imported_at)
+                     VALUES (?1, ?2, 100, 100, 'png', 1000, '2026-01-01', '2026-01-01')",
+                    rusqlite::params![id, format!("hash-{id}")],
+                )
+                .unwrap();
+            db.conn
+                .lock()
+                .execute(
+                    "INSERT INTO image_files (id, image_id, path, last_seen_at)
+                     VALUES (?1, ?2, ?3, '2026-01-01')",
+                    rusqlite::params![format!("file-{id}"), id, format!("/test/{id}.png")],
+                )
+                .unwrap();
+            db.store_embedding(id, "clip-vit-b32", &vector).unwrap();
+        }
+        drop(db);
+
+        let args = CliArgs::try_parse_from([
+            "cull",
+            "--db",
+            db_path.to_str().unwrap(),
+            "--app-data-dir",
+            tmp.path().to_str().unwrap(),
+            "find_similar",
+            "--image_id",
+            "source",
+            "--limit",
+            "2",
+        ])
+        .unwrap();
+
+        let result = execute_headless(&args).unwrap();
+        let matches = result.as_array().unwrap();
+        assert_eq!(matches.len(), 2);
+        assert_eq!(matches[0]["image_id"], "near");
+        assert_eq!(matches[1]["image_id"], "far");
     }
 
     #[test]

--- a/src-tauri/src/cli/output.rs
+++ b/src-tauri/src/cli/output.rs
@@ -60,6 +60,24 @@ mod tests {
         assert!(human.contains("\"confidence\""));
         assert!(human.contains('\n'));
     }
+
+    #[test]
+    fn success_output_reports_similarity_matches_in_json_and_human_modes() {
+        let value = serde_json::json!([
+            { "image_id": "near", "similarity": 0.94, "model": "clip-vit-b32" },
+            { "image_id": "far", "similarity": 0.42, "model": "clip-vit-b32" }
+        ]);
+
+        let json = success_output(true, &value);
+        assert_eq!(serde_json::from_str::<Value>(&json).unwrap(), value);
+        assert!(!json.contains('\n'));
+
+        let human = success_output(false, &value);
+        assert!(human.contains("\"near\""));
+        assert!(human.contains("\"similarity\""));
+        assert!(human.contains("\"clip-vit-b32\""));
+        assert!(human.contains('\n'));
+    }
 }
 
 pub fn print_error(json: bool, message: &str) {

--- a/src-tauri/src/cli/tools/mod.rs
+++ b/src-tauri/src/cli/tools/mod.rs
@@ -32,6 +32,7 @@ pub const SUPPORTED_TOOLS: &[&str] = &[
     "list_collections",
     "import_folder",
     "import_files",
+    "find_similar",
     "reject_catalog_values",
     "set_rating",
     "search_by_object",
@@ -73,6 +74,7 @@ pub fn execute_named_tool(
         "list_collections" => library::list_collections(ctx),
         "import_folder" => import::import_folder(ctx, params),
         "import_files" => import::import_files(ctx, params),
+        "find_similar" => search::find_similar(ctx, params),
         "reject_catalog_values" => catalog::reject_catalog_values(ctx, params),
         "set_rating" => curation::set_rating(ctx, params),
         "search_by_object" => search::search_by_object(ctx, params),
@@ -148,5 +150,53 @@ mod tests {
         assert!((matches[0]["confidence"].as_f64().unwrap() - 0.94).abs() < 0.000_001);
         assert_eq!(matches[1]["image_id"], "lower");
         assert!((matches[1]["confidence"].as_f64().unwrap() - 0.61).abs() < 0.000_001);
+    }
+
+    #[test]
+    fn named_find_similar_dispatches_with_mcp_shaped_params() {
+        let tmp = tempfile::tempdir().unwrap();
+        let db = Database::open(std::path::Path::new(":memory:")).unwrap();
+        for (id, vector) in [
+            ("source", vec![1.0, 0.0]),
+            ("near", vec![0.8, 0.6]),
+            ("far", vec![0.0, 1.0]),
+        ] {
+            db.conn
+                .lock()
+                .execute(
+                    "INSERT INTO images (id, sha256_hash, width, height, format, file_size, created_at, imported_at)
+                     VALUES (?1, ?2, 100, 100, 'png', 1000, '2026-01-01', '2026-01-01')",
+                    rusqlite::params![id, format!("hash-{id}")],
+                )
+                .unwrap();
+            db.conn
+                .lock()
+                .execute(
+                    "INSERT INTO image_files (id, image_id, path, last_seen_at)
+                     VALUES (?1, ?2, ?3, '2026-01-01')",
+                    rusqlite::params![format!("file-{id}"), id, format!("/test/{id}.png")],
+                )
+                .unwrap();
+            db.store_embedding(id, "clip-vit-b32", &vector).unwrap();
+        }
+        let ctx = HeadlessContext {
+            db,
+            app_data_dir: tmp.path().to_path_buf(),
+        };
+
+        let result = execute_named_tool(
+            &ctx,
+            "find_similar",
+            serde_json::json!({ "image_id": "source", "limit": 2 }),
+        )
+        .unwrap();
+
+        let matches = result.as_array().unwrap();
+        assert_eq!(matches.len(), 2);
+        assert_eq!(matches[0]["image_id"], "near");
+        assert_eq!(matches[0]["model"], "clip-vit-b32");
+        assert!(
+            matches[0]["similarity"].as_f64().unwrap() > matches[1]["similarity"].as_f64().unwrap()
+        );
     }
 }

--- a/src-tauri/src/cli/tools/search.rs
+++ b/src-tauri/src/cli/tools/search.rs
@@ -1,6 +1,6 @@
 use serde_json::Value;
 
-use crate::services::ai::{self as ai_service, SearchByObjectParams};
+use crate::services::ai::{self as ai_service, FindSimilarParams, SearchByObjectParams};
 
 use super::HeadlessContext;
 
@@ -8,6 +8,14 @@ pub fn search_by_object(ctx: &HeadlessContext, params: Value) -> Result<Value, S
     let parsed: SearchByObjectParams = serde_json::from_value(params)
         .map_err(|error| format!("Invalid search_by_object params: {error}"))?;
     let matches = ai_service::search_by_object_in_database(&ctx.db, &parsed)
+        .map_err(|error| error.to_string())?;
+    serde_json::to_value(matches).map_err(|error| error.to_string())
+}
+
+pub fn find_similar(ctx: &HeadlessContext, params: Value) -> Result<Value, String> {
+    let parsed: FindSimilarParams = serde_json::from_value(params)
+        .map_err(|error| format!("Invalid find_similar params: {error}"))?;
+    let matches = ai_service::find_similar_in_database(&ctx.db, &parsed)
         .map_err(|error| error.to_string())?;
     serde_json::to_value(matches).map_err(|error| error.to_string())
 }

--- a/src-tauri/src/db_core/queries/embeddings.rs
+++ b/src-tauri/src/db_core/queries/embeddings.rs
@@ -5,6 +5,7 @@ use crate::db_core::db::Database;
 use crate::db_core::db::{cosine_similarity, decode_embedding_bytes};
 
 use crate::db_core::models::*;
+use crate::db_core::queries::images::image_scope_filter;
 use crate::db_core::smart_collections::FilterNode;
 use crate::db_core::tags::normalize_tag_name;
 use crate::db_core::visibility::RejectedVisibility;
@@ -635,6 +636,69 @@ impl Database {
         top_k: usize,
     ) -> Result<Option<Vec<(String, f32)>>> {
         let (scope_clause, scope_params, visibility) = scoped_where_clause(scope)?;
+        self.find_similar_with_candidate_filter(
+            image_id,
+            model_name,
+            top_k,
+            &scope_clause,
+            scope_params,
+            visibility.sql_predicate(),
+        )
+    }
+
+    /// Finds nearest live library neighbors without an authorization scope.
+    /// The source image is excluded and ties are ordered by image ID.
+    pub fn find_similar_live(
+        &self,
+        image_id: &str,
+        model_name: &str,
+        top_k: usize,
+    ) -> Result<Option<Vec<(String, f32)>>> {
+        self.find_similar_with_candidate_filter(
+            image_id,
+            model_name,
+            top_k,
+            "1 = 1",
+            Vec::new(),
+            "1 = 1",
+        )
+    }
+
+    /// Finds nearest live neighbors admitted by the MCP token-scope union.
+    /// Scope filtering happens in SQL before vector decoding and ranking.
+    pub fn find_similar_in_token_scope(
+        &self,
+        image_id: &str,
+        model_name: &str,
+        folders: &[String],
+        collections: &[String],
+        tag_norms: &[String],
+        top_k: usize,
+    ) -> Result<Option<Vec<(String, f32)>>> {
+        let Some((scope_clause, scope_params)) =
+            image_scope_filter(folders, collections, tag_norms)
+        else {
+            return Ok(Some(Vec::new()));
+        };
+        self.find_similar_with_candidate_filter(
+            image_id,
+            model_name,
+            top_k,
+            &scope_clause,
+            scope_params,
+            "1 = 1",
+        )
+    }
+
+    fn find_similar_with_candidate_filter(
+        &self,
+        image_id: &str,
+        model_name: &str,
+        top_k: usize,
+        scope_clause: &str,
+        scope_params: Vec<Value>,
+        visibility_predicate: &str,
+    ) -> Result<Option<Vec<(String, f32)>>> {
         let (source_bytes, raw_candidates): (Option<Vec<u8>>, Vec<(String, Vec<u8>)>) = {
             let mut conn = self.read_connection();
             let transaction = conn.transaction()?;
@@ -656,8 +720,7 @@ impl Database {
                  LEFT JOIN image_color_metrics cm ON cm.image_id = i.id
                  LEFT JOIN image_similarity_group_items sgi ON sgi.image_id = i.id
                  WHERE e.model_name = ? AND e.image_id != ?
-                   AND ({scope_clause}) AND {}",
-                visibility.sql_predicate()
+                   AND ({scope_clause}) AND {visibility_predicate}"
             );
             let mut candidate_params = vec![
                 Value::Text(model_name.to_string()),
@@ -865,6 +928,40 @@ mod tests {
         assert_eq!(neighbors[1], ("in-far".to_string(), 0.0));
         assert!(neighbors.iter().all(|(id, _)| id != "source"));
         assert!(neighbors.iter().all(|(id, _)| id != "outside-closest"));
+    }
+
+    #[test]
+    fn live_neighbors_exclude_source_missing_files_and_tiebreak_by_id() {
+        let db = open_test_db();
+        for (id, path) in [
+            ("source", "/test/source.png"),
+            ("beta", "/test/beta.png"),
+            ("alpha", "/test/alpha.png"),
+            ("missing", "/test/missing.png"),
+        ] {
+            insert_scoped_image(&db, id, path, 100, 100, None);
+            db.store_embedding(id, "clip-vit-b32", &[1.0, 0.0]).unwrap();
+        }
+        db.conn
+            .lock()
+            .execute(
+                "UPDATE image_files SET missing_at = '2026-08-08' WHERE image_id = 'missing'",
+                [],
+            )
+            .unwrap();
+
+        let neighbors = db
+            .find_similar_live("source", "clip-vit-b32", 10)
+            .unwrap()
+            .expect("source embedding exists");
+
+        assert_eq!(
+            neighbors
+                .iter()
+                .map(|item| item.0.as_str())
+                .collect::<Vec<_>>(),
+            vec!["alpha", "beta"]
+        );
     }
 
     #[test]

--- a/src-tauri/src/mcp/tools.rs
+++ b/src-tauri/src/mcp/tools.rs
@@ -13,7 +13,7 @@ use tauri::{Emitter, Manager};
 use super::auth::{require_capability, AuthContext};
 use crate::db_core::canvas_document::CanvasDocument;
 use crate::db_core::models::{Canvas, TokenScope};
-use crate::services::ai::{self as ai_service, SearchByObjectParams};
+use crate::services::ai::{self as ai_service, FindSimilarParams, SearchByObjectParams};
 use crate::services::curation::{self as curation_service, SetRatingParams};
 use crate::services::tokens;
 use crate::AppState;
@@ -686,16 +686,6 @@ pub struct CreateSmartCollectionParams {
         description = "Natural language query like 'landscape photos rated 4+' or raw filter JSON"
     )]
     pub query: String,
-}
-
-#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
-pub struct FindSimilarParams {
-    #[schemars(description = "Image ID to find similar images for")]
-    pub image_id: String,
-    #[schemars(description = "Number of results to return (default 10)")]
-    pub limit: Option<u32>,
-    #[schemars(description = "Embedding model: 'clip-vit-b32' or 'dinov2-vits14'")]
-    pub model: Option<String>,
 }
 
 #[derive(Debug, serde::Deserialize, schemars::JsonSchema)]

--- a/src-tauri/src/mcp/tools/ml.rs
+++ b/src-tauri/src/mcp/tools/ml.rs
@@ -6,38 +6,31 @@ impl CullMcp {
         description = "Find visually similar images using CLIP embeddings. Requires embeddings to be generated first."
     )]
     fn find_similar(&self, Parameters(params): Parameters<FindSimilarParams>) -> String {
-        match self.check_image_id_scope(&params.image_id) {
+        let image_id = match ai_service::validated_find_similar_image_id(&params) {
+            Ok(image_id) => image_id,
+            Err(error) => return format!("Error: {error}"),
+        };
+        match self.check_image_id_scope(image_id) {
             Ok(false) => return "Error: Access denied — image outside token scope".to_string(),
             Err(e) => return format!("Error: {}", e),
             _ => {}
         }
         let state = self.app_handle.state::<AppState>();
-        let top_k = clamp_limit(params.limit.unwrap_or(10)) as usize;
-        let model_id = params.model.as_deref().unwrap_or("clip-vit-b32");
-        if crate::db_core::embeddings::embedding_model_spec(model_id).is_none() {
-            return format!("Error: Unsupported embedding model '{}'", model_id);
-        }
-
-        let query = match state.db.get_embedding_vector(&params.image_id, model_id) {
-            Ok(Some(vector)) => vector,
-            Err(e) => return format!("Error: {}", e),
-            Ok(None) => {
-                return format!(
-                    "Error: Image '{}' has no '{}' embedding. Run generate_embeddings first.",
-                    params.image_id, model_id
+        let result = match self.token_scope() {
+            Some(scope) => {
+                let (folders, collections, tag_norms) = Self::scope_dimensions(&scope);
+                ai_service::find_similar_in_token_scope_database(
+                    &state.db,
+                    &params,
+                    &folders,
+                    &collections,
+                    &tag_norms,
                 )
             }
+            None => ai_service::find_similar_in_database(&state.db, &params),
         };
-        match state.db.find_similar(&query, model_id, top_k * 2) {
-            Ok(results) => {
-                let r: Vec<serde_json::Value> = results
-                .iter()
-                .filter(|(id, _)| self.check_image_id_scope(id).unwrap_or(false))
-                .take(top_k)
-                .map(|(id, score)| serde_json::json!({"image_id": id, "similarity": score, "model": model_id}))
-                .collect();
-                serde_json::to_string(&r).unwrap_or_else(|_| "[]".to_string())
-            }
+        match result {
+            Ok(results) => serde_json::to_string(&results).unwrap_or_else(|_| "[]".to_string()),
             Err(e) => format!("Error: {}", e),
         }
     }

--- a/src-tauri/src/services/ai.rs
+++ b/src-tauri/src/services/ai.rs
@@ -30,6 +30,93 @@ pub struct SearchByObjectMatch {
     pub confidence: f32,
 }
 
+#[derive(Debug, Clone, serde::Deserialize, schemars::JsonSchema)]
+pub struct FindSimilarParams {
+    #[schemars(description = "Image ID to find similar images for")]
+    pub image_id: String,
+    #[schemars(description = "Number of results to return (default 10, max 100)")]
+    pub limit: Option<u32>,
+    #[schemars(description = "Embedding model: 'clip-vit-b32' or 'dinov2-vits14'")]
+    pub model: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, serde::Serialize)]
+pub struct FindSimilarMatch {
+    pub image_id: String,
+    pub similarity: f32,
+    pub model: String,
+}
+
+pub fn find_similar_in_database(
+    db: &Database,
+    params: &FindSimilarParams,
+) -> Result<Vec<FindSimilarMatch>, ServiceError> {
+    let (image_id, limit, model) = validate_find_similar(params)?;
+    let results = db
+        .find_similar_live(image_id, model, limit)?
+        .ok_or_else(|| missing_embedding_error(image_id, model))?;
+    Ok(similarity_matches(results, model))
+}
+
+pub fn find_similar_in_token_scope_database(
+    db: &Database,
+    params: &FindSimilarParams,
+    folders: &[String],
+    collections: &[String],
+    tag_norms: &[String],
+) -> Result<Vec<FindSimilarMatch>, ServiceError> {
+    let (image_id, limit, model) = validate_find_similar(params)?;
+    let results = db
+        .find_similar_in_token_scope(image_id, model, folders, collections, tag_norms, limit)?
+        .ok_or_else(|| missing_embedding_error(image_id, model))?;
+    Ok(similarity_matches(results, model))
+}
+
+fn validate_find_similar(params: &FindSimilarParams) -> Result<(&str, usize, &str), ServiceError> {
+    let image_id = validated_find_similar_image_id(params)?;
+    let model = params.model.as_deref().unwrap_or("clip-vit-b32").trim();
+    if crate::db_core::embeddings::embedding_model_spec(model).is_none() {
+        return Err(ServiceError::InvalidInput(format!(
+            "Unsupported embedding model '{model}'"
+        )));
+    }
+    Ok((
+        image_id,
+        params
+            .limit
+            .unwrap_or(10)
+            .clamp(1, MAX_SIMILAR_IMAGES as u32) as usize,
+        model,
+    ))
+}
+
+pub fn validated_find_similar_image_id(params: &FindSimilarParams) -> Result<&str, ServiceError> {
+    let image_id = params.image_id.trim();
+    if image_id.is_empty() {
+        return Err(ServiceError::InvalidInput(
+            "image_id must not be empty".to_string(),
+        ));
+    }
+    Ok(image_id)
+}
+
+fn missing_embedding_error(image_id: &str, model: &str) -> ServiceError {
+    ServiceError::NotFound(format!(
+        "Image '{image_id}' has no '{model}' embedding. Run generate_embeddings first."
+    ))
+}
+
+fn similarity_matches(results: Vec<(String, f32)>, model: &str) -> Vec<FindSimilarMatch> {
+    results
+        .into_iter()
+        .map(|(image_id, similarity)| FindSimilarMatch {
+            image_id,
+            similarity,
+            model: model.to_string(),
+        })
+        .collect()
+}
+
 pub fn search_by_object_in_database(
     db: &Database,
     params: &SearchByObjectParams,
@@ -736,6 +823,138 @@ mod tests {
             ServiceError::NotFound(msg) => assert!(msg.contains("no embedding")),
             other => panic!("Expected NotFound, got {:?}", other),
         }
+    }
+
+    #[test]
+    fn find_similar_shared_params_validate_rank_and_model() {
+        let (db, _s, _d, _ee, _de, _se, _tmp) = make_ctx_parts();
+        for (id, vector) in [
+            ("source", vec![1.0, 0.0]),
+            ("near", vec![0.8, 0.6]),
+            ("far", vec![0.0, 1.0]),
+        ] {
+            insert_test_image(&db, id);
+            db.store_embedding(id, "clip-vit-b32", &vector).unwrap();
+        }
+
+        let matches = find_similar_in_database(
+            &db,
+            &FindSimilarParams {
+                image_id: " source ".to_string(),
+                limit: Some(10),
+                model: None,
+            },
+        )
+        .unwrap();
+
+        assert_eq!(matches.len(), 2);
+        assert_eq!(matches[0].image_id, "near");
+        assert!((matches[0].similarity - 0.8).abs() < 0.000_001);
+        assert_eq!(matches[0].model, "clip-vit-b32");
+        assert_eq!(matches[1].image_id, "far");
+
+        let unsupported = find_similar_in_database(
+            &db,
+            &FindSimilarParams {
+                image_id: "source".to_string(),
+                limit: None,
+                model: Some("unknown-model".to_string()),
+            },
+        );
+        assert!(matches!(unsupported, Err(ServiceError::InvalidInput(_))));
+    }
+
+    #[test]
+    fn find_similar_shared_params_reject_empty_and_missing_embeddings() {
+        let (db, _s, _d, _ee, _de, _se, _tmp) = make_ctx_parts();
+        insert_test_image(&db, "without-vector");
+
+        let empty = find_similar_in_database(
+            &db,
+            &FindSimilarParams {
+                image_id: "   ".to_string(),
+                limit: None,
+                model: None,
+            },
+        );
+        assert!(matches!(empty, Err(ServiceError::InvalidInput(_))));
+
+        let missing = find_similar_in_database(
+            &db,
+            &FindSimilarParams {
+                image_id: "without-vector".to_string(),
+                limit: None,
+                model: None,
+            },
+        );
+        assert!(matches!(missing, Err(ServiceError::NotFound(_))));
+    }
+
+    #[test]
+    fn find_similar_scopes_candidates_before_ranking_and_limit() {
+        let (db, _s, _d, _ee, _de, _se, _tmp) = make_ctx_parts();
+        insert_test_image(&db, "source");
+        db.store_embedding("source", "clip-vit-b32", &[1.0, 0.0])
+            .unwrap();
+        for index in 0..105 {
+            let id = format!("outside-{index:03}");
+            insert_test_image(&db, &id);
+            db.store_embedding(&id, "clip-vit-b32", &[1.0, (index + 1) as f32 / 10_000.0])
+                .unwrap();
+        }
+        insert_test_image(&db, "inside");
+        db.store_embedding("inside", "clip-vit-b32", &[0.0, 1.0])
+            .unwrap();
+        let collection_id = db
+            .create_collection_with_images("Allowed", &["source", "inside"])
+            .unwrap();
+
+        let matches = find_similar_in_token_scope_database(
+            &db,
+            &FindSimilarParams {
+                image_id: "source".to_string(),
+                limit: Some(2),
+                model: None,
+            },
+            &[],
+            &[collection_id],
+            &[],
+        )
+        .unwrap();
+
+        assert_eq!(matches.len(), 1);
+        assert_eq!(matches[0].image_id, "inside");
+        assert!(matches.iter().all(|item| item.image_id != "source"));
+    }
+
+    #[test]
+    fn find_similar_defaults_to_ten_and_clamps_to_standard_bounds() {
+        let (db, _s, _d, _ee, _de, _se, _tmp) = make_ctx_parts();
+        insert_test_image(&db, "source");
+        db.store_embedding("source", "clip-vit-b32", &[1.0, 0.0])
+            .unwrap();
+        for index in 0..105 {
+            let id = format!("candidate-{index:03}");
+            insert_test_image(&db, &id);
+            db.store_embedding(&id, "clip-vit-b32", &[1.0, (index + 1) as f32 / 1_000.0])
+                .unwrap();
+        }
+
+        let run = |limit| {
+            find_similar_in_database(
+                &db,
+                &FindSimilarParams {
+                    image_id: "source".to_string(),
+                    limit,
+                    model: None,
+                },
+            )
+            .unwrap()
+        };
+
+        assert_eq!(run(None).len(), 10);
+        assert_eq!(run(Some(0)).len(), 1);
+        assert_eq!(run(Some(u32::MAX)).len(), 100);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add typed `cull find_similar` and named `call_tool find_similar` dispatch
- share MCP/CLI parameter validation and typed similarity results
- exclude the source and missing files with deterministic similarity/ID ordering
- apply MCP folder/collection/tag scope in SQL before vector scoring and limiting
- document the stored-embedding-only command

Closes imageview-24x.3 after Beads reconciliation.

## Validation
- `npm run preflight -- full` (exact HEAD): frontend 170 files / 1280 tests; Rust 857 passed / 3 ignored plus integration targets; Svelte check 0 errors / 0 warnings; clippy warnings pre-existing/non-fatal
- focused similarity + scope/output tests: 19/19
- independent Spec review: PASS
- independent Standards/correctness/security/performance review: PASS
- `git diff --check origin/main...HEAD`

## Push note
The pre-push hook rerun was skipped with `CULL_HOOK_SKIP_CHECKS=1` only after the exact-head full preflight completed successfully.