### PR TITLE
feat(photos): add read-only Apple Photos catalog

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -924,6 +924,7 @@ dependencies = [
  "objc2-app-kit",
  "objc2-avf-audio",
  "objc2-foundation",
+ "objc2-photos",
  "objc2-speech",
  "objc2-vision",
  "ort",
@@ -3270,6 +3271,18 @@ dependencies = [
  "bitflags 2.11.1",
  "objc2",
  "objc2-app-kit",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-photos"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6ea9a706f18e32cf8a0723e99855af4f135282891e07259301bae9135ae3872"
+dependencies = [
+ "bitflags 2.11.1",
+ "block2",
+ "objc2",
  "objc2-foundation",
 ]
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -90,3 +90,4 @@ objc2-vision = { version = "0.3.2", default-features = false, features = ["std",
 objc2-speech = "0.3"
 objc2-avf-audio = "0.3"
 block2 = "0.6"
+objc2-photos = { version = "0.3.2", default-features = false, features = ["std", "block2", "PHAsset", "PHAssetResource", "PHCollection", "PHFetchOptions", "PHFetchResult", "PHObject", "PHPhotoLibrary", "PhotosTypes"] }

--- a/src-tauri/Entitlements.plist
+++ b/src-tauri/Entitlements.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.personal-information.photos-library</key>
+    <true/>
+</dict>
+</plist>

--- a/src-tauri/Info.plist
+++ b/src-tauri/Info.plist
@@ -12,5 +12,7 @@
     <string>Cull uses the microphone for voice search dictation.</string>
     <key>NSSpeechRecognitionUsageDescription</key>
     <string>Cull uses speech recognition for voice-powered image search.</string>
+    <key>NSPhotoLibraryUsageDescription</key>
+    <string>Cull reads photos and albums you choose to import from your Apple Photos library.</string>
 </dict>
 </plist>

--- a/src-tauri/capabilities/app-photos.json
+++ b/src-tauri/capabilities/app-photos.json
@@ -2,6 +2,6 @@
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "app-photos",
   "description": "Apple Photos authorization and read-only catalog metadata IPC.",
-  "windows": ["main", "window-*"],
+  "windows": ["main"],
   "permissions": ["app-photos"]
 }

--- a/src-tauri/capabilities/app-photos.json
+++ b/src-tauri/capabilities/app-photos.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "../gen/schemas/desktop-schema.json",
+  "identifier": "app-photos",
+  "description": "Apple Photos authorization and read-only catalog metadata IPC.",
+  "windows": ["main", "window-*"],
+  "permissions": ["app-photos"]
+}

--- a/src-tauri/permissions/app-photos.toml
+++ b/src-tauri/permissions/app-photos.toml
@@ -1,0 +1,9 @@
+[[permission]]
+identifier = "app-photos"
+description = "Allows explicit Apple Photos authorization and read-only catalog metadata access."
+commands.allow = [
+  "photos_authorization_status",
+  "photos_list_albums",
+  "photos_list_assets",
+  "photos_request_authorization",
+]

--- a/src-tauri/src/apple_photos/macos.rs
+++ b/src-tauri/src/apple_photos/macos.rs
@@ -1,0 +1,196 @@
+//! The sole unsafe/native boundary for the read-only PhotoKit catalog.
+
+use super::{
+    PhotosAlbum, PhotosAlbumKind, PhotosAsset, PhotosAuthorizationStatus, PhotosError, PhotosPage,
+};
+use block2::RcBlock;
+use objc2_foundation::{NSArray, NSDate, NSPredicate, NSSortDescriptor, NSString};
+use objc2_photos::{
+    PHAccessLevel, PHAsset, PHAssetCollection, PHAssetCollectionSubtype, PHAssetCollectionType,
+    PHAssetMediaType, PHAssetResource, PHAuthorizationStatus, PHFetchOptions, PHPhotoLibrary,
+};
+
+fn normalize_status(status: PHAuthorizationStatus) -> PhotosAuthorizationStatus {
+    match status {
+        PHAuthorizationStatus::NotDetermined => PhotosAuthorizationStatus::NotDetermined,
+        PHAuthorizationStatus::Restricted => PhotosAuthorizationStatus::Restricted,
+        PHAuthorizationStatus::Denied => PhotosAuthorizationStatus::Denied,
+        PHAuthorizationStatus::Limited => PhotosAuthorizationStatus::Limited,
+        PHAuthorizationStatus::Authorized => PhotosAuthorizationStatus::Authorized,
+        _ => PhotosAuthorizationStatus::Restricted,
+    }
+}
+
+fn require_read_access() -> Result<(), PhotosError> {
+    match authorization_status()? {
+        PhotosAuthorizationStatus::Limited | PhotosAuthorizationStatus::Authorized => Ok(()),
+        _ => Err(PhotosError::PermissionDenied),
+    }
+}
+
+pub(super) fn authorization_status() -> Result<PhotosAuthorizationStatus, PhotosError> {
+    // SAFETY: This is a class query with no object lifetime or callback requirements.
+    let status =
+        unsafe { PHPhotoLibrary::authorizationStatusForAccessLevel(PHAccessLevel::ReadWrite) };
+    Ok(normalize_status(status))
+}
+
+pub(super) fn request_authorization() -> Result<PhotosAuthorizationStatus, PhotosError> {
+    let (sender, receiver) = std::sync::mpsc::sync_channel(1);
+    let handler = RcBlock::new(move |status: PHAuthorizationStatus| {
+        let _ = sender.send(normalize_status(status));
+    });
+    // SAFETY: PhotoKit retains the block for the asynchronous request. RcBlock owns
+    // the captured sender, and this function keeps the block alive while waiting.
+    unsafe {
+        PHPhotoLibrary::requestAuthorizationForAccessLevel_handler(
+            PHAccessLevel::ReadWrite,
+            &handler,
+        )
+    };
+    receiver
+        .recv()
+        .map_err(|error| PhotosError::Native(format!("authorization callback failed: {error}")))
+}
+
+pub(super) fn list_albums() -> Result<Vec<PhotosAlbum>, PhotosError> {
+    require_read_access()?;
+    // SAFETY: Fetch results and every retained object are created, read, and dropped
+    // on this worker thread. No PhotoKit object escapes this adapter.
+    unsafe {
+        let mut albums = Vec::new();
+        collect_albums(
+            PHAssetCollectionType::Album,
+            PhotosAlbumKind::User,
+            &mut albums,
+        );
+        collect_albums(
+            PHAssetCollectionType::SmartAlbum,
+            PhotosAlbumKind::Smart,
+            &mut albums,
+        );
+        Ok(albums)
+    }
+}
+
+unsafe fn collect_albums(
+    collection_type: PHAssetCollectionType,
+    kind: PhotosAlbumKind,
+    output: &mut Vec<PhotosAlbum>,
+) {
+    let result = PHAssetCollection::fetchAssetCollectionsWithType_subtype_options(
+        collection_type,
+        PHAssetCollectionSubtype::Any,
+        None,
+    );
+    for index in 0..result.count() {
+        let album = result.objectAtIndex(index);
+        let id = album.localIdentifier().to_string();
+        let title = album.localizedTitle().map(|value| value.to_string());
+        output.push(PhotosAlbum { id, title, kind });
+    }
+}
+
+pub(super) fn list_assets_page(
+    album_id: Option<&str>,
+    offset: u32,
+    limit: u32,
+) -> Result<PhotosPage<PhotosAsset>, PhotosError> {
+    require_read_access()?;
+    // SAFETY: All PhotoKit objects stay within this worker-thread scope. Fetching
+    // asset metadata does not request image bytes or permit an iCloud download.
+    unsafe {
+        let options = PHFetchOptions::new();
+        let creation_key = NSString::from_str("creationDate");
+        let creation_sort =
+            NSSortDescriptor::sortDescriptorWithKey_ascending(Some(&creation_key), false);
+        let descriptors = NSArray::from_retained_slice(&[creation_sort]);
+        options.setSortDescriptors(Some(&descriptors));
+        let image_predicate_format = NSString::from_str("mediaType == 1");
+        let image_predicate =
+            NSPredicate::predicateWithFormat_argumentArray(&image_predicate_format, None);
+        options.setPredicate(Some(&image_predicate));
+
+        let result = if let Some(album_id) = album_id {
+            let identifier = NSString::from_str(album_id);
+            let identifiers = NSArray::from_retained_slice(&[identifier]);
+            let albums = PHAssetCollection::fetchAssetCollectionsWithLocalIdentifiers_options(
+                &identifiers,
+                None,
+            );
+            let album = albums
+                .firstObject()
+                .ok_or_else(|| PhotosError::InvalidAlbum(album_id.to_string()))?;
+            PHAsset::fetchAssetsInAssetCollection_options(&album, Some(&options))
+        } else {
+            PHAsset::fetchAssetsWithMediaType_options(PHAssetMediaType::Image, Some(&options))
+        };
+
+        let result_count = result.count();
+        let total = u32::try_from(result_count).unwrap_or(u32::MAX);
+        // PhotoKit does not guarantee a stable tie order for equal creation dates.
+        // Read only lightweight keys across the fetch result, then bound the more
+        // expensive PHAssetResource lookup to the requested page.
+        let mut ordered_indices = Vec::with_capacity(result_count);
+        for index in 0..result_count {
+            let asset = result.objectAtIndex(index);
+            ordered_indices.push((
+                index,
+                asset.creationDate().as_deref().and_then(date_to_rfc3339),
+                asset.localIdentifier().to_string(),
+            ));
+        }
+        ordered_indices.sort_by(|a, b| match (&a.1, &b.1) {
+            (Some(a_date), Some(b_date)) => b_date.cmp(a_date).then_with(|| a.2.cmp(&b.2)),
+            (Some(_), None) => std::cmp::Ordering::Less,
+            (None, Some(_)) => std::cmp::Ordering::Greater,
+            (None, None) => a.2.cmp(&b.2),
+        });
+        let start = usize::try_from(offset)
+            .unwrap_or(usize::MAX)
+            .min(ordered_indices.len());
+        let end = start
+            .saturating_add(limit as usize)
+            .min(ordered_indices.len());
+        let mut assets = Vec::new();
+        for (index, _, _) in &ordered_indices[start..end] {
+            let asset = result.objectAtIndex(*index);
+            if asset.mediaType() != PHAssetMediaType::Image {
+                continue;
+            }
+            let resources = PHAssetResource::assetResourcesForAsset(&asset);
+            let filename = resources
+                .firstObject()
+                .map(|resource| resource.originalFilename().to_string());
+            assets.push(PhotosAsset {
+                id: asset.localIdentifier().to_string(),
+                filename,
+                created_at: asset.creationDate().as_deref().and_then(date_to_rfc3339),
+                modified_at: asset
+                    .modificationDate()
+                    .as_deref()
+                    .and_then(date_to_rfc3339),
+                pixel_width: u32::try_from(asset.pixelWidth()).unwrap_or(u32::MAX),
+                pixel_height: u32::try_from(asset.pixelHeight()).unwrap_or(u32::MAX),
+                media_subtypes: u64::try_from(asset.mediaSubtypes().0).unwrap_or(u64::MAX),
+                favorite: asset.isFavorite(),
+            });
+        }
+        Ok(PhotosPage {
+            items: assets,
+            total,
+            offset,
+            has_more: end < ordered_indices.len(),
+        })
+    }
+}
+
+fn date_to_rfc3339(date: &NSDate) -> Option<String> {
+    let timestamp = date.timeIntervalSince1970();
+    if !timestamp.is_finite() {
+        return None;
+    }
+    let seconds = timestamp.floor() as i64;
+    let nanos = ((timestamp - seconds as f64) * 1_000_000_000.0).round() as u32;
+    chrono::DateTime::<chrono::Utc>::from_timestamp(seconds, nanos).map(|date| date.to_rfc3339())
+}

--- a/src-tauri/src/apple_photos/macos.rs
+++ b/src-tauri/src/apple_photos/macos.rs
@@ -102,9 +102,12 @@ pub(super) fn list_assets_page(
     unsafe {
         let options = PHFetchOptions::new();
         let creation_key = NSString::from_str("creationDate");
+        let identifier_key = NSString::from_str("localIdentifier");
         let creation_sort =
             NSSortDescriptor::sortDescriptorWithKey_ascending(Some(&creation_key), false);
-        let descriptors = NSArray::from_retained_slice(&[creation_sort]);
+        let identifier_sort =
+            NSSortDescriptor::sortDescriptorWithKey_ascending(Some(&identifier_key), true);
+        let descriptors = NSArray::from_retained_slice(&[creation_sort, identifier_sort]);
         options.setSortDescriptors(Some(&descriptors));
         let image_predicate_format = NSString::from_str("mediaType == 1");
         let image_predicate =
@@ -128,33 +131,13 @@ pub(super) fn list_assets_page(
 
         let result_count = result.count();
         let total = u32::try_from(result_count).unwrap_or(u32::MAX);
-        // PhotoKit does not guarantee a stable tie order for equal creation dates.
-        // Read only lightweight keys across the fetch result, then bound the more
-        // expensive PHAssetResource lookup to the requested page.
-        let mut ordered_indices = Vec::with_capacity(result_count);
-        for index in 0..result_count {
-            let asset = result.objectAtIndex(index);
-            ordered_indices.push((
-                index,
-                asset.creationDate().as_deref().and_then(date_to_rfc3339),
-                asset.localIdentifier().to_string(),
-            ));
-        }
-        ordered_indices.sort_by(|a, b| match (&a.1, &b.1) {
-            (Some(a_date), Some(b_date)) => b_date.cmp(a_date).then_with(|| a.2.cmp(&b.2)),
-            (Some(_), None) => std::cmp::Ordering::Less,
-            (None, Some(_)) => std::cmp::Ordering::Greater,
-            (None, None) => a.2.cmp(&b.2),
-        });
         let start = usize::try_from(offset)
             .unwrap_or(usize::MAX)
-            .min(ordered_indices.len());
-        let end = start
-            .saturating_add(limit as usize)
-            .min(ordered_indices.len());
+            .min(result_count);
+        let end = start.saturating_add(limit as usize).min(result_count);
         let mut assets = Vec::new();
-        for (index, _, _) in &ordered_indices[start..end] {
-            let asset = result.objectAtIndex(*index);
+        for index in start..end {
+            let asset = result.objectAtIndex(index);
             if asset.mediaType() != PHAssetMediaType::Image {
                 continue;
             }
@@ -180,7 +163,7 @@ pub(super) fn list_assets_page(
             items: assets,
             total,
             offset,
-            has_more: end < ordered_indices.len(),
+            has_more: end < result_count,
         })
     }
 }

--- a/src-tauri/src/apple_photos/mod.rs
+++ b/src-tauri/src/apple_photos/mod.rs
@@ -1,0 +1,325 @@
+use serde::Serialize;
+use std::fmt;
+
+#[cfg(target_os = "macos")]
+mod macos;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PhotosAuthorizationStatus {
+    Unsupported,
+    NotDetermined,
+    Restricted,
+    Denied,
+    Limited,
+    Authorized,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct PhotosAlbum {
+    pub id: String,
+    pub title: Option<String>,
+    pub kind: PhotosAlbumKind,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PhotosAlbumKind {
+    User,
+    Smart,
+}
+
+impl PhotosAlbum {
+    fn new(id: impl Into<String>, title: impl Into<String>, kind: PhotosAlbumKind) -> Self {
+        Self {
+            id: id.into(),
+            title: Some(title.into()),
+            kind,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct PhotosAsset {
+    pub id: String,
+    pub filename: Option<String>,
+    pub created_at: Option<String>,
+    pub modified_at: Option<String>,
+    pub pixel_width: u32,
+    pub pixel_height: u32,
+    pub media_subtypes: u64,
+    pub favorite: bool,
+}
+
+impl PhotosAsset {
+    fn new(id: impl Into<String>, created_at: Option<&str>) -> Self {
+        Self {
+            id: id.into(),
+            filename: None,
+            created_at: created_at.map(str::to_owned),
+            modified_at: None,
+            pixel_width: 0,
+            pixel_height: 0,
+            media_subtypes: 0,
+            favorite: false,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct PhotosPage<T> {
+    pub items: Vec<T>,
+    pub total: u32,
+    pub offset: u32,
+    pub has_more: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PhotosError {
+    Unsupported,
+    PermissionDenied,
+    InvalidAlbum(String),
+    Native(String),
+}
+
+impl fmt::Display for PhotosError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Unsupported => write!(f, "Apple Photos is unsupported on this platform"),
+            Self::PermissionDenied => write!(f, "Apple Photos permission is not granted"),
+            Self::InvalidAlbum(id) => write!(f, "Apple Photos album not found: {id}"),
+            Self::Native(message) => write!(f, "Apple Photos error: {message}"),
+        }
+    }
+}
+
+impl std::error::Error for PhotosError {}
+
+pub trait PhotosCatalog {
+    fn authorization_status(&self) -> Result<PhotosAuthorizationStatus, PhotosError>;
+    fn request_authorization(&self) -> Result<PhotosAuthorizationStatus, PhotosError>;
+    fn list_albums(&self) -> Result<Vec<PhotosAlbum>, PhotosError>;
+    fn list_assets_page(
+        &self,
+        album_id: Option<&str>,
+        offset: u32,
+        limit: u32,
+    ) -> Result<PhotosPage<PhotosAsset>, PhotosError>;
+}
+
+pub fn authorization_status(
+    catalog: &impl PhotosCatalog,
+) -> Result<PhotosAuthorizationStatus, PhotosError> {
+    catalog.authorization_status()
+}
+
+pub fn request_authorization(
+    catalog: &impl PhotosCatalog,
+) -> Result<PhotosAuthorizationStatus, PhotosError> {
+    catalog.request_authorization()
+}
+
+pub fn list_albums(
+    catalog: &impl PhotosCatalog,
+    offset: u32,
+    limit: u32,
+) -> Result<PhotosPage<PhotosAlbum>, PhotosError> {
+    let mut albums = catalog.list_albums()?;
+    albums.sort_by(|a, b| {
+        a.kind
+            .cmp(&b.kind)
+            .then_with(|| match (&a.title, &b.title) {
+                (Some(a_title), Some(b_title)) => {
+                    a_title.to_lowercase().cmp(&b_title.to_lowercase())
+                }
+                (Some(_), None) => std::cmp::Ordering::Less,
+                (None, Some(_)) => std::cmp::Ordering::Greater,
+                (None, None) => std::cmp::Ordering::Equal,
+            })
+            .then_with(|| a.id.cmp(&b.id))
+    });
+    Ok(paginate(albums, offset, limit))
+}
+
+pub fn list_assets(
+    catalog: &impl PhotosCatalog,
+    album_id: Option<&str>,
+    offset: u32,
+    limit: u32,
+) -> Result<PhotosPage<PhotosAsset>, PhotosError> {
+    catalog.list_assets_page(album_id, offset, limit.clamp(1, 100))
+}
+
+fn page_assets(mut assets: Vec<PhotosAsset>, offset: u32, limit: u32) -> PhotosPage<PhotosAsset> {
+    assets.sort_by(|a, b| match (&a.created_at, &b.created_at) {
+        (Some(a_date), Some(b_date)) => b_date.cmp(a_date).then_with(|| a.id.cmp(&b.id)),
+        (Some(_), None) => std::cmp::Ordering::Less,
+        (None, Some(_)) => std::cmp::Ordering::Greater,
+        (None, None) => a.id.cmp(&b.id),
+    });
+    paginate(assets, offset, limit)
+}
+
+fn paginate<T>(items: Vec<T>, offset: u32, limit: u32) -> PhotosPage<T> {
+    let limit = limit.clamp(1, 100) as usize;
+    let total = u32::try_from(items.len()).unwrap_or(u32::MAX);
+    let start = usize::try_from(offset)
+        .unwrap_or(usize::MAX)
+        .min(items.len());
+    let end = start.saturating_add(limit).min(items.len());
+    let has_more = end < items.len();
+    PhotosPage {
+        items: items.into_iter().skip(start).take(limit).collect(),
+        total,
+        offset,
+        has_more,
+    }
+}
+
+pub struct SystemPhotosCatalog;
+
+#[cfg(target_os = "macos")]
+impl PhotosCatalog for SystemPhotosCatalog {
+    fn authorization_status(&self) -> Result<PhotosAuthorizationStatus, PhotosError> {
+        macos::authorization_status()
+    }
+
+    fn request_authorization(&self) -> Result<PhotosAuthorizationStatus, PhotosError> {
+        macos::request_authorization()
+    }
+
+    fn list_albums(&self) -> Result<Vec<PhotosAlbum>, PhotosError> {
+        macos::list_albums()
+    }
+
+    fn list_assets_page(
+        &self,
+        album_id: Option<&str>,
+        offset: u32,
+        limit: u32,
+    ) -> Result<PhotosPage<PhotosAsset>, PhotosError> {
+        macos::list_assets_page(album_id, offset, limit)
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+impl PhotosCatalog for SystemPhotosCatalog {
+    fn authorization_status(&self) -> Result<PhotosAuthorizationStatus, PhotosError> {
+        Ok(PhotosAuthorizationStatus::Unsupported)
+    }
+
+    fn request_authorization(&self) -> Result<PhotosAuthorizationStatus, PhotosError> {
+        Err(PhotosError::Unsupported)
+    }
+
+    fn list_albums(&self) -> Result<Vec<PhotosAlbum>, PhotosError> {
+        Err(PhotosError::Unsupported)
+    }
+
+    fn list_assets_page(
+        &self,
+        _album_id: Option<&str>,
+        _offset: u32,
+        _limit: u32,
+    ) -> Result<PhotosPage<PhotosAsset>, PhotosError> {
+        Err(PhotosError::Unsupported)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Default)]
+    struct FakeCatalog {
+        request_count: std::sync::atomic::AtomicUsize,
+    }
+
+    impl PhotosCatalog for FakeCatalog {
+        fn authorization_status(&self) -> Result<PhotosAuthorizationStatus, PhotosError> {
+            Ok(PhotosAuthorizationStatus::Limited)
+        }
+
+        fn request_authorization(&self) -> Result<PhotosAuthorizationStatus, PhotosError> {
+            self.request_count
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            Ok(PhotosAuthorizationStatus::Authorized)
+        }
+
+        fn list_albums(&self) -> Result<Vec<PhotosAlbum>, PhotosError> {
+            Ok(vec![
+                PhotosAlbum::new("z", "Trips", PhotosAlbumKind::User),
+                PhotosAlbum::new("b", "Favorites", PhotosAlbumKind::Smart),
+                PhotosAlbum::new("a", "favorites", PhotosAlbumKind::Smart),
+            ])
+        }
+
+        fn list_assets_page(
+            &self,
+            _album_id: Option<&str>,
+            offset: u32,
+            limit: u32,
+        ) -> Result<PhotosPage<PhotosAsset>, PhotosError> {
+            Ok(page_assets(
+                vec![
+                    PhotosAsset::new("old", Some("2026-01-01T00:00:00Z")),
+                    PhotosAsset::new("null", None),
+                    PhotosAsset::new("new-b", Some("2026-02-01T00:00:00Z")),
+                    PhotosAsset::new("new-a", Some("2026-02-01T00:00:00Z")),
+                ],
+                offset,
+                limit,
+            ))
+        }
+    }
+
+    #[test]
+    fn authorization_request_is_explicit() {
+        let catalog = FakeCatalog::default();
+        assert_eq!(
+            authorization_status(&catalog).unwrap(),
+            PhotosAuthorizationStatus::Limited
+        );
+        assert_eq!(
+            catalog
+                .request_count
+                .load(std::sync::atomic::Ordering::SeqCst),
+            0
+        );
+        assert_eq!(
+            request_authorization(&catalog).unwrap(),
+            PhotosAuthorizationStatus::Authorized
+        );
+        assert_eq!(
+            catalog
+                .request_count
+                .load(std::sync::atomic::Ordering::SeqCst),
+            1
+        );
+    }
+
+    #[test]
+    fn album_page_clamps_and_orders_by_kind_title_then_id() {
+        let page = list_albums(&FakeCatalog::default(), 0, 500).unwrap();
+        let ids: Vec<&str> = page.items.iter().map(|item| item.id.as_str()).collect();
+        assert_eq!(ids, vec!["z", "a", "b"]);
+        assert_eq!(page.offset, 0);
+        assert!(!page.has_more);
+    }
+
+    #[test]
+    fn asset_page_orders_created_desc_null_last_then_id() {
+        let page = list_assets(&FakeCatalog::default(), None, 0, 100).unwrap();
+        let ids: Vec<&str> = page.items.iter().map(|item| item.id.as_str()).collect();
+        assert_eq!(ids, vec!["new-a", "new-b", "old", "null"]);
+    }
+
+    #[test]
+    fn pagination_clamps_limit_and_reports_total_and_more() {
+        let page = paginate(vec![1, 2, 3], 1, 0);
+        assert_eq!(page.items, vec![2]);
+        assert_eq!(page.total, 3);
+        assert_eq!(page.offset, 1);
+        assert!(page.has_more);
+    }
+}

--- a/src-tauri/src/apple_photos/mod.rs
+++ b/src-tauri/src/apple_photos/mod.rs
@@ -150,16 +150,6 @@ pub fn list_assets(
     catalog.list_assets_page(album_id, offset, limit.clamp(1, 100))
 }
 
-fn page_assets(mut assets: Vec<PhotosAsset>, offset: u32, limit: u32) -> PhotosPage<PhotosAsset> {
-    assets.sort_by(|a, b| match (&a.created_at, &b.created_at) {
-        (Some(a_date), Some(b_date)) => b_date.cmp(a_date).then_with(|| a.id.cmp(&b.id)),
-        (Some(_), None) => std::cmp::Ordering::Less,
-        (None, Some(_)) => std::cmp::Ordering::Greater,
-        (None, None) => a.id.cmp(&b.id),
-    });
-    paginate(assets, offset, limit)
-}
-
 fn paginate<T>(items: Vec<T>, offset: u32, limit: u32) -> PhotosPage<T> {
     let limit = limit.clamp(1, 100) as usize;
     let total = u32::try_from(items.len()).unwrap_or(u32::MAX);
@@ -260,12 +250,12 @@ mod tests {
             offset: u32,
             limit: u32,
         ) -> Result<PhotosPage<PhotosAsset>, PhotosError> {
-            Ok(page_assets(
+            Ok(paginate(
                 vec![
+                    PhotosAsset::new("new-a", Some("2026-02-01T00:00:00Z")),
+                    PhotosAsset::new("new-b", Some("2026-02-01T00:00:00Z")),
                     PhotosAsset::new("old", Some("2026-01-01T00:00:00Z")),
                     PhotosAsset::new("null", None),
-                    PhotosAsset::new("new-b", Some("2026-02-01T00:00:00Z")),
-                    PhotosAsset::new("new-a", Some("2026-02-01T00:00:00Z")),
                 ],
                 offset,
                 limit,
@@ -308,7 +298,7 @@ mod tests {
     }
 
     #[test]
-    fn asset_page_orders_created_desc_null_last_then_id() {
+    fn asset_adapter_page_preserves_created_desc_null_last_then_id() {
         let page = list_assets(&FakeCatalog::default(), None, 0, 100).unwrap();
         let ids: Vec<&str> = page.items.iter().map(|item| item.id.as_str()).collect();
         assert_eq!(ids, vec!["new-a", "new-b", "old", "null"]);

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -21,6 +21,7 @@ pub mod mcp;
 pub mod media;
 pub mod ocr;
 pub mod perceptual_hash;
+pub mod photos;
 pub mod plugins;
 pub mod preview;
 pub mod privacy;

--- a/src-tauri/src/commands/photos.rs
+++ b/src-tauri/src/commands/photos.rs
@@ -4,24 +4,50 @@ use crate::apple_photos::{
 
 const DEFAULT_PAGE_LIMIT: u32 = 50;
 
-async fn blocking<T, F>(operation: F) -> Result<T, String>
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+pub struct PhotosCommandError {
+    pub code: &'static str,
+    pub message: String,
+}
+
+impl From<crate::apple_photos::PhotosError> for PhotosCommandError {
+    fn from(error: crate::apple_photos::PhotosError) -> Self {
+        let code = match &error {
+            crate::apple_photos::PhotosError::Unsupported => "unsupported_platform",
+            crate::apple_photos::PhotosError::PermissionDenied => "permission_denied",
+            crate::apple_photos::PhotosError::InvalidAlbum(_) => "invalid_album",
+            crate::apple_photos::PhotosError::Native(_) => "native_error",
+        };
+        Self {
+            code,
+            message: error.to_string(),
+        }
+    }
+}
+
+async fn blocking<T, F>(operation: F) -> Result<T, PhotosCommandError>
 where
     T: Send + 'static,
     F: FnOnce() -> Result<T, crate::apple_photos::PhotosError> + Send + 'static,
 {
     tauri::async_runtime::spawn_blocking(operation)
         .await
-        .map_err(|error| format!("Apple Photos worker failed: {error}"))?
-        .map_err(|error| error.to_string())
+        .map_err(|error| PhotosCommandError {
+            code: "worker_failed",
+            message: format!("Apple Photos worker failed: {error}"),
+        })?
+        .map_err(PhotosCommandError::from)
 }
 
 #[tauri::command]
-pub async fn photos_authorization_status() -> Result<PhotosAuthorizationStatus, String> {
+pub async fn photos_authorization_status() -> Result<PhotosAuthorizationStatus, PhotosCommandError>
+{
     blocking(|| apple_photos::authorization_status(&SystemPhotosCatalog)).await
 }
 
 #[tauri::command]
-pub async fn photos_request_authorization() -> Result<PhotosAuthorizationStatus, String> {
+pub async fn photos_request_authorization() -> Result<PhotosAuthorizationStatus, PhotosCommandError>
+{
     blocking(|| apple_photos::request_authorization(&SystemPhotosCatalog)).await
 }
 
@@ -29,7 +55,7 @@ pub async fn photos_request_authorization() -> Result<PhotosAuthorizationStatus,
 pub async fn photos_list_albums(
     offset: Option<u32>,
     limit: Option<u32>,
-) -> Result<PhotosPage<PhotosAlbum>, String> {
+) -> Result<PhotosPage<PhotosAlbum>, PhotosCommandError> {
     blocking(move || {
         apple_photos::list_albums(
             &SystemPhotosCatalog,
@@ -45,7 +71,7 @@ pub async fn photos_list_assets(
     album_id: Option<String>,
     offset: Option<u32>,
     limit: Option<u32>,
-) -> Result<PhotosPage<PhotosAsset>, String> {
+) -> Result<PhotosPage<PhotosAsset>, PhotosCommandError> {
     blocking(move || {
         apple_photos::list_assets(
             &SystemPhotosCatalog,
@@ -55,4 +81,20 @@ pub async fn photos_list_assets(
         )
     })
     .await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unsupported_platform_error_is_machine_readable_and_frontend_consumable() {
+        let error = PhotosCommandError::from(crate::apple_photos::PhotosError::Unsupported);
+        let json = serde_json::to_value(error).unwrap();
+        assert_eq!(json["code"], "unsupported_platform");
+        assert_eq!(
+            json["message"],
+            "Apple Photos is unsupported on this platform"
+        );
+    }
 }

--- a/src-tauri/src/commands/photos.rs
+++ b/src-tauri/src/commands/photos.rs
@@ -1,0 +1,58 @@
+use crate::apple_photos::{
+    self, PhotosAlbum, PhotosAsset, PhotosAuthorizationStatus, PhotosPage, SystemPhotosCatalog,
+};
+
+const DEFAULT_PAGE_LIMIT: u32 = 50;
+
+async fn blocking<T, F>(operation: F) -> Result<T, String>
+where
+    T: Send + 'static,
+    F: FnOnce() -> Result<T, crate::apple_photos::PhotosError> + Send + 'static,
+{
+    tauri::async_runtime::spawn_blocking(operation)
+        .await
+        .map_err(|error| format!("Apple Photos worker failed: {error}"))?
+        .map_err(|error| error.to_string())
+}
+
+#[tauri::command]
+pub async fn photos_authorization_status() -> Result<PhotosAuthorizationStatus, String> {
+    blocking(|| apple_photos::authorization_status(&SystemPhotosCatalog)).await
+}
+
+#[tauri::command]
+pub async fn photos_request_authorization() -> Result<PhotosAuthorizationStatus, String> {
+    blocking(|| apple_photos::request_authorization(&SystemPhotosCatalog)).await
+}
+
+#[tauri::command]
+pub async fn photos_list_albums(
+    offset: Option<u32>,
+    limit: Option<u32>,
+) -> Result<PhotosPage<PhotosAlbum>, String> {
+    blocking(move || {
+        apple_photos::list_albums(
+            &SystemPhotosCatalog,
+            offset.unwrap_or(0),
+            limit.unwrap_or(DEFAULT_PAGE_LIMIT),
+        )
+    })
+    .await
+}
+
+#[tauri::command]
+pub async fn photos_list_assets(
+    album_id: Option<String>,
+    offset: Option<u32>,
+    limit: Option<u32>,
+) -> Result<PhotosPage<PhotosAsset>, String> {
+    blocking(move || {
+        apple_photos::list_assets(
+            &SystemPhotosCatalog,
+            album_id.as_deref(),
+            offset.unwrap_or(0),
+            limit.unwrap_or(DEFAULT_PAGE_LIMIT),
+        )
+    })
+    .await
+}

--- a/src-tauri/src/commands/photos.rs
+++ b/src-tauri/src/commands/photos.rs
@@ -4,50 +4,24 @@ use crate::apple_photos::{
 
 const DEFAULT_PAGE_LIMIT: u32 = 50;
 
-#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
-pub struct PhotosCommandError {
-    pub code: &'static str,
-    pub message: String,
-}
-
-impl From<crate::apple_photos::PhotosError> for PhotosCommandError {
-    fn from(error: crate::apple_photos::PhotosError) -> Self {
-        let code = match &error {
-            crate::apple_photos::PhotosError::Unsupported => "unsupported_platform",
-            crate::apple_photos::PhotosError::PermissionDenied => "permission_denied",
-            crate::apple_photos::PhotosError::InvalidAlbum(_) => "invalid_album",
-            crate::apple_photos::PhotosError::Native(_) => "native_error",
-        };
-        Self {
-            code,
-            message: error.to_string(),
-        }
-    }
-}
-
-async fn blocking<T, F>(operation: F) -> Result<T, PhotosCommandError>
+async fn blocking<T, F>(operation: F) -> Result<T, String>
 where
     T: Send + 'static,
     F: FnOnce() -> Result<T, crate::apple_photos::PhotosError> + Send + 'static,
 {
     tauri::async_runtime::spawn_blocking(operation)
         .await
-        .map_err(|error| PhotosCommandError {
-            code: "worker_failed",
-            message: format!("Apple Photos worker failed: {error}"),
-        })?
-        .map_err(PhotosCommandError::from)
+        .map_err(|error| format!("Apple Photos worker failed: {error}"))?
+        .map_err(|error| error.to_string())
 }
 
 #[tauri::command]
-pub async fn photos_authorization_status() -> Result<PhotosAuthorizationStatus, PhotosCommandError>
-{
+pub async fn photos_authorization_status() -> Result<PhotosAuthorizationStatus, String> {
     blocking(|| apple_photos::authorization_status(&SystemPhotosCatalog)).await
 }
 
 #[tauri::command]
-pub async fn photos_request_authorization() -> Result<PhotosAuthorizationStatus, PhotosCommandError>
-{
+pub async fn photos_request_authorization() -> Result<PhotosAuthorizationStatus, String> {
     blocking(|| apple_photos::request_authorization(&SystemPhotosCatalog)).await
 }
 
@@ -55,7 +29,7 @@ pub async fn photos_request_authorization() -> Result<PhotosAuthorizationStatus,
 pub async fn photos_list_albums(
     offset: Option<u32>,
     limit: Option<u32>,
-) -> Result<PhotosPage<PhotosAlbum>, PhotosCommandError> {
+) -> Result<PhotosPage<PhotosAlbum>, String> {
     blocking(move || {
         apple_photos::list_albums(
             &SystemPhotosCatalog,
@@ -71,7 +45,7 @@ pub async fn photos_list_assets(
     album_id: Option<String>,
     offset: Option<u32>,
     limit: Option<u32>,
-) -> Result<PhotosPage<PhotosAsset>, PhotosCommandError> {
+) -> Result<PhotosPage<PhotosAsset>, String> {
     blocking(move || {
         apple_photos::list_assets(
             &SystemPhotosCatalog,
@@ -85,16 +59,9 @@ pub async fn photos_list_assets(
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-
     #[test]
-    fn unsupported_platform_error_is_machine_readable_and_frontend_consumable() {
-        let error = PhotosCommandError::from(crate::apple_photos::PhotosError::Unsupported);
-        let json = serde_json::to_value(error).unwrap();
-        assert_eq!(json["code"], "unsupported_platform");
-        assert_eq!(
-            json["message"],
-            "Apple Photos is unsupported on this platform"
-        );
+    fn unsupported_platform_operation_uses_standard_command_error_string() {
+        let error = crate::apple_photos::PhotosError::Unsupported.to_string();
+        assert_eq!(error, "Apple Photos is unsupported on this platform");
     }
 }

--- a/src-tauri/src/config_contract.rs
+++ b/src-tauri/src/config_contract.rs
@@ -74,4 +74,21 @@ mod tests {
             );
         }
     }
+
+    #[test]
+    fn apple_photos_privacy_usage_and_entitlement_are_packaged() {
+        let info = include_str!("../Info.plist");
+        assert!(info.contains("<key>NSPhotoLibraryUsageDescription</key>"));
+
+        let entitlements = include_str!("../Entitlements.plist");
+        assert!(entitlements
+            .contains("<key>com.apple.security.personal-information.photos-library</key>"));
+        assert!(entitlements.contains("<true/>"));
+
+        let conf = config();
+        assert_eq!(
+            conf["bundle"]["macOS"]["entitlements"].as_str(),
+            Some("Entitlements.plist")
+        );
+    }
 }

--- a/src-tauri/src/config_contract.rs
+++ b/src-tauri/src/config_contract.rs
@@ -90,5 +90,10 @@ mod tests {
             conf["bundle"]["macOS"]["entitlements"].as_str(),
             Some("Entitlements.plist")
         );
+
+        let capability: serde_json::Value =
+            serde_json::from_str(include_str!("../capabilities/app-photos.json"))
+                .expect("app-photos capability must be valid JSON");
+        assert_eq!(capability["windows"], serde_json::json!(["main"]));
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,6 +1,7 @@
 // Copyright (c) 2026-present Gleb Kalinin. Architecture and design by author.
 // Implementation assisted by Claude (Anthropic). See AUTHORSHIP.md.
 
+mod apple_photos;
 mod cli;
 mod cloud;
 mod commands;
@@ -269,6 +270,28 @@ mod gui_launch_tests {
             .lines()
             .any(|line| line.trim() == format!("\"{command_name}\",")));
     }
+
+    #[test]
+    fn apple_photos_commands_are_registered_and_least_privilege_permitted() {
+        let registry = include_str!("lib.rs");
+        let photos_permissions = include_str!("../permissions/app-photos.toml");
+        let broad_permissions = format!(
+            "{}{}",
+            include_str!("../permissions/app-read.toml"),
+            include_str!("../permissions/app-file-access.toml")
+        );
+
+        for command in [
+            "photos_authorization_status",
+            "photos_list_albums",
+            "photos_list_assets",
+            "photos_request_authorization",
+        ] {
+            assert!(registry.contains(&format!("commands::photos::{command},")));
+            assert!(photos_permissions.contains(&format!("\"{command}\"")));
+            assert!(!broad_permissions.contains(&format!("\"{command}\"")));
+        }
+    }
 }
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
@@ -516,6 +539,10 @@ pub fn run() {
             commands::import::regenerate_thumbnails_by_ids,
             commands::import::regenerate_single_thumbnail,
             commands::import::rescan_sources,
+            commands::photos::photos_authorization_status,
+            commands::photos::photos_request_authorization,
+            commands::photos::photos_list_albums,
+            commands::photos::photos_list_assets,
             commands::deeplink::drain_pending_open_params,
             commands::deeplink::complete_deep_link_navigation,
             commands::deeplink::open_deep_link_urls,

--- a/src-tauri/src/menu.rs
+++ b/src-tauri/src/menu.rs
@@ -66,6 +66,14 @@ pub fn create_menu(app: &AppHandle) -> tauri::Result<Menu<Wry>> {
         true,
         Some::<&str>("CmdOrCtrl+Shift+O"),
     )?)?;
+    #[cfg(target_os = "macos")]
+    file_menu.append(&MenuItem::with_id(
+        app,
+        "import_apple_photos",
+        "Import from Apple Photos...",
+        true,
+        None::<&str>,
+    )?)?;
     file_menu.append(&PredefinedMenuItem::separator(app)?)?;
     file_menu.append(&PredefinedMenuItem::close_window(app, None)?)?;
     menu.append(&file_menu)?;
@@ -1108,6 +1116,7 @@ pub fn handle_menu_event(app: &AppHandle, event: &tauri::menu::MenuEvent) {
         | "check_update"
         | "open_file"
         | "import_folder"
+        | "import_apple_photos"
         | "open_folder"
         | "settings"
         | "undo"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -73,6 +73,7 @@
       "../node_modules/@anthropic-ai/claude-agent-sdk": "node_modules/@anthropic-ai/claude-agent-sdk"
     },
     "macOS": {
+      "entitlements": "Entitlements.plist",
       "files": {
         "Resources/Cull.help": "help/Cull.help"
       },

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -38,6 +38,9 @@ export interface ApplePhotosPage<T> {
     has_more: boolean;
 }
 
+export type ApplePhotosAlbumPage = ApplePhotosPage<ApplePhotosAlbum>;
+export type ApplePhotosAssetPage = ApplePhotosPage<ApplePhotosAsset>;
+
 export function photosAuthorizationStatus(): Promise<ApplePhotosAuthorization> {
     return invoke<ApplePhotosAuthorization>('photos_authorization_status');
 }
@@ -46,16 +49,16 @@ export function photosRequestAuthorization(): Promise<ApplePhotosAuthorization> 
     return invoke<ApplePhotosAuthorization>('photos_request_authorization');
 }
 
-export function photosListAlbums(offset = 0, limit = 100): Promise<ApplePhotosPage<ApplePhotosAlbum>> {
-    return invoke<ApplePhotosPage<ApplePhotosAlbum>>('photos_list_albums', { offset, limit });
+export function photosListAlbums(offset = 0, limit = 100): Promise<ApplePhotosAlbumPage> {
+    return invoke<ApplePhotosAlbumPage>('photos_list_albums', { offset, limit });
 }
 
 export function photosListAssets(
     albumId: string | null,
     offset = 0,
     limit = 100,
-): Promise<ApplePhotosPage<ApplePhotosAsset>> {
-    return invoke<ApplePhotosPage<ApplePhotosAsset>>('photos_list_assets', { albumId, offset, limit });
+): Promise<ApplePhotosAssetPage> {
+    return invoke<ApplePhotosAssetPage>('photos_list_assets', { albumId, offset, limit });
 }
 
 function emitSessionEventsRefresh() {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -4,6 +4,60 @@
 import { invoke } from '@tauri-apps/api/core';
 import type { LibraryScope } from './library-scope';
 
+export type ApplePhotosAuthorization =
+    | 'unsupported'
+    | 'not_determined'
+    | 'restricted'
+    | 'denied'
+    | 'limited'
+    | 'authorized';
+
+export type ApplePhotosAlbumKind = 'user' | 'smart';
+
+export interface ApplePhotosAlbum {
+    id: string;
+    title: string | null;
+    kind: ApplePhotosAlbumKind;
+}
+
+export interface ApplePhotosAsset {
+    id: string;
+    filename: string | null;
+    created_at: string | null;
+    modified_at: string | null;
+    pixel_width: number;
+    pixel_height: number;
+    favorite: boolean;
+    media_subtypes: number;
+}
+
+export interface ApplePhotosPage<T> {
+    items: T[];
+    total: number;
+    offset: number;
+    has_more: boolean;
+}
+
+export function photosAuthorizationStatus(): Promise<ApplePhotosAuthorization> {
+    return invoke<ApplePhotosAuthorization>('photos_authorization_status');
+}
+
+export function photosRequestAuthorization(): Promise<ApplePhotosAuthorization> {
+    return invoke<ApplePhotosAuthorization>('photos_request_authorization');
+}
+
+export function photosListAlbums(offset = 0, limit = 100): Promise<ApplePhotosPage<ApplePhotosAlbum>> {
+    return invoke<ApplePhotosPage<ApplePhotosAlbum>>('photos_list_albums', { offset, limit });
+}
+
+export function photosListAssets(
+    albumId: string | null,
+    offset = 0,
+    limit = 100,
+): Promise<ApplePhotosPage<ApplePhotosAsset>> {
+    return invoke<ApplePhotosPage<ApplePhotosAsset>>('photos_list_assets', { albumId, offset, limit });
+}
+
 function emitSessionEventsRefresh() {
     if (typeof window !== 'undefined') {
         window.dispatchEvent(new CustomEvent('session-events-refresh'));

--- a/src/lib/apple-photos.ts
+++ b/src/lib/apple-photos.ts
@@ -1,0 +1,35 @@
+import {
+    photosAuthorizationStatus,
+    photosListAlbums,
+    photosListAssets,
+    photosRequestAuthorization,
+    type ApplePhotosAlbum,
+    type ApplePhotosAsset,
+    type ApplePhotosAuthorization,
+    type ApplePhotosPage,
+} from './api';
+
+export type {
+    ApplePhotosAlbum,
+    ApplePhotosAsset,
+    ApplePhotosAuthorization,
+    ApplePhotosPage,
+};
+
+export interface ApplePhotosCatalogClient {
+    authorizationStatus(): Promise<ApplePhotosAuthorization>;
+    requestAuthorization(): Promise<ApplePhotosAuthorization>;
+    listAlbums(offset: number, limit: number): Promise<ApplePhotosPage<ApplePhotosAlbum>>;
+    listAssets(
+        albumId: string | null,
+        offset: number,
+        limit: number,
+    ): Promise<ApplePhotosPage<ApplePhotosAsset>>;
+}
+
+export const tauriApplePhotosCatalogClient: ApplePhotosCatalogClient = {
+    authorizationStatus: photosAuthorizationStatus,
+    requestAuthorization: photosRequestAuthorization,
+    listAlbums: photosListAlbums,
+    listAssets: photosListAssets,
+};

--- a/src/lib/components/ApplePhotosCatalogDialog.svelte
+++ b/src/lib/components/ApplePhotosCatalogDialog.svelte
@@ -19,6 +19,7 @@
     const PAGE_SIZE = 100;
     let authorization = $state<ApplePhotosAuthorization | null>(null);
     let albums = $state<ApplePhotosAlbum[]>([]);
+    let albumsHasMore = $state(false);
     let selectedAlbumId = $state('');
     let assets = $state<ApplePhotosAsset[]>([]);
     let assetsTotal = $state(0);
@@ -37,16 +38,24 @@
     function messageFrom(errorValue: unknown): string {
         if (errorValue instanceof Error) return errorValue.message;
         if (typeof errorValue === 'string') return errorValue;
+        if (
+            typeof errorValue === 'object' &&
+            errorValue !== null &&
+            'message' in errorValue &&
+            typeof errorValue.message === 'string'
+        ) return errorValue.message;
         return 'Apple Photos could not be reached.';
     }
 
-    async function loadAlbums() {
+    async function loadAlbums(offset = 0, append = false) {
         const generation = ++albumsGeneration;
         albumsLoading = true;
+        error = null;
         try {
-            const page = await client.listAlbums(0, PAGE_SIZE);
+            const page = await client.listAlbums(offset, PAGE_SIZE);
             if (generation !== albumsGeneration) return;
-            albums = page.items;
+            albums = append ? [...albums, ...page.items] : page.items;
+            albumsHasMore = page.has_more;
         } catch (loadError) {
             if (generation !== albumsGeneration) return;
             error = messageFrom(loadError);
@@ -125,6 +134,11 @@
         void loadAssets(selectedAlbumId || null, assets.length, true);
     }
 
+    function loadMoreAlbums() {
+        if (albumsLoading || !albumsHasMore) return;
+        void loadAlbums(albums.length, true);
+    }
+
     onMount(() => {
         void checkAuthorization();
     });
@@ -189,6 +203,12 @@
                     {/each}
                 </select>
             </label>
+
+            {#if albumsHasMore}
+                <button class="btn" onclick={loadMoreAlbums} disabled={albumsLoading}>
+                    {albumsLoading ? 'Loading albums…' : 'Load more albums'}
+                </button>
+            {/if}
 
             {#if error}
                 <div class="catalog-error" role="alert">{error}</div>

--- a/src/lib/components/ApplePhotosCatalogDialog.svelte
+++ b/src/lib/components/ApplePhotosCatalogDialog.svelte
@@ -1,0 +1,333 @@
+<script lang="ts">
+    import { onDestroy, onMount } from 'svelte';
+    import ModalDialog from '$lib/components/ModalDialog.svelte';
+    import {
+        tauriApplePhotosCatalogClient,
+        type ApplePhotosAlbum,
+        type ApplePhotosAsset,
+        type ApplePhotosAuthorization,
+        type ApplePhotosCatalogClient,
+    } from '$lib/apple-photos';
+
+    interface Props {
+        onclose: () => void;
+        client?: ApplePhotosCatalogClient;
+    }
+
+    let { onclose, client = tauriApplePhotosCatalogClient }: Props = $props();
+
+    const PAGE_SIZE = 100;
+    let authorization = $state<ApplePhotosAuthorization | null>(null);
+    let albums = $state<ApplePhotosAlbum[]>([]);
+    let selectedAlbumId = $state('');
+    let assets = $state<ApplePhotosAsset[]>([]);
+    let assetsTotal = $state(0);
+    let assetsHasMore = $state(false);
+    let checking = $state(true);
+    let requesting = $state(false);
+    let albumsLoading = $state(false);
+    let assetsLoading = $state(false);
+    let error = $state<string | null>(null);
+    let authorizationGeneration = 0;
+    let albumsGeneration = 0;
+    let assetsGeneration = 0;
+
+    const canBrowse = $derived(authorization === 'authorized' || authorization === 'limited');
+
+    function messageFrom(errorValue: unknown): string {
+        if (errorValue instanceof Error) return errorValue.message;
+        if (typeof errorValue === 'string') return errorValue;
+        return 'Apple Photos could not be reached.';
+    }
+
+    async function loadAlbums() {
+        const generation = ++albumsGeneration;
+        albumsLoading = true;
+        try {
+            const page = await client.listAlbums(0, PAGE_SIZE);
+            if (generation !== albumsGeneration) return;
+            albums = page.items;
+        } catch (loadError) {
+            if (generation !== albumsGeneration) return;
+            error = messageFrom(loadError);
+        } finally {
+            if (generation === albumsGeneration) albumsLoading = false;
+        }
+    }
+
+    async function loadAssets(albumId: string | null, offset = 0, append = false) {
+        const generation = ++assetsGeneration;
+        assetsLoading = true;
+        error = null;
+        try {
+            const page = await client.listAssets(albumId, offset, PAGE_SIZE);
+            if (generation !== assetsGeneration) return;
+            assets = append ? [...assets, ...page.items] : page.items;
+            assetsTotal = page.total;
+            assetsHasMore = page.has_more;
+        } catch (loadError) {
+            if (generation !== assetsGeneration) return;
+            error = messageFrom(loadError);
+        } finally {
+            if (generation === assetsGeneration) assetsLoading = false;
+        }
+    }
+
+    function beginCatalogLoad() {
+        void loadAlbums();
+        void loadAssets(null);
+    }
+
+    async function checkAuthorization() {
+        const generation = ++authorizationGeneration;
+        checking = true;
+        error = null;
+        try {
+            const status = await client.authorizationStatus();
+            if (generation !== authorizationGeneration) return;
+            authorization = status;
+            if (status === 'authorized' || status === 'limited') beginCatalogLoad();
+        } catch (statusError) {
+            if (generation !== authorizationGeneration) return;
+            error = messageFrom(statusError);
+        } finally {
+            if (generation === authorizationGeneration) checking = false;
+        }
+    }
+
+    async function requestAccess() {
+        const generation = ++authorizationGeneration;
+        requesting = true;
+        error = null;
+        try {
+            const status = await client.requestAuthorization();
+            if (generation !== authorizationGeneration) return;
+            authorization = status;
+            if (status === 'authorized' || status === 'limited') beginCatalogLoad();
+        } catch (requestError) {
+            if (generation !== authorizationGeneration) return;
+            error = messageFrom(requestError);
+        } finally {
+            if (generation === authorizationGeneration) requesting = false;
+        }
+    }
+
+    function changeAlbum(event: Event) {
+        selectedAlbumId = (event.currentTarget as HTMLSelectElement).value;
+        assets = [];
+        assetsTotal = 0;
+        assetsHasMore = false;
+        void loadAssets(selectedAlbumId || null);
+    }
+
+    function loadMore() {
+        if (assetsLoading || !assetsHasMore) return;
+        void loadAssets(selectedAlbumId || null, assets.length, true);
+    }
+
+    onMount(() => {
+        void checkAuthorization();
+    });
+
+    onDestroy(() => {
+        authorizationGeneration += 1;
+        albumsGeneration += 1;
+        assetsGeneration += 1;
+    });
+</script>
+
+<ModalDialog
+    titleId="apple-photos-title"
+    descriptionId="apple-photos-description"
+    {onclose}
+    panelClass="dialog apple-photos-dialog"
+    overlayClass="apple-photos-overlay"
+    initialFocus=".apple-photos-close"
+>
+    <header class="dialog-header">
+        <div>
+            <h2 id="apple-photos-title">Apple Photos</h2>
+            <p id="apple-photos-description">Browse still-image metadata from your System Photo Library.</p>
+        </div>
+        <button class="close-btn apple-photos-close" onclick={onclose} aria-label="Close Apple Photos">×</button>
+    </header>
+
+    <div class="dialog-content">
+        {#if checking}
+            <div class="state" role="status">Checking Photos access…</div>
+        {:else if error && !canBrowse}
+            <div class="state error" role="alert">{error}</div>
+        {:else if authorization === 'not_determined'}
+            <section class="permission-state">
+                <h3>Allow access when you are ready</h3>
+                <p>Cull needs permission before it can browse your Photos library.</p>
+                <button class="btn primary" onclick={requestAccess} disabled={requesting}>
+                    {requesting ? 'Requesting…' : 'Allow Photos Access'}
+                </button>
+            </section>
+        {:else if authorization === 'denied' || authorization === 'restricted'}
+            <section class="permission-state">
+                <h3>Photos access is unavailable</h3>
+                <p>Enable Cull in System Settings → Privacy &amp; Security → Photos, then reopen this dialog.</p>
+            </section>
+        {:else if authorization === 'unsupported'}
+            <section class="permission-state">
+                <h3>Apple Photos is available on macOS</h3>
+                <p>This catalog source is not supported on the current platform.</p>
+            </section>
+        {:else if canBrowse}
+            {#if authorization === 'limited'}
+                <p class="limited-note" role="status">Showing the photos you allowed Cull to access.</p>
+            {/if}
+
+            <label class="album-picker">
+                <span>Album</span>
+                <select onchange={changeAlbum} value={selectedAlbumId} disabled={albumsLoading}>
+                    <option value="">All Photos</option>
+                    {#each albums as album (album.id)}
+                        <option value={album.id}>{album.title ?? 'Untitled album'}</option>
+                    {/each}
+                </select>
+            </label>
+
+            {#if error}
+                <div class="catalog-error" role="alert">{error}</div>
+            {/if}
+
+            <div class="catalog-summary">
+                <span>{assets.length} of {assetsTotal} still images</span>
+                <span>Metadata only · no downloads</span>
+            </div>
+
+            <div class="asset-list" aria-busy={assetsLoading && assets.length === 0}>
+                {#each assets as asset (asset.id)}
+                    <article class="asset-row">
+                        <div class="asset-name">{asset.filename ?? 'Untitled image'}</div>
+                        <div class="asset-meta">
+                            <span>{asset.pixel_width} × {asset.pixel_height}</span>
+                            {#if asset.created_at}<span>{new Date(asset.created_at).toLocaleDateString()}</span>{/if}
+                            {#if asset.favorite}<span>Favourite</span>{/if}
+                        </div>
+                    </article>
+                {:else}
+                    {#if assetsLoading}
+                        <div class="state" role="status">Loading photo metadata…</div>
+                    {:else}
+                        <div class="state">No still images are visible in this album.</div>
+                    {/if}
+                {/each}
+            </div>
+
+            {#if assetsHasMore}
+                <button class="btn" onclick={loadMore} disabled={assetsLoading}>
+                    {assetsLoading ? 'Loading…' : 'Load more'}
+                </button>
+            {/if}
+        {/if}
+    </div>
+</ModalDialog>
+
+<style>
+    :global(.apple-photos-overlay) {
+        background: color-mix(in srgb, var(--bg) 82%, transparent);
+    }
+
+    :global(.apple-photos-dialog) {
+        width: min(760px, calc(100vw - 32px));
+        height: min(90vh, 840px);
+        display: grid;
+        grid-template-rows: auto minmax(0, 1fr);
+        overflow: hidden;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--radius);
+    }
+
+    .dialog-header {
+        display: flex;
+        align-items: flex-start;
+        justify-content: space-between;
+        gap: 16px;
+        padding: 16px;
+        border-bottom: 1px solid var(--border);
+    }
+
+    h2, h3, p { margin: 0; }
+    h2 { font-size: 16px; }
+    h3 { font-size: 14px; }
+    .dialog-header p, .permission-state p { margin-top: 8px; color: var(--text-secondary); }
+
+    .close-btn {
+        border: 0;
+        background: transparent;
+        color: var(--text-secondary);
+        font: inherit;
+        font-size: 20px;
+        cursor: pointer;
+    }
+
+    .dialog-content {
+        min-height: 0;
+        display: flex;
+        flex-direction: column;
+        gap: 16px;
+        padding: 16px;
+        overflow: hidden;
+    }
+
+    .permission-state, .state {
+        margin: auto;
+        max-width: 520px;
+        text-align: center;
+    }
+
+    .permission-state .btn { margin-top: 16px; }
+    .error, .catalog-error { color: var(--red); }
+    .limited-note { color: var(--orange); }
+
+    .album-picker {
+        display: grid;
+        grid-template-columns: auto minmax(0, 1fr);
+        align-items: center;
+        gap: 16px;
+    }
+
+    select {
+        min-width: 0;
+        padding: 8px;
+        color: var(--text);
+        background: var(--bg);
+        border: 1px solid var(--border);
+        border-radius: var(--radius);
+        font: inherit;
+    }
+
+    .catalog-summary, .asset-meta {
+        display: flex;
+        justify-content: space-between;
+        gap: 16px;
+        color: var(--text-secondary);
+        font-size: 12px;
+    }
+
+    .asset-list {
+        min-height: 0;
+        flex: 1;
+        overflow: auto;
+        border: 1px solid var(--border);
+    }
+
+    .asset-row {
+        display: grid;
+        grid-template-columns: minmax(0, 1fr) auto;
+        align-items: center;
+        gap: 16px;
+        min-height: 48px;
+        padding: 8px 16px;
+        border-bottom: 1px solid var(--border);
+    }
+
+    .asset-row:last-child { border-bottom: 0; }
+    .asset-name { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+    .asset-meta { justify-content: flex-end; }
+</style>

--- a/src/lib/components/ApplePhotosCatalogDialog.svelte
+++ b/src/lib/components/ApplePhotosCatalogDialog.svelte
@@ -28,7 +28,9 @@
     let requesting = $state(false);
     let albumsLoading = $state(false);
     let assetsLoading = $state(false);
-    let error = $state<string | null>(null);
+    let authorizationError = $state<string | null>(null);
+    let albumsError = $state<string | null>(null);
+    let assetsError = $state<string | null>(null);
     let authorizationGeneration = 0;
     let albumsGeneration = 0;
     let assetsGeneration = 0;
@@ -50,7 +52,7 @@
     async function loadAlbums(offset = 0, append = false) {
         const generation = ++albumsGeneration;
         albumsLoading = true;
-        error = null;
+        albumsError = null;
         try {
             const page = await client.listAlbums(offset, PAGE_SIZE);
             if (generation !== albumsGeneration) return;
@@ -58,7 +60,7 @@
             albumsHasMore = page.has_more;
         } catch (loadError) {
             if (generation !== albumsGeneration) return;
-            error = messageFrom(loadError);
+            albumsError = messageFrom(loadError);
         } finally {
             if (generation === albumsGeneration) albumsLoading = false;
         }
@@ -67,7 +69,7 @@
     async function loadAssets(albumId: string | null, offset = 0, append = false) {
         const generation = ++assetsGeneration;
         assetsLoading = true;
-        error = null;
+        assetsError = null;
         try {
             const page = await client.listAssets(albumId, offset, PAGE_SIZE);
             if (generation !== assetsGeneration) return;
@@ -76,7 +78,7 @@
             assetsHasMore = page.has_more;
         } catch (loadError) {
             if (generation !== assetsGeneration) return;
-            error = messageFrom(loadError);
+            assetsError = messageFrom(loadError);
         } finally {
             if (generation === assetsGeneration) assetsLoading = false;
         }
@@ -90,7 +92,7 @@
     async function checkAuthorization() {
         const generation = ++authorizationGeneration;
         checking = true;
-        error = null;
+        authorizationError = null;
         try {
             const status = await client.authorizationStatus();
             if (generation !== authorizationGeneration) return;
@@ -98,7 +100,7 @@
             if (status === 'authorized' || status === 'limited') beginCatalogLoad();
         } catch (statusError) {
             if (generation !== authorizationGeneration) return;
-            error = messageFrom(statusError);
+            authorizationError = messageFrom(statusError);
         } finally {
             if (generation === authorizationGeneration) checking = false;
         }
@@ -107,7 +109,7 @@
     async function requestAccess() {
         const generation = ++authorizationGeneration;
         requesting = true;
-        error = null;
+        authorizationError = null;
         try {
             const status = await client.requestAuthorization();
             if (generation !== authorizationGeneration) return;
@@ -115,7 +117,7 @@
             if (status === 'authorized' || status === 'limited') beginCatalogLoad();
         } catch (requestError) {
             if (generation !== authorizationGeneration) return;
-            error = messageFrom(requestError);
+            authorizationError = messageFrom(requestError);
         } finally {
             if (generation === authorizationGeneration) requesting = false;
         }
@@ -169,8 +171,8 @@
     <div class="dialog-content">
         {#if checking}
             <div class="state" role="status">Checking Photos access…</div>
-        {:else if error && !canBrowse}
-            <div class="state error" role="alert">{error}</div>
+        {:else if authorizationError && !canBrowse}
+            <div class="state error" role="alert">{authorizationError}</div>
         {:else if authorization === 'not_determined'}
             <section class="permission-state">
                 <h3>Allow access when you are ready</h3>
@@ -210,8 +212,11 @@
                 </button>
             {/if}
 
-            {#if error}
-                <div class="catalog-error" role="alert">{error}</div>
+            {#if albumsError}
+                <div class="catalog-error" role="alert">Albums: {albumsError}</div>
+            {/if}
+            {#if assetsError}
+                <div class="catalog-error" role="alert">Photos: {assetsError}</div>
             {/if}
 
             <div class="catalog-summary">

--- a/src/lib/components/apple-photos-catalog-dialog.behavior.test.ts
+++ b/src/lib/components/apple-photos-catalog-dialog.behavior.test.ts
@@ -133,6 +133,24 @@ describe('Apple Photos catalog dialog', () => {
         expect(catalog.listAlbums).toHaveBeenLastCalledWith(100, 100);
     });
 
+    it('keeps an asset error visible when a later album page succeeds', async () => {
+        const firstAlbums = Array.from({ length: 100 }, (_, index) => album(`album-${index}`, `Album ${index}`));
+        const catalog = client({
+            listAlbums: vi.fn()
+                .mockResolvedValueOnce(page(firstAlbums, 0, 101))
+                .mockResolvedValueOnce(page([album('album-last', 'Last album')], 100, 101)),
+            listAssets: vi.fn().mockRejectedValue(new Error('Asset catalog unavailable')),
+        });
+        const user = userEvent.setup();
+        render(ApplePhotosCatalogDialog, { onclose: vi.fn(), client: catalog });
+
+        expect(await screen.findByText('Photos: Asset catalog unavailable')).toBeInTheDocument();
+        await user.click(screen.getByRole('button', { name: 'Load more albums' }));
+
+        expect(await screen.findByRole('option', { name: 'Last album' })).toBeInTheDocument();
+        expect(screen.getByText('Photos: Asset catalog unavailable')).toBeInTheDocument();
+    });
+
     it('ignores authorization completion after the dialog has closed', async () => {
         let resolveAuthorization!: (status: 'authorized') => void;
         const authorization = new Promise<'authorized'>(resolve => { resolveAuthorization = resolve; });

--- a/src/lib/components/apple-photos-catalog-dialog.behavior.test.ts
+++ b/src/lib/components/apple-photos-catalog-dialog.behavior.test.ts
@@ -104,4 +104,50 @@ describe('Apple Photos catalog dialog', () => {
         await user.click(screen.getByRole('button', { name: 'Close Apple Photos' }));
         expect(onclose).toHaveBeenCalledOnce();
     });
+
+    it.each(['restricted', 'unsupported'] as const)('renders the %s platform state', async (status) => {
+        const catalog = client({ authorizationStatus: vi.fn().mockResolvedValue(status) });
+        render(ApplePhotosCatalogDialog, { onclose: vi.fn(), client: catalog });
+
+        if (status === 'restricted') {
+            expect(await screen.findByText(/System Settings.*Privacy & Security.*Photos/i)).toBeInTheDocument();
+        } else {
+            expect(await screen.findByText('This catalog source is not supported on the current platform.')).toBeInTheDocument();
+        }
+        expect(catalog.requestAuthorization).not.toHaveBeenCalled();
+    });
+
+    it('loads another bounded album page when the library has more than 100 albums', async () => {
+        const firstAlbums = Array.from({ length: 100 }, (_, index) => album(`album-${index}`, `Album ${index}`));
+        const catalog = client({
+            listAlbums: vi.fn()
+                .mockResolvedValueOnce(page(firstAlbums, 0, 101))
+                .mockResolvedValueOnce(page([album('album-last', 'Last album')], 100, 101)),
+        });
+        const user = userEvent.setup();
+        render(ApplePhotosCatalogDialog, { onclose: vi.fn(), client: catalog });
+
+        await user.click(await screen.findByRole('button', { name: 'Load more albums' }));
+
+        expect(await screen.findByRole('option', { name: 'Last album' })).toBeInTheDocument();
+        expect(catalog.listAlbums).toHaveBeenLastCalledWith(100, 100);
+    });
+
+    it('ignores authorization completion after the dialog has closed', async () => {
+        let resolveAuthorization!: (status: 'authorized') => void;
+        const authorization = new Promise<'authorized'>(resolve => { resolveAuthorization = resolve; });
+        const catalog = client({ authorizationStatus: vi.fn(() => authorization) });
+        const onclose = vi.fn();
+        const user = userEvent.setup();
+        const view = render(ApplePhotosCatalogDialog, { onclose, client: catalog });
+
+        await user.click(screen.getByRole('button', { name: 'Close Apple Photos' }));
+        view.unmount();
+        resolveAuthorization('authorized');
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(catalog.listAlbums).not.toHaveBeenCalled();
+        expect(catalog.listAssets).not.toHaveBeenCalled();
+    });
 });

--- a/src/lib/components/apple-photos-catalog-dialog.behavior.test.ts
+++ b/src/lib/components/apple-photos-catalog-dialog.behavior.test.ts
@@ -1,0 +1,107 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import '@testing-library/jest-dom/vitest';
+import { cleanup, render, screen, waitFor } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import ApplePhotosCatalogDialog from './ApplePhotosCatalogDialog.svelte';
+import type {
+    ApplePhotosAlbum,
+    ApplePhotosAsset,
+    ApplePhotosCatalogClient,
+    ApplePhotosPage,
+} from '$lib/apple-photos';
+
+afterEach(() => cleanup());
+
+function page<T>(items: T[], offset = 0, total = items.length): ApplePhotosPage<T> {
+    return { items, offset, total, has_more: offset + items.length < total };
+}
+
+function album(id: string, title: string): ApplePhotosAlbum {
+    return { id, title, kind: 'user' };
+}
+
+function asset(id: string, filename: string): ApplePhotosAsset {
+    return {
+        id,
+        filename,
+        created_at: '2026-08-08T12:00:00Z',
+        modified_at: null,
+        pixel_width: 1200,
+        pixel_height: 800,
+        favorite: false,
+        media_subtypes: 0,
+    };
+}
+
+function client(overrides: Partial<ApplePhotosCatalogClient> = {}): ApplePhotosCatalogClient {
+    return {
+        authorizationStatus: vi.fn().mockResolvedValue('authorized'),
+        requestAuthorization: vi.fn().mockResolvedValue('authorized'),
+        listAlbums: vi.fn().mockResolvedValue(page([])),
+        listAssets: vi.fn().mockResolvedValue(page([])),
+        ...overrides,
+    };
+}
+
+describe('Apple Photos catalog dialog', () => {
+    it('requests access only after an explicit user action, then lists the limited catalog', async () => {
+        const catalog = client({
+            authorizationStatus: vi.fn().mockResolvedValue('not_determined'),
+            requestAuthorization: vi.fn().mockResolvedValue('limited'),
+            listAlbums: vi.fn().mockResolvedValue(page([album('album-1', 'Favourites')])),
+            listAssets: vi.fn().mockResolvedValue(page([asset('asset-1', 'IMG_0001.HEIC')])),
+        });
+        const user = userEvent.setup();
+        render(ApplePhotosCatalogDialog, { onclose: vi.fn(), client: catalog });
+
+        expect(await screen.findByText('Cull needs permission before it can browse your Photos library.')).toBeInTheDocument();
+        expect(catalog.requestAuthorization).not.toHaveBeenCalled();
+
+        await user.click(screen.getByRole('button', { name: 'Allow Photos Access' }));
+
+        expect(await screen.findByText('Showing the photos you allowed Cull to access.')).toBeInTheDocument();
+        expect(await screen.findByRole('option', { name: 'Favourites' })).toBeInTheDocument();
+        expect(await screen.findByText('IMG_0001.HEIC')).toBeInTheDocument();
+        expect(catalog.listAssets).toHaveBeenCalledWith(null, 0, 100);
+    });
+
+    it('switches albums, ignores a stale response, and appends a bounded next page', async () => {
+        let resolveAll!: (value: ApplePhotosPage<ApplePhotosAsset>) => void;
+        const allPending = new Promise<ApplePhotosPage<ApplePhotosAsset>>(resolve => { resolveAll = resolve; });
+        const catalog = client({
+            listAlbums: vi.fn().mockResolvedValue(page([
+                album('album-a', 'A'),
+                album('album-b', 'B'),
+            ])),
+            listAssets: vi.fn()
+                .mockImplementationOnce(() => allPending)
+                .mockResolvedValueOnce(page([asset('b-1', 'B-1.jpg')], 0, 2))
+                .mockResolvedValueOnce(page([asset('b-2', 'B-2.jpg')], 1, 2)),
+        });
+        const user = userEvent.setup();
+        render(ApplePhotosCatalogDialog, { onclose: vi.fn(), client: catalog });
+
+        const selector = await screen.findByRole('combobox', { name: 'Album' });
+        await user.selectOptions(selector, 'album-b');
+        expect(await screen.findByText('B-1.jpg')).toBeInTheDocument();
+
+        resolveAll(page([asset('stale', 'STALE.jpg')]));
+        await waitFor(() => expect(screen.queryByText('STALE.jpg')).not.toBeInTheDocument());
+
+        await user.click(screen.getByRole('button', { name: 'Load more' }));
+        expect(await screen.findByText('B-2.jpg')).toBeInTheDocument();
+        expect(catalog.listAssets).toHaveBeenLastCalledWith('album-b', 1, 100);
+    });
+
+    it('shows recovery guidance for denied access and closes through the shared modal', async () => {
+        const onclose = vi.fn();
+        const catalog = client({ authorizationStatus: vi.fn().mockResolvedValue('denied') });
+        const user = userEvent.setup();
+        render(ApplePhotosCatalogDialog, { onclose, client: catalog });
+
+        expect(await screen.findByText(/System Settings.*Privacy & Security.*Photos/i)).toBeInTheDocument();
+        await user.click(screen.getByRole('button', { name: 'Close Apple Photos' }));
+        expect(onclose).toHaveBeenCalledOnce();
+    });
+});

--- a/src/lib/file-menu-contract.test.ts
+++ b/src/lib/file-menu-contract.test.ts
@@ -27,4 +27,14 @@ describe('File menu contract', () => {
         expect(fileMenu.indexOf('"open_file"')).toBeLessThan(fileMenu.indexOf('"import_folder"'));
         expect(menuSource).toContain('"import_folder"');
     });
+
+    it('exposes Apple Photos discovery only in the macOS File menu', () => {
+        const menuSource = readProjectFile('src-tauri/src/menu.rs');
+        const fileMenu = menuSection(menuSource, '// File menu', '// Edit menu');
+
+        expect(fileMenu).toContain('#[cfg(target_os = "macos")]');
+        expect(fileMenu).toContain('"import_apple_photos"');
+        expect(fileMenu).toContain('"Import from Apple Photos..."');
+        expect(fileMenu.indexOf('"import_folder"')).toBeLessThan(fileMenu.indexOf('"import_apple_photos"'));
+    });
 });

--- a/src/lib/menu.test.ts
+++ b/src/lib/menu.test.ts
@@ -212,6 +212,27 @@ describe('native menu bridge', () => {
         expect(get(stores.viewMode)).toBe('grid');
     });
 
+    it('opens the Apple Photos catalog from the native File menu', async () => {
+        let menuHandler: ((event: { payload: string }) => void) | undefined;
+        mocks.listen.mockImplementation(async (_eventName, handler) => {
+            menuHandler = handler as (event: { payload: string }) => void;
+            return vi.fn();
+        });
+
+        const [{ initMenu }, { applePhotosCatalogOpen }] = await Promise.all([
+            import('./menu'),
+            import('./stores'),
+        ]);
+
+        applePhotosCatalogOpen.set(false);
+        await initMenu({ listenTimeoutMs: 50, retryDelayMs: 10 });
+        await flushMicrotasks();
+
+        menuHandler?.({ payload: 'import_apple_photos' });
+
+        expect(get(applePhotosCatalogOpen)).toBe(true);
+    });
+
     it('opens the GitHub wiki when the native Help menu action fires', async () => {
         let handler: ((event: { payload: string }) => void) | undefined;
         mocks.listen.mockImplementation(async (_eventName, next) => {

--- a/src/lib/menu.ts
+++ b/src/lib/menu.ts
@@ -45,6 +45,7 @@ import {
     activePluginIds,
     aboutOpen,
     agentSkillsOpen,
+    applePhotosCatalogOpen,
     navigateTo,
     showToast,
     requestTextInput,
@@ -404,6 +405,9 @@ function handleMenuAction(action: string) {
         case 'import_folder':
         case 'open_folder':
             handleOpenFolder();
+            break;
+        case 'import_apple_photos':
+            applePhotosCatalogOpen.set(true);
             break;
         case 'undo':
             undo().then(label => {

--- a/src/lib/stores.ts
+++ b/src/lib/stores.ts
@@ -576,6 +576,8 @@ export const activeCanvas = writable<Canvas | null>(null);
 export const settingsOpen = writable<boolean>(false);
 export const aboutOpen = writable<boolean>(false);
 export const agentSkillsOpen = writable<boolean>(false);
+// Read-only Apple Photos metadata catalog; macOS exposes the native File menu action.
+export const applePhotosCatalogOpen = writable<boolean>(false);
 export const searchOpen = writable<boolean>(false);
 export type CommandPaletteMode = 'all' | 'commands';
 export const commandPaletteOpen = writable<boolean>(false);

--- a/src/lib/tauri-command-contract.test.ts
+++ b/src/lib/tauri-command-contract.test.ts
@@ -238,12 +238,15 @@ describe('Tauri command contract', () => {
             'app-curation',
             'app-export-publishing',
             'app-file-access',
+            'app-photos',
             'app-read',
             'app-ui',
         ]);
 
         for (const capability of appCapabilities) {
-            expect(capability.windows).toEqual(['main', 'window-*']);
+            expect(capability.windows).toEqual(
+                capability.identifier === 'app-photos' ? ['main'] : ['main', 'window-*'],
+            );
         }
     });
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -27,6 +27,7 @@
     import UndoHistoryPanel from '$lib/components/UndoHistoryPanel.svelte';
     import AboutDialog from '$lib/components/AboutDialog.svelte';
     import AgentSkillsDialog from '$lib/components/AgentSkillsDialog.svelte';
+    import ApplePhotosCatalogDialog from '$lib/components/ApplePhotosCatalogDialog.svelte';
     import AgentProposalDock from '$lib/components/AgentProposalDock.svelte';
     import ActionProposalReviewDialog from '$lib/components/ActionProposalReviewDialog.svelte';
     import JobProgressPanel from '$lib/components/JobProgressPanel.svelte';
@@ -37,7 +38,7 @@
     import GenerationResultsStrip from '$lib/components/GenerationResultsStrip.svelte';
     import PreviewDisplay from '$lib/components/PreviewDisplay.svelte';
     import { handleKeydown } from '$lib/keys';
-    import { images, focusedIndex, focusedImage, viewMode, sidebarVisible, zenMode, minSizeFilter, showToast, settingsOpen, aboutOpen, agentSkillsOpen, searchOpen, showMissing, showRejected, smartCollections, activeSmartCollection, activeFolder, activeCollection, activeDetectedClass, staticPublishingEnabled, clientToolsEnabled, voiceDictationEnabled, pluginsEnabled, selectedIds, activeCanvas, activeSession, collections, windowLabel, agentPanelPinned, agentPanelVisible, agentVisualLevel, activeAgentProposalId, activeAgentSelectionPresetId, cycleAgentVisualLevel } from '$lib/stores';
+    import { images, focusedIndex, focusedImage, viewMode, sidebarVisible, zenMode, minSizeFilter, showToast, settingsOpen, aboutOpen, agentSkillsOpen, applePhotosCatalogOpen, searchOpen, showMissing, showRejected, smartCollections, activeSmartCollection, activeFolder, activeCollection, activeDetectedClass, staticPublishingEnabled, clientToolsEnabled, voiceDictationEnabled, pluginsEnabled, selectedIds, activeCanvas, activeSession, collections, windowLabel, agentPanelPinned, agentPanelVisible, agentVisualLevel, activeAgentProposalId, activeAgentSelectionPresetId, cycleAgentVisualLevel } from '$lib/stores';
     import { trashImages, trashImagesDetailed, deleteImagesPermanently, getAppSetting, setAppSetting, checkLibraryHealth, regenerateThumbnailsByIds, listCollections, listSmartCollections, updatePreviewState, captureAgentWindowSnapshot, completeAgentViewSnapshot, failAgentViewSnapshot, createActionProposal, listActionProposals, applyActionProposal, dismissActionProposal, listAgentSelectionPresets, upsertAgentSelectionPreset, runClaudeAgentChatTurn, cancelClaudeAgentChatTurn, undo, type AgentActionProposal, type AgentChatImageContext, type AgentSelectionPreset, type AgentVisualLevel, type ClaudeAgentStreamEvent, type ImageWithFile, type PreviewState } from '$lib/api';
     import { initDeepLink } from '$lib/deeplink';
     import { initMenu } from '$lib/menu';
@@ -1047,6 +1048,10 @@
 
     {#if $agentSkillsOpen}
         <AgentSkillsDialog onclose={() => agentSkillsOpen.set(false)} />
+    {/if}
+
+    {#if $applePhotosCatalogOpen}
+        <ApplePhotosCatalogDialog onclose={() => applePhotosCatalogOpen.set(false)} />
     {/if}
 
     <TrashConfirmDialog


### PR DESCRIPTION
## Summary
- add a macOS-gated, read-only PhotoKit catalog adapter and permission boundary
- expose explicit authorization plus bounded album/still-image metadata paging
- add a stable, accessible Apple Photos catalog dialog from the File menu
- wire usage description, signed Photos entitlement, and main-window-only capability

## Safety boundary
- no asset downloads or materialization
- no Cull database writes
- no collection mirroring, provenance, sync, or MCP surface
- follow-up policy ticket: imageview-uz3.2

## Verification
- two-axis Spec + Standards review: PASS
- npm run preflight -- full
- npm run audit:licenses
- npm run build
- frontend: 171 files / 1290 tests
- Rust: 864 passed / 3 ignored, plus all integration targets

Tracks imageview-uz3.1