### PR TITLE
fix: unify Trash safety and reliable undo (dtj.11)

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -85,7 +85,7 @@ libc = "0.2"
 core-foundation = "0.10"
 objc2 = "0.6"
 objc2-app-kit = { version = "0.3", features = ["NSApplication", "NSImage", "NSPasteboard", "NSPasteboardItem", "NSResponder", "NSSharingService", "NSView", "NSWindow", "NSWorkspace"] }
-objc2-foundation = { version = "0.3", features = ["NSArray", "NSError", "NSGeometry", "NSLocale", "NSObject", "NSString", "NSThread", "NSURL", "block2"] }
+objc2-foundation = { version = "0.3", features = ["NSArray", "NSError", "NSFileManager", "NSGeometry", "NSLocale", "NSObject", "NSString", "NSThread", "NSURL", "block2"] }
 objc2-vision = { version = "0.3.2", default-features = false, features = ["std", "VNObservation", "VNRecognizeTextRequest", "VNRequest", "VNRequestHandler", "VNTypes"] }
 objc2-speech = "0.3"
 objc2-avf-audio = "0.3"

--- a/src-tauri/src/commands/library.rs
+++ b/src-tauri/src/commands/library.rs
@@ -155,54 +155,7 @@ pub async fn trash_images(
 }
 
 fn trash_images_inner(state: &AppState, image_ids: &[String]) -> Result<u32, String> {
-    let mut trashed = 0u32;
-    for image_id in image_ids {
-        let id_refs: Vec<&str> = vec![image_id.as_str()];
-        let found = state
-            .db
-            .get_images_by_ids(&id_refs)
-            .map_err(|e| e.to_string())?;
-        if let Some(img) = found.first() {
-            let path = std::path::Path::new(&img.path);
-            if path.exists() {
-                match trash::delete(path) {
-                    Ok(()) => {
-                        trashed += 1;
-                        let _ = state.db.mark_file_missing(&img.path);
-                        let filename = path
-                            .file_name()
-                            .and_then(|n| n.to_str())
-                            .unwrap_or("file")
-                            .to_string();
-                        log_library_event(
-                            state,
-                            "image_moved_to_trash",
-                            Some("image"),
-                            Some(image_id.clone()),
-                            serde_json::json!({
-                                "image_id": image_id,
-                                "path": &img.path,
-                                "filename": filename.clone(),
-                            }),
-                        );
-                        let _ = state.action_manager.record_action(
-                            &state.db,
-                            "trash_image",
-                            format!("Trash {}", filename),
-                            serde_json::json!({"image_id": image_id, "path": &img.path}).to_string(),
-                            serde_json::json!({"image_id": image_id, "path": &img.path, "trashed": true}).to_string(),
-                            image_id.clone(),
-                            true,
-                        );
-                    }
-                    Err(e) => {
-                        eprintln!("Failed to trash {}: {}", img.path, e);
-                    }
-                }
-            }
-        }
-    }
-    Ok(trashed)
+    Ok(trash_images_detailed_inner(state, image_ids)?.succeeded)
 }
 
 #[tauri::command]
@@ -216,6 +169,14 @@ pub async fn trash_images_detailed(
 pub(crate) fn trash_images_detailed_inner(
     state: &AppState,
     image_ids: &[String],
+) -> Result<TrashImagesDetailedResult, String> {
+    trash_images_detailed_with(state, image_ids, &crate::services::trash::SystemTrash)
+}
+
+fn trash_images_detailed_with(
+    state: &AppState,
+    image_ids: &[String],
+    platform: &dyn crate::services::trash::TrashPlatform,
 ) -> Result<TrashImagesDetailedResult, String> {
     let mut results = Vec::new();
 
@@ -247,14 +208,64 @@ pub(crate) fn trash_images_detailed_inner(
             continue;
         }
 
-        match trash::delete(path) {
-            Ok(()) => {
-                let _ = state.db.mark_file_missing(&img.path);
+        match crate::services::trash::move_to_trash(platform, path) {
+            Ok(Some(record)) => {
                 let filename = path
                     .file_name()
                     .and_then(|n| n.to_str())
                     .unwrap_or("file")
                     .to_string();
+                if let Err(error) = state.db.mark_file_missing(&img.path) {
+                    let _ = crate::services::trash::restore_from_trash(&record);
+                    results.push(TrashImageResult {
+                        image_id: image_id.clone(),
+                        path: Some(img.path.clone()),
+                        status: "failed".to_string(),
+                        error: Some(format!("Could not update library state: {error}")),
+                    });
+                    continue;
+                }
+                let record_result = state.action_manager.record_action(
+                    &state.db,
+                    "trash_image",
+                    format!("Trash {}", filename),
+                    serde_json::json!({
+                        "image_id": image_id,
+                        "path": &img.path,
+                        "original_path": record.original_path,
+                        "trashed_path": record.trashed_path,
+                    })
+                    .to_string(),
+                    serde_json::json!({
+                        "image_id": image_id,
+                        "path": &img.path,
+                        "original_path": record.original_path,
+                        "trashed_path": record.trashed_path,
+                        "trashed": true,
+                    })
+                    .to_string(),
+                    image_id.clone(),
+                    true,
+                );
+                if let Err(error) = record_result {
+                    let rollback_error = crate::services::trash::restore_from_trash(&record).err();
+                    if rollback_error.is_none() {
+                        let _ = state.db.restore_file(&img.path);
+                    }
+                    let detail = match rollback_error {
+                        Some(rollback) => format!(
+                            "Could not record undo ({error}); restore also failed ({rollback})"
+                        ),
+                        None => format!("Could not record undo: {error}"),
+                    };
+                    results.push(TrashImageResult {
+                        image_id: image_id.clone(),
+                        path: Some(img.path.clone()),
+                        status: "failed".to_string(),
+                        error: Some(detail),
+                    });
+                    continue;
+                }
                 log_library_event(
                     state,
                     "image_moved_to_trash",
@@ -263,24 +274,36 @@ pub(crate) fn trash_images_detailed_inner(
                     serde_json::json!({
                         "image_id": image_id,
                         "path": &img.path,
-                        "filename": filename.clone(),
+                        "trash_path": record.trashed_path,
+                        "filename": filename,
                     }),
-                );
-                let _ = state.action_manager.record_action(
-                    &state.db,
-                    "trash_image",
-                    format!("Trash {}", filename),
-                    serde_json::json!({"image_id": image_id, "path": &img.path}).to_string(),
-                    serde_json::json!({"image_id": image_id, "path": &img.path, "trashed": true})
-                        .to_string(),
-                    image_id.clone(),
-                    true,
                 );
                 results.push(TrashImageResult {
                     image_id: image_id.clone(),
                     path: Some(img.path.clone()),
                     status: "trashed".to_string(),
                     error: None,
+                });
+            }
+            Ok(None) => {
+                let mark_error = state.db.mark_file_missing(&img.path).err();
+                log_library_event(
+                    state,
+                    "image_moved_to_trash",
+                    Some("image"),
+                    Some(image_id.clone()),
+                    serde_json::json!({
+                        "image_id": image_id,
+                        "path": &img.path,
+                        "undo_available": false,
+                    }),
+                );
+                results.push(TrashImageResult {
+                    image_id: image_id.clone(),
+                    path: Some(img.path.clone()),
+                    status: "trashed".to_string(),
+                    error: mark_error
+                        .map(|error| format!("Could not update library state: {error}")),
                 });
             }
             Err(e) => {
@@ -495,6 +518,35 @@ mod tests {
     use crate::{services, watcher};
     use std::path::Path;
 
+    struct TestTrash {
+        root: std::path::PathBuf,
+    }
+
+    impl crate::services::trash::TrashPlatform for TestTrash {
+        fn move_to_trash(
+            &self,
+            source: &Path,
+        ) -> Result<crate::services::trash::TrashDestination, String> {
+            let file_name = source.file_name().ok_or("missing file name")?;
+            let mut destination = self.root.join(file_name);
+            let mut suffix = 2;
+            while destination.exists() {
+                let stem = source
+                    .file_stem()
+                    .and_then(|value| value.to_str())
+                    .unwrap_or("file");
+                let extension = source.extension().and_then(|value| value.to_str());
+                destination = self.root.join(match extension {
+                    Some(extension) => format!("{stem} {suffix}.{extension}"),
+                    None => format!("{stem} {suffix}"),
+                });
+                suffix += 1;
+            }
+            std::fs::rename(source, &destination).map_err(|error| error.to_string())?;
+            Ok(crate::services::trash::TrashDestination::Exact(destination))
+        }
+    }
+
     fn test_state(tmp: &Path) -> AppState {
         let db = Database::open(&tmp.join("test.db")).unwrap();
         let app_data_dir = tmp.join("app-data");
@@ -628,8 +680,9 @@ mod tests {
         }
     }
 
-    /// Verify that the trash crate can handle filenames with special characters
-    /// that would have caused AppleScript injection with the old implementation.
+    /// Verify that the native Trash API treats special characters as path data,
+    /// never as AppleScript or shell syntax.
+    #[cfg(target_os = "macos")]
     #[test]
     fn trash_special_char_filename() {
         let dir = tempfile::tempdir().unwrap();
@@ -638,13 +691,19 @@ mod tests {
         std::fs::write(&file_path, b"fake image data").unwrap();
         assert!(file_path.exists());
 
-        trash::delete(&file_path).expect("trash::delete should handle special characters");
+        let record =
+            crate::services::trash::move_to_trash(&crate::services::trash::SystemTrash, &file_path)
+                .expect("native Trash should handle special characters")
+                .expect("macOS should return the exact Trash destination");
         assert!(
             !file_path.exists(),
             "file should no longer exist at original path"
         );
+        crate::services::trash::restore_from_trash(&record).unwrap();
+        assert!(file_path.exists());
     }
 
+    #[cfg(target_os = "macos")]
     #[test]
     fn trash_images_moves_file_marks_missing_and_records_audit_and_undo() {
         let dir = tempfile::tempdir().unwrap();
@@ -677,6 +736,13 @@ mod tests {
         assert_eq!(undo_records.len(), 1);
         assert_eq!(undo_records[0].action_type, "trash_image");
         assert!(undo_records[0].has_file_backup);
+        let before: serde_json::Value = serde_json::from_str(&undo_records[0].before_json).unwrap();
+        let trash_path = before["trashed_path"].as_str().unwrap();
+        assert!(std::path::Path::new(trash_path).exists());
+        assert_ne!(trash_path, file_path.to_string_lossy());
+
+        state.action_manager.undo(&state.db).unwrap();
+        assert!(file_path.exists());
     }
 
     #[test]
@@ -715,5 +781,78 @@ mod tests {
             .unwrap()
             .unwrap();
         assert!(image_file.missing_at.is_some());
+    }
+
+    #[test]
+    fn trash_undo_restores_exact_duplicate_destinations_and_database_visibility() {
+        let dir = tempfile::tempdir().unwrap();
+        let trash_root = dir.path().join("external-volume-trash");
+        let first_dir = dir.path().join("first");
+        let second_dir = dir.path().join("second");
+        std::fs::create_dir_all(&trash_root).unwrap();
+        std::fs::create_dir_all(&first_dir).unwrap();
+        std::fs::create_dir_all(&second_dir).unwrap();
+        let first_path = first_dir.join("duplicate.png");
+        let second_path = second_dir.join("duplicate.png");
+        std::fs::write(&first_path, b"first").unwrap();
+        std::fs::write(&second_path, b"second").unwrap();
+        let state = test_state(dir.path());
+        insert_test_image(&state.db, "img-trash-first", &first_path);
+        insert_test_image(&state.db, "img-trash-second", &second_path);
+        let platform = TestTrash {
+            root: trash_root.clone(),
+        };
+
+        let result = trash_images_detailed_with(
+            &state,
+            &[
+                "img-trash-first".to_string(),
+                "img-trash-second".to_string(),
+            ],
+            &platform,
+        )
+        .unwrap();
+
+        assert_eq!(result.succeeded, 2);
+        let records = state.db.list_undo_records(10).unwrap();
+        assert_eq!(records.len(), 2);
+        let destinations: Vec<String> = records
+            .iter()
+            .map(|record| {
+                serde_json::from_str::<serde_json::Value>(&record.before_json).unwrap()
+                    ["trashed_path"]
+                    .as_str()
+                    .unwrap()
+                    .to_string()
+            })
+            .collect();
+        assert_ne!(destinations[0], destinations[1]);
+        assert!(destinations
+            .iter()
+            .all(|path| Path::new(path).starts_with(&trash_root)));
+
+        state.action_manager.undo(&state.db).unwrap();
+        state.action_manager.undo(&state.db).unwrap();
+
+        assert_eq!(std::fs::read(&first_path).unwrap(), b"first");
+        assert_eq!(std::fs::read(&second_path).unwrap(), b"second");
+        for path in [&first_path, &second_path] {
+            let image_file = state
+                .db
+                .get_image_file_by_path(&path.to_string_lossy())
+                .unwrap()
+                .unwrap();
+            assert!(image_file.missing_at.is_none());
+        }
+
+        state.action_manager.redo(&state.db).unwrap();
+        state.action_manager.redo(&state.db).unwrap();
+        assert!(!first_path.exists());
+        assert!(!second_path.exists());
+
+        state.action_manager.undo(&state.db).unwrap();
+        state.action_manager.undo(&state.db).unwrap();
+        assert_eq!(std::fs::read(&first_path).unwrap(), b"first");
+        assert_eq!(std::fs::read(&second_path).unwrap(), b"second");
     }
 }

--- a/src-tauri/src/commands/library.rs
+++ b/src-tauri/src/commands/library.rs
@@ -209,49 +209,41 @@ fn trash_images_detailed_with(
         }
 
         match crate::services::trash::move_to_trash(platform, path) {
-            Ok(Some(record)) => {
+            Ok(record) => {
                 let filename = path
                     .file_name()
                     .and_then(|n| n.to_str())
                     .unwrap_or("file")
                     .to_string();
-                if let Err(error) = state.db.mark_file_missing(&img.path) {
-                    let _ = crate::services::trash::restore_from_trash(&record);
-                    results.push(TrashImageResult {
-                        image_id: image_id.clone(),
-                        path: Some(img.path.clone()),
-                        status: "failed".to_string(),
-                        error: Some(format!("Could not update library state: {error}")),
-                    });
-                    continue;
-                }
-                let record_result = state.action_manager.record_action(
-                    &state.db,
-                    "trash_image",
-                    format!("Trash {}", filename),
-                    serde_json::json!({
-                        "image_id": image_id,
-                        "path": &img.path,
-                        "original_path": record.original_path,
-                        "trashed_path": record.trashed_path,
-                    })
-                    .to_string(),
-                    serde_json::json!({
-                        "image_id": image_id,
-                        "path": &img.path,
-                        "original_path": record.original_path,
-                        "trashed_path": record.trashed_path,
-                        "trashed": true,
-                    })
-                    .to_string(),
-                    image_id.clone(),
-                    true,
-                );
+                let record_result = (|| -> Result<_, String> {
+                    let before_json =
+                        serde_json::to_string(&crate::services::trash::TrashActionState {
+                            image_id: image_id.clone(),
+                            original_path: record.original_path.clone(),
+                            trashed_path: record.trashed_path.clone(),
+                            trashed: false,
+                        })
+                        .map_err(|error| error.to_string())?;
+                    let after_json =
+                        serde_json::to_string(&crate::services::trash::TrashActionState {
+                            image_id: image_id.clone(),
+                            original_path: record.original_path.clone(),
+                            trashed_path: record.trashed_path.clone(),
+                            trashed: true,
+                        })
+                        .map_err(|error| error.to_string())?;
+                    state.action_manager.record_action(
+                        &state.db,
+                        "trash_image",
+                        format!("Trash {}", filename),
+                        before_json,
+                        after_json,
+                        image_id.clone(),
+                        true,
+                    )
+                })();
                 if let Err(error) = record_result {
                     let rollback_error = crate::services::trash::restore_from_trash(&record).err();
-                    if rollback_error.is_none() {
-                        let _ = state.db.restore_file(&img.path);
-                    }
                     let detail = match rollback_error {
                         Some(rollback) => format!(
                             "Could not record undo ({error}); restore also failed ({rollback})"
@@ -266,6 +258,7 @@ fn trash_images_detailed_with(
                     });
                     continue;
                 }
+                let mark_error = state.db.mark_file_missing(&img.path).err();
                 log_library_event(
                     state,
                     "image_moved_to_trash",
@@ -276,26 +269,7 @@ fn trash_images_detailed_with(
                         "path": &img.path,
                         "trash_path": record.trashed_path,
                         "filename": filename,
-                    }),
-                );
-                results.push(TrashImageResult {
-                    image_id: image_id.clone(),
-                    path: Some(img.path.clone()),
-                    status: "trashed".to_string(),
-                    error: None,
-                });
-            }
-            Ok(None) => {
-                let mark_error = state.db.mark_file_missing(&img.path).err();
-                log_library_event(
-                    state,
-                    "image_moved_to_trash",
-                    Some("image"),
-                    Some(image_id.clone()),
-                    serde_json::json!({
-                        "image_id": image_id,
-                        "path": &img.path,
-                        "undo_available": false,
+                        "library_state_error": mark_error.as_ref().map(ToString::to_string),
                     }),
                 );
                 results.push(TrashImageResult {
@@ -518,35 +492,6 @@ mod tests {
     use crate::{services, watcher};
     use std::path::Path;
 
-    struct TestTrash {
-        root: std::path::PathBuf,
-    }
-
-    impl crate::services::trash::TrashPlatform for TestTrash {
-        fn move_to_trash(
-            &self,
-            source: &Path,
-        ) -> Result<crate::services::trash::TrashDestination, String> {
-            let file_name = source.file_name().ok_or("missing file name")?;
-            let mut destination = self.root.join(file_name);
-            let mut suffix = 2;
-            while destination.exists() {
-                let stem = source
-                    .file_stem()
-                    .and_then(|value| value.to_str())
-                    .unwrap_or("file");
-                let extension = source.extension().and_then(|value| value.to_str());
-                destination = self.root.join(match extension {
-                    Some(extension) => format!("{stem} {suffix}.{extension}"),
-                    None => format!("{stem} {suffix}"),
-                });
-                suffix += 1;
-            }
-            std::fs::rename(source, &destination).map_err(|error| error.to_string())?;
-            Ok(crate::services::trash::TrashDestination::Exact(destination))
-        }
-    }
-
     fn test_state(tmp: &Path) -> AppState {
         let db = Database::open(&tmp.join("test.db")).unwrap();
         let app_data_dir = tmp.join("app-data");
@@ -693,8 +638,7 @@ mod tests {
 
         let record =
             crate::services::trash::move_to_trash(&crate::services::trash::SystemTrash, &file_path)
-                .expect("native Trash should handle special characters")
-                .expect("macOS should return the exact Trash destination");
+                .expect("native Trash should handle special characters");
         assert!(
             !file_path.exists(),
             "file should no longer exist at original path"
@@ -799,9 +743,7 @@ mod tests {
         let state = test_state(dir.path());
         insert_test_image(&state.db, "img-trash-first", &first_path);
         insert_test_image(&state.db, "img-trash-second", &second_path);
-        let platform = TestTrash {
-            root: trash_root.clone(),
-        };
+        let platform = crate::services::trash::tests::DirectoryTrash::new(trash_root.clone());
 
         let result = trash_images_detailed_with(
             &state,

--- a/src-tauri/src/services/mod.rs
+++ b/src-tauri/src/services/mod.rs
@@ -25,6 +25,7 @@ pub mod model_pipeline;
 pub mod ocr;
 pub mod sessions;
 pub mod tokens;
+pub mod trash;
 pub mod undo;
 
 use crate::db_core::db::Database;

--- a/src-tauri/src/services/trash.rs
+++ b/src-tauri/src/services/trash.rs
@@ -1,0 +1,189 @@
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct TrashRecord {
+    pub original_path: PathBuf,
+    pub trashed_path: PathBuf,
+}
+
+pub(crate) enum TrashDestination {
+    Exact(PathBuf),
+    #[cfg(not(target_os = "macos"))]
+    Untracked,
+}
+
+pub(crate) trait TrashPlatform {
+    fn move_to_trash(&self, source: &Path) -> Result<TrashDestination, String>;
+}
+
+pub(crate) struct SystemTrash;
+
+#[cfg(target_os = "macos")]
+impl TrashPlatform for SystemTrash {
+    fn move_to_trash(&self, source: &Path) -> Result<TrashDestination, String> {
+        use objc2_foundation::{NSFileManager, NSString, NSURL};
+
+        let source = source
+            .to_str()
+            .ok_or_else(|| "Trash path is not valid UTF-8".to_string())?;
+        let source = NSString::from_str(source);
+        let source_url = NSURL::fileURLWithPath(&source);
+        let mut resulting_url = None;
+        NSFileManager::defaultManager()
+            .trashItemAtURL_resultingItemURL_error(&source_url, Some(&mut resulting_url))
+            .map_err(|error| error.to_string())?;
+        let resulting_url = resulting_url
+            .ok_or_else(|| "macOS did not return the Trash destination".to_string())?;
+        let resulting_path = resulting_url
+            .path()
+            .ok_or_else(|| "macOS returned a Trash destination without a file path".to_string())?;
+        Ok(TrashDestination::Exact(PathBuf::from(
+            resulting_path.to_string(),
+        )))
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+impl TrashPlatform for SystemTrash {
+    fn move_to_trash(&self, source: &Path) -> Result<TrashDestination, String> {
+        trash::delete(source).map_err(|error| error.to_string())?;
+        Ok(TrashDestination::Untracked)
+    }
+}
+
+pub(crate) fn move_to_trash(
+    platform: &dyn TrashPlatform,
+    source: &Path,
+) -> Result<Option<TrashRecord>, String> {
+    match platform.move_to_trash(source)? {
+        TrashDestination::Exact(trashed_path) => Ok(Some(TrashRecord {
+            original_path: source.to_path_buf(),
+            trashed_path,
+        })),
+        #[cfg(not(target_os = "macos"))]
+        TrashDestination::Untracked => Ok(None),
+    }
+}
+
+pub(crate) fn restore_from_trash(record: &TrashRecord) -> Result<(), String> {
+    rename_exclusive(&record.trashed_path, &record.original_path)
+}
+
+pub(crate) fn retrash_exact(record: &TrashRecord) -> Result<(), String> {
+    rename_exclusive(&record.original_path, &record.trashed_path)
+}
+
+#[cfg(target_os = "macos")]
+fn rename_exclusive(source: &Path, target: &Path) -> Result<(), String> {
+    use std::ffi::CString;
+    use std::os::unix::ffi::OsStrExt;
+
+    let source = CString::new(source.as_os_str().as_bytes())
+        .map_err(|_| "Source path contains an invalid NUL byte".to_string())?;
+    let target = CString::new(target.as_os_str().as_bytes())
+        .map_err(|_| "Target path contains an invalid NUL byte".to_string())?;
+    // SAFETY: the paths are valid NUL-terminated strings for the duration of
+    // the call. RENAME_EXCL atomically prevents replacing an unrelated file.
+    let result = unsafe {
+        libc::renameatx_np(
+            libc::AT_FDCWD,
+            source.as_ptr(),
+            libc::AT_FDCWD,
+            target.as_ptr(),
+            libc::RENAME_EXCL,
+        )
+    };
+    if result == 0 {
+        Ok(())
+    } else {
+        Err(std::io::Error::last_os_error().to_string())
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+fn rename_exclusive(source: &Path, target: &Path) -> Result<(), String> {
+    if target.exists() {
+        return Err(format!(
+            "Restore target already exists: {}",
+            target.display()
+        ));
+    }
+    std::fs::rename(source, target).map_err(|error| error.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    struct FakeTrash {
+        root: PathBuf,
+        moved: Mutex<Vec<(PathBuf, PathBuf)>>,
+    }
+
+    impl FakeTrash {
+        fn new(root: PathBuf) -> Self {
+            Self {
+                root,
+                moved: Mutex::new(Vec::new()),
+            }
+        }
+    }
+
+    impl TrashPlatform for FakeTrash {
+        fn move_to_trash(&self, source: &Path) -> Result<TrashDestination, String> {
+            let file_name = source.file_name().ok_or("missing file name")?;
+            let mut destination = self.root.join(file_name);
+            let mut suffix = 2;
+            while destination.exists() {
+                let stem = source
+                    .file_stem()
+                    .and_then(|value| value.to_str())
+                    .unwrap_or("file");
+                let extension = source.extension().and_then(|value| value.to_str());
+                let unique_name = match extension {
+                    Some(extension) => format!("{stem} {suffix}.{extension}"),
+                    None => format!("{stem} {suffix}"),
+                };
+                destination = self.root.join(unique_name);
+                suffix += 1;
+            }
+            std::fs::rename(source, &destination).map_err(|error| error.to_string())?;
+            self.moved
+                .lock()
+                .unwrap()
+                .push((source.to_path_buf(), destination.clone()));
+            Ok(TrashDestination::Exact(destination))
+        }
+    }
+
+    #[test]
+    fn exact_destination_round_trip_handles_duplicate_names_and_external_trash_roots() {
+        let source_volume = tempfile::tempdir().unwrap();
+        let trash_volume = tempfile::tempdir().unwrap();
+        let first_dir = source_volume.path().join("one");
+        let second_dir = source_volume.path().join("two");
+        std::fs::create_dir_all(&first_dir).unwrap();
+        std::fs::create_dir_all(&second_dir).unwrap();
+        let first = first_dir.join("same.png");
+        let second = second_dir.join("same.png");
+        std::fs::write(&first, b"first").unwrap();
+        std::fs::write(&second, b"second").unwrap();
+        let platform = FakeTrash::new(trash_volume.path().to_path_buf());
+
+        let first_record = move_to_trash(&platform, &first).unwrap().unwrap();
+        let second_record = move_to_trash(&platform, &second).unwrap().unwrap();
+
+        assert_ne!(first_record.trashed_path, second_record.trashed_path);
+        assert!(first_record.trashed_path.starts_with(trash_volume.path()));
+        assert!(second_record.trashed_path.starts_with(trash_volume.path()));
+
+        restore_from_trash(&first_record).unwrap();
+        restore_from_trash(&second_record).unwrap();
+
+        assert_eq!(std::fs::read(&first).unwrap(), b"first");
+        assert_eq!(std::fs::read(&second).unwrap(), b"second");
+        assert!(!first_record.trashed_path.exists());
+        assert!(!second_record.trashed_path.exists());
+    }
+}

--- a/src-tauri/src/services/trash.rs
+++ b/src-tauri/src/services/trash.rs
@@ -1,26 +1,29 @@
 use std::path::{Path, PathBuf};
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub(crate) struct TrashRecord {
     pub original_path: PathBuf,
     pub trashed_path: PathBuf,
 }
 
-pub(crate) enum TrashDestination {
-    Exact(PathBuf),
-    #[cfg(not(target_os = "macos"))]
-    Untracked,
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub(crate) struct TrashActionState {
+    pub image_id: String,
+    pub original_path: PathBuf,
+    pub trashed_path: PathBuf,
+    #[serde(default)]
+    pub trashed: bool,
 }
 
 pub(crate) trait TrashPlatform {
-    fn move_to_trash(&self, source: &Path) -> Result<TrashDestination, String>;
+    fn move_to_trash(&self, source: &Path) -> Result<PathBuf, String>;
 }
 
 pub(crate) struct SystemTrash;
 
 #[cfg(target_os = "macos")]
 impl TrashPlatform for SystemTrash {
-    fn move_to_trash(&self, source: &Path) -> Result<TrashDestination, String> {
+    fn move_to_trash(&self, source: &Path) -> Result<PathBuf, String> {
         use objc2_foundation::{NSFileManager, NSString, NSURL};
 
         let source = source
@@ -37,39 +40,39 @@ impl TrashPlatform for SystemTrash {
         let resulting_path = resulting_url
             .path()
             .ok_or_else(|| "macOS returned a Trash destination without a file path".to_string())?;
-        Ok(TrashDestination::Exact(PathBuf::from(
-            resulting_path.to_string(),
-        )))
+        Ok(PathBuf::from(resulting_path.to_string()))
     }
 }
 
 #[cfg(not(target_os = "macos"))]
 impl TrashPlatform for SystemTrash {
-    fn move_to_trash(&self, source: &Path) -> Result<TrashDestination, String> {
-        trash::delete(source).map_err(|error| error.to_string())?;
-        Ok(TrashDestination::Untracked)
+    fn move_to_trash(&self, _source: &Path) -> Result<PathBuf, String> {
+        Err("Reliable Trash and undo are currently supported on macOS only".to_string())
     }
 }
 
 pub(crate) fn move_to_trash(
     platform: &dyn TrashPlatform,
     source: &Path,
-) -> Result<Option<TrashRecord>, String> {
-    match platform.move_to_trash(source)? {
-        TrashDestination::Exact(trashed_path) => Ok(Some(TrashRecord {
-            original_path: source.to_path_buf(),
-            trashed_path,
-        })),
-        #[cfg(not(target_os = "macos"))]
-        TrashDestination::Untracked => Ok(None),
-    }
+) -> Result<TrashRecord, String> {
+    let trashed_path = platform.move_to_trash(source)?;
+    Ok(TrashRecord {
+        original_path: source.to_path_buf(),
+        trashed_path,
+    })
 }
 
 pub(crate) fn restore_from_trash(record: &TrashRecord) -> Result<(), String> {
+    if record.original_path.exists() && !record.trashed_path.exists() {
+        return Ok(());
+    }
     rename_exclusive(&record.trashed_path, &record.original_path)
 }
 
 pub(crate) fn retrash_exact(record: &TrashRecord) -> Result<(), String> {
+    if record.trashed_path.exists() && !record.original_path.exists() {
+        return Ok(());
+    }
     rename_exclusive(&record.original_path, &record.trashed_path)
 }
 
@@ -112,17 +115,17 @@ fn rename_exclusive(source: &Path, target: &Path) -> Result<(), String> {
 }
 
 #[cfg(test)]
-mod tests {
+pub(crate) mod tests {
     use super::*;
     use std::sync::Mutex;
 
-    struct FakeTrash {
+    pub(crate) struct DirectoryTrash {
         root: PathBuf,
         moved: Mutex<Vec<(PathBuf, PathBuf)>>,
     }
 
-    impl FakeTrash {
-        fn new(root: PathBuf) -> Self {
+    impl DirectoryTrash {
+        pub(crate) fn new(root: PathBuf) -> Self {
             Self {
                 root,
                 moved: Mutex::new(Vec::new()),
@@ -130,8 +133,8 @@ mod tests {
         }
     }
 
-    impl TrashPlatform for FakeTrash {
-        fn move_to_trash(&self, source: &Path) -> Result<TrashDestination, String> {
+    impl TrashPlatform for DirectoryTrash {
+        fn move_to_trash(&self, source: &Path) -> Result<PathBuf, String> {
             let file_name = source.file_name().ok_or("missing file name")?;
             let mut destination = self.root.join(file_name);
             let mut suffix = 2;
@@ -153,7 +156,7 @@ mod tests {
                 .lock()
                 .unwrap()
                 .push((source.to_path_buf(), destination.clone()));
-            Ok(TrashDestination::Exact(destination))
+            Ok(destination)
         }
     }
 
@@ -169,10 +172,10 @@ mod tests {
         let second = second_dir.join("same.png");
         std::fs::write(&first, b"first").unwrap();
         std::fs::write(&second, b"second").unwrap();
-        let platform = FakeTrash::new(trash_volume.path().to_path_buf());
+        let platform = DirectoryTrash::new(trash_volume.path().to_path_buf());
 
-        let first_record = move_to_trash(&platform, &first).unwrap().unwrap();
-        let second_record = move_to_trash(&platform, &second).unwrap().unwrap();
+        let first_record = move_to_trash(&platform, &first).unwrap();
+        let second_record = move_to_trash(&platform, &second).unwrap();
 
         assert_ne!(first_record.trashed_path, second_record.trashed_path);
         assert!(first_record.trashed_path.starts_with(trash_volume.path()));

--- a/src-tauri/src/services/undo.rs
+++ b/src-tauri/src/services/undo.rs
@@ -362,11 +362,31 @@ impl ActionManager {
                     .map_err(|e| e.to_string())
             }
             "trash_image" => {
-                let path = val["path"].as_str().ok_or("Missing path")?;
+                let path = val
+                    .get("original_path")
+                    .and_then(|value| value.as_str())
+                    .or_else(|| val.get("path").and_then(|value| value.as_str()))
+                    .ok_or("Missing original path")?;
                 let trashed = val
                     .get("trashed")
                     .and_then(|v| v.as_bool())
                     .unwrap_or(false);
+                if let Some(trashed_path) = val.get("trashed_path").and_then(|value| value.as_str())
+                {
+                    let record = crate::services::trash::TrashRecord {
+                        original_path: std::path::PathBuf::from(path),
+                        trashed_path: std::path::PathBuf::from(trashed_path),
+                    };
+                    if trashed {
+                        crate::services::trash::retrash_exact(&record)?;
+                        db.mark_file_missing(path)
+                            .map_err(|error| error.to_string())?;
+                    } else {
+                        crate::services::trash::restore_from_trash(&record)?;
+                        db.restore_file(path).map_err(|error| error.to_string())?;
+                    }
+                    return Ok(());
+                }
                 if trashed {
                     // Redo: re-trash the file
                     #[cfg(target_os = "macos")]

--- a/src-tauri/src/services/undo.rs
+++ b/src-tauri/src/services/undo.rs
@@ -347,6 +347,27 @@ impl ActionManager {
         action_type: &str,
         state_json: &str,
     ) -> Result<(), String> {
+        if action_type == "trash_image" {
+            if let Ok(state) =
+                serde_json::from_str::<crate::services::trash::TrashActionState>(state_json)
+            {
+                let record = crate::services::trash::TrashRecord {
+                    original_path: state.original_path.clone(),
+                    trashed_path: state.trashed_path,
+                };
+                let original_path = state.original_path.to_string_lossy();
+                if state.trashed {
+                    crate::services::trash::retrash_exact(&record)?;
+                    db.mark_file_missing(&original_path)
+                        .map_err(|error| error.to_string())?;
+                } else {
+                    crate::services::trash::restore_from_trash(&record)?;
+                    db.restore_file(&original_path)
+                        .map_err(|error| error.to_string())?;
+                }
+                return Ok(());
+            }
+        }
         let val: serde_json::Value = serde_json::from_str(state_json)
             .map_err(|e| format!("Invalid undo state JSON: {}", e))?;
         match action_type {
@@ -371,22 +392,6 @@ impl ActionManager {
                     .get("trashed")
                     .and_then(|v| v.as_bool())
                     .unwrap_or(false);
-                if let Some(trashed_path) = val.get("trashed_path").and_then(|value| value.as_str())
-                {
-                    let record = crate::services::trash::TrashRecord {
-                        original_path: std::path::PathBuf::from(path),
-                        trashed_path: std::path::PathBuf::from(trashed_path),
-                    };
-                    if trashed {
-                        crate::services::trash::retrash_exact(&record)?;
-                        db.mark_file_missing(path)
-                            .map_err(|error| error.to_string())?;
-                    } else {
-                        crate::services::trash::restore_from_trash(&record)?;
-                        db.restore_file(path).map_err(|error| error.to_string())?;
-                    }
-                    return Ok(());
-                }
                 if trashed {
                     // Redo: re-trash the file
                     #[cfg(target_os = "macos")]

--- a/src/lib/agent-proposal-apply-contract.test.ts
+++ b/src/lib/agent-proposal-apply-contract.test.ts
@@ -8,12 +8,15 @@ describe('agent proposal apply flow contract', () => {
     it('routes approved Trash proposals through confirmation before marking them applied', () => {
         const requestCall = pageSource.indexOf('requestTrashImages(approvedImageIds)');
         const trashCall = pageSource.indexOf('result = await trashImagesDetailed(ids)');
-        const applyCall = pageSource.indexOf('await applyActionProposal(\n                proposalContext.proposalId');
+        const applyCall = pageSource.indexOf('await applyActionProposal(\n                completion.proposalId');
         expect(requestCall).toBeGreaterThan(-1);
         expect(trashCall).toBeGreaterThan(-1);
         expect(applyCall).toBeGreaterThan(-1);
         expect(trashCall).toBeLessThan(applyCall);
         expect(pageSource).toContain('pendingTrashProposal = { proposalId, approvedImageIds: [...approvedImageIds] }');
+        expect(pageSource).toContain('const ids = resolveTrashRequestIds(requestedIds, defaultTrashIds())');
+        expect(pageSource).toContain("showToast('Images moved, but proposal update failed'");
+        expect(pageSource).toContain('pendingTrashProposalCompletion = completion');
         expect(pageSource).toContain(".filter(item => item.status === 'trashed')");
         expect(pageSource).toContain("{ label: 'Undo', onclick: () => { void undoLastTrashProposal(); } },");
         expect(pageSource).toContain('const label = await undo()');

--- a/src/lib/agent-proposal-apply-contract.test.ts
+++ b/src/lib/agent-proposal-apply-contract.test.ts
@@ -5,13 +5,16 @@ import { describe, expect, it } from 'vitest';
 const pageSource = readFileSync(join(process.cwd(), 'src/routes/+page.svelte'), 'utf8');
 
 describe('agent proposal apply flow contract', () => {
-    it('moves approved Trash proposals before marking the proposal applied', () => {
-        const trashCall = pageSource.indexOf('const trashResult = await trashImagesDetailed(approvedImageIds)');
-        const applyCall = pageSource.indexOf('await applyActionProposal(proposalId, approvedImageIds, JSON.stringify(trashResult))');
+    it('routes approved Trash proposals through confirmation before marking them applied', () => {
+        const requestCall = pageSource.indexOf('requestTrashImages(approvedImageIds)');
+        const trashCall = pageSource.indexOf('result = await trashImagesDetailed(ids)');
+        const applyCall = pageSource.indexOf('await applyActionProposal(\n                proposalContext.proposalId');
+        expect(requestCall).toBeGreaterThan(-1);
         expect(trashCall).toBeGreaterThan(-1);
         expect(applyCall).toBeGreaterThan(-1);
         expect(trashCall).toBeLessThan(applyCall);
-        expect(pageSource).toContain("trashResult.results.filter(item => item.status === 'trashed')");
+        expect(pageSource).toContain('pendingTrashProposal = { proposalId, approvedImageIds: [...approvedImageIds] }');
+        expect(pageSource).toContain(".filter(item => item.status === 'trashed')");
         expect(pageSource).toContain("{ label: 'Undo', onclick: () => { void undoLastTrashProposal(); } },");
         expect(pageSource).toContain('const label = await undo()');
         expect(pageSource).toContain("await loadImages({ resetFocus: false, force: true, invalidateCache: true })");

--- a/src/lib/agent-proposal-apply-contract.test.ts
+++ b/src/lib/agent-proposal-apply-contract.test.ts
@@ -8,7 +8,7 @@ describe('agent proposal apply flow contract', () => {
     it('routes approved Trash proposals through confirmation before marking them applied', () => {
         const requestCall = pageSource.indexOf('requestTrashImages(approvedImageIds)');
         const trashCall = pageSource.indexOf('result = await trashImagesDetailed(ids)');
-        const applyCall = pageSource.indexOf('await applyActionProposal(\n                completion.proposalId');
+        const applyCall = pageSource.indexOf('completion.proposalId');
         expect(requestCall).toBeGreaterThan(-1);
         expect(trashCall).toBeGreaterThan(-1);
         expect(applyCall).toBeGreaterThan(-1);
@@ -17,6 +17,8 @@ describe('agent proposal apply flow contract', () => {
         expect(pageSource).toContain('const ids = resolveTrashRequestIds(requestedIds, defaultTrashIds())');
         expect(pageSource).toContain("showToast('Images moved, but proposal update failed'");
         expect(pageSource).toContain('pendingTrashProposalCompletion = completion');
+        expect(pageSource).toContain('if (trashProposalCompletionInFlight) return');
+        expect(pageSource).toContain('|| pendingTrashProposalCompletion');
         expect(pageSource).toContain(".filter(item => item.status === 'trashed')");
         expect(pageSource).toContain("{ label: 'Undo', onclick: () => { void undoLastTrashProposal(); } },");
         expect(pageSource).toContain('const label = await undo()');

--- a/src/lib/command-palette.ts
+++ b/src/lib/command-palette.ts
@@ -62,6 +62,7 @@ import { tabRegistry } from './plugins/tab-registry';
 import { save as saveDialog } from '@tauri-apps/plugin-dialog';
 import { runAiLibraryJob, type AiLibraryJobKind } from './ai-library-jobs';
 import { openSettings } from './settings-navigation';
+import { requestTrashImages } from './trash-actions';
 import {
     previewDisplayAlwaysOnTop,
     previewDisplayBlanked,
@@ -1006,9 +1007,7 @@ function commandItems(): CommandPaletteItem[] {
             keywords: ['delete', 'remove'],
             defaultShortcut: 'Backspace',
             disabled: !hasImage,
-            run: () => {
-                window.dispatchEvent(new CustomEvent('trash-focused-image'));
-            },
+            run: () => requestTrashImages(),
         },
         {
             id: 'image.delete-permanently',

--- a/src/lib/components/ContextMenu.svelte
+++ b/src/lib/components/ContextMenu.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
     import { onMount, tick } from 'svelte';
     import { open as openDialog } from '@tauri-apps/plugin-dialog';
-    import { setRating, setDecision, listCollections, addToCollection, removeFromCollection, createCollection, trashImages, moveImage, renameImage, listFolders, shareImages, openImagesWithApplication, listOpenWithApplications } from '$lib/api';
+    import { setRating, setDecision, listCollections, addToCollection, removeFromCollection, createCollection, moveImage, renameImage, listFolders, shareImages, openImagesWithApplication, listOpenWithApplications } from '$lib/api';
     import { loadSimilarImages } from '$lib/similarity';
     import type { ImageWithFile, OpenWithApplication } from '$lib/api';
     import { images, focusedIndex, selectedIds, activeCollection, activeSession, collections, folders, showToast, requestTextInput, showRejected } from '$lib/stores';
@@ -10,6 +10,7 @@
     import { filterMoveFolders, folderDisplayName, folderParentPath } from '$lib/move-menu-utils';
     import { withDecision, withRating, type ImageDecision } from '$lib/selection-updates';
     import { applyDecisionToCurrentView } from '$lib/rejected-visibility';
+    import { requestTrashImages } from '$lib/trash-actions';
 
     interface Props {
         image: ImageWithFile;
@@ -473,20 +474,9 @@
         }
     }
 
-    async function handleTrash() {
+    function handleTrash() {
         onclose();
-        const ids = new Set(targetIds);
-        await trashImages([...ids]);
-        const remainingLoadedCount = $images.filter(img => !ids.has(img.image.id)).length;
-        await loadImagesForCurrentScope({
-            resetFocus: false,
-            force: true,
-            invalidateCache: true,
-            minItems: remainingLoadedCount,
-        });
-        const c = await listCollections($showRejected);
-        collections.set(c);
-        if ($focusedIndex >= $images.length) focusedIndex.set(Math.max(0, $images.length - 1));
+        requestTrashImages(targetIds);
     }
 
     async function handleRename() {

--- a/src/lib/keys.ts
+++ b/src/lib/keys.ts
@@ -26,6 +26,7 @@ import { withRating, type ImageDecision } from './selection-updates';
 import { applyDecisionToCurrentView } from './rejected-visibility';
 import { pasteDestinationForContext } from './clipboard-actions';
 import { nudgeThumbnailSize } from './thumbnail-zoom';
+import { requestTrashImages } from './trash-actions';
 
 let waitingForStar = false;
 
@@ -497,7 +498,7 @@ export function handleKeydown(e: KeyboardEvent) {
     // Delete: Backspace → trash, Cmd+Backspace → permanent delete
     if (e.key === 'Backspace' && !e.metaKey) {
         e.preventDefault();
-        window.dispatchEvent(new CustomEvent('trash-focused-image'));
+        requestTrashImages();
         return;
     }
     if (e.key === 'Backspace' && e.metaKey) {

--- a/src/lib/menu.test.ts
+++ b/src/lib/menu.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment jsdom
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { get } from 'svelte/store';
 
@@ -176,6 +177,32 @@ describe('native menu bridge', () => {
 
         expect(get(commandPaletteOpen)).toBe(true);
         expect(get(commandPaletteMode)).toBe('commands');
+    });
+
+    it('routes the native Trash action through the shared confirmation request', async () => {
+        let menuHandler: ((event: { payload: string }) => void) | undefined;
+        mocks.listen.mockImplementation(async (_eventName, handler) => {
+            menuHandler = handler as (event: { payload: string }) => void;
+            return vi.fn();
+        });
+        const requestListener = vi.fn();
+        window.addEventListener('trash-images-requested', requestListener);
+        const [{ initMenu }, stores] = await Promise.all([
+            import('./menu'),
+            import('./stores'),
+        ]);
+        stores.images.set([makeImage('img-1'), makeImage('img-2')]);
+        stores.focusedIndex.set(0);
+        stores.selectedIds.set(new Set(['img-1', 'img-2']));
+
+        await initMenu({ listenTimeoutMs: 50, retryDelayMs: 10 });
+        menuHandler?.({ payload: 'image_trash' });
+
+        expect(requestListener).toHaveBeenCalledTimes(1);
+        expect((requestListener.mock.calls[0][0] as CustomEvent).detail).toEqual({
+            imageIds: ['img-1', 'img-2'],
+        });
+        window.removeEventListener('trash-images-requested', requestListener);
     });
 
     it('imports the selected folder from the native Import Folder menu action', async () => {

--- a/src/lib/menu.ts
+++ b/src/lib/menu.ts
@@ -12,7 +12,6 @@ import {
     openImagesWithApplication,
     renameImage,
     shareImages,
-    trashImages,
     listCollections,
     listFolders,
     updateMenuState,
@@ -66,6 +65,7 @@ import {
     setPreviewDisplayWebStreamStatus,
 } from './preview-display-store';
 import { tabRegistry } from './plugins/tab-registry';
+import { requestTrashImages } from './trash-actions';
 
 /** Publish is plugin-only now: it is reachable iff the bundled cull-publish
  * plugin has registered its tab in the tab registry. */
@@ -368,19 +368,13 @@ async function handleImageMoveTo() {
     await moveMenuImagesToFolder(ids, selected);
 }
 
-async function handleImageTrash() {
+function handleImageTrash() {
     const ids = currentMenuTargetIds();
     if (ids.length === 0) {
         showToast('No image selected', { type: 'warning' });
         return;
     }
-
-    try {
-        await trashImages(ids);
-        await reloadAfterImageRemoval(ids);
-    } catch (e) {
-        showToast('Trash failed', { detail: String(e), type: 'error', duration: 8000 });
-    }
+    requestTrashImages(ids);
 }
 
 async function handleGitHubWiki() {

--- a/src/lib/trash-actions.test.ts
+++ b/src/lib/trash-actions.test.ts
@@ -1,6 +1,10 @@
 // @vitest-environment jsdom
 import { describe, expect, it, vi } from 'vitest';
-import { requestTrashImages, TRASH_IMAGES_REQUESTED_EVENT } from './trash-actions';
+import {
+    requestTrashImages,
+    resolveTrashRequestIds,
+    TRASH_IMAGES_REQUESTED_EVENT,
+} from './trash-actions';
 
 describe('shared Trash request', () => {
     it('dispatches one canonical deduplicated request for every caller', () => {
@@ -14,5 +18,15 @@ describe('shared Trash request', () => {
             imageIds: ['img-two', 'img-one'],
         });
         window.removeEventListener(TRASH_IMAGES_REQUESTED_EVENT, listener);
+    });
+
+    it('preserves explicit IDs that are outside the currently loaded view', () => {
+        expect(resolveTrashRequestIds(['stale-proposal-id'], ['focused-id']))
+            .toEqual(['stale-proposal-id']);
+    });
+
+    it('uses the focused selection only when no explicit IDs were requested', () => {
+        expect(resolveTrashRequestIds([], ['focused-id', 'focused-id']))
+            .toEqual(['focused-id']);
     });
 });

--- a/src/lib/trash-actions.test.ts
+++ b/src/lib/trash-actions.test.ts
@@ -1,0 +1,18 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi } from 'vitest';
+import { requestTrashImages, TRASH_IMAGES_REQUESTED_EVENT } from './trash-actions';
+
+describe('shared Trash request', () => {
+    it('dispatches one canonical deduplicated request for every caller', () => {
+        const listener = vi.fn();
+        window.addEventListener(TRASH_IMAGES_REQUESTED_EVENT, listener);
+
+        requestTrashImages(['img-two', 'img-one', 'img-two', '']);
+
+        expect(listener).toHaveBeenCalledTimes(1);
+        expect((listener.mock.calls[0][0] as CustomEvent).detail).toEqual({
+            imageIds: ['img-two', 'img-one'],
+        });
+        window.removeEventListener(TRASH_IMAGES_REQUESTED_EVENT, listener);
+    });
+});

--- a/src/lib/trash-actions.ts
+++ b/src/lib/trash-actions.ts
@@ -1,0 +1,13 @@
+export const TRASH_IMAGES_REQUESTED_EVENT = 'trash-images-requested';
+
+export interface TrashImagesRequestDetail {
+    imageIds: string[];
+}
+
+export function requestTrashImages(imageIds: Iterable<string> = []): void {
+    const canonicalIds = [...new Set(imageIds)].filter(Boolean);
+    window.dispatchEvent(new CustomEvent<TrashImagesRequestDetail>(
+        TRASH_IMAGES_REQUESTED_EVENT,
+        { detail: { imageIds: canonicalIds } },
+    ));
+}

--- a/src/lib/trash-actions.ts
+++ b/src/lib/trash-actions.ts
@@ -4,6 +4,16 @@ export interface TrashImagesRequestDetail {
     imageIds: string[];
 }
 
+export function resolveTrashRequestIds(
+    requestedIds: Iterable<string>,
+    defaultIds: Iterable<string>,
+): string[] {
+    const requested = [...new Set(requestedIds)].filter(Boolean);
+    return requested.length > 0
+        ? requested
+        : [...new Set(defaultIds)].filter(Boolean);
+}
+
 export function requestTrashImages(imageIds: Iterable<string> = []): void {
     const canonicalIds = [...new Set(imageIds)].filter(Boolean);
     window.dispatchEvent(new CustomEvent<TrashImagesRequestDetail>(

--- a/src/lib/trash-safety-contract.test.ts
+++ b/src/lib/trash-safety-contract.test.ts
@@ -19,6 +19,8 @@ describe('shared destructive-action safety contract', () => {
         expect(keys).toContain('requestTrashImages()');
         expect(page).toContain('window.addEventListener(TRASH_IMAGES_REQUESTED_EVENT, handleTrashRequest)');
         expect(page).toContain('await trashImagesDetailed(ids)');
+        expect(page).toContain('pendingTrashProposal = { proposalId, approvedImageIds: [...approvedImageIds] }');
+        expect(page).toContain('requestTrashImages(approvedImageIds)');
         expect(contextMenu).not.toContain('trashImages(');
         expect(menu).not.toContain('trashImages(');
     });

--- a/src/lib/trash-safety-contract.test.ts
+++ b/src/lib/trash-safety-contract.test.ts
@@ -1,0 +1,33 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+function source(path: string): string {
+    return readFileSync(path, 'utf8');
+}
+
+describe('shared destructive-action safety contract', () => {
+    it('routes context, native-menu, palette, and keyboard Trash through one request', () => {
+        const contextMenu = source('src/lib/components/ContextMenu.svelte');
+        const menu = source('src/lib/menu.ts');
+        const palette = source('src/lib/command-palette.ts');
+        const keys = source('src/lib/keys.ts');
+        const page = source('src/routes/+page.svelte');
+
+        expect(contextMenu).toContain('requestTrashImages(targetIds)');
+        expect(menu).toContain('requestTrashImages(ids)');
+        expect(palette).toContain('run: () => requestTrashImages()');
+        expect(keys).toContain('requestTrashImages()');
+        expect(page).toContain('window.addEventListener(TRASH_IMAGES_REQUESTED_EVENT, handleTrashRequest)');
+        expect(page).toContain('await trashImagesDetailed(ids)');
+        expect(contextMenu).not.toContain('trashImages(');
+        expect(menu).not.toContain('trashImages(');
+    });
+
+    it('keeps permanent deletion on a distinct irreversible confirmation path', () => {
+        const page = source('src/routes/+page.svelte');
+
+        expect(page).toContain('Permanently delete "${name}"? This cannot be undone.');
+        expect(page).toContain('await deleteImagesPermanently([img.image.id])');
+        expect(page).toContain("window.addEventListener('delete-focused-image', handlePermanentDelete)");
+    });
+});

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -39,7 +39,7 @@
     import PreviewDisplay from '$lib/components/PreviewDisplay.svelte';
     import { handleKeydown } from '$lib/keys';
     import { images, focusedIndex, focusedImage, viewMode, sidebarVisible, zenMode, minSizeFilter, showToast, settingsOpen, aboutOpen, agentSkillsOpen, applePhotosCatalogOpen, searchOpen, showMissing, showRejected, smartCollections, activeSmartCollection, activeFolder, activeCollection, activeDetectedClass, staticPublishingEnabled, clientToolsEnabled, voiceDictationEnabled, pluginsEnabled, selectedIds, activeCanvas, activeSession, collections, windowLabel, agentPanelPinned, agentPanelVisible, agentVisualLevel, activeAgentProposalId, activeAgentSelectionPresetId, cycleAgentVisualLevel } from '$lib/stores';
-    import { trashImages, trashImagesDetailed, deleteImagesPermanently, getAppSetting, setAppSetting, checkLibraryHealth, regenerateThumbnailsByIds, listCollections, listSmartCollections, updatePreviewState, captureAgentWindowSnapshot, completeAgentViewSnapshot, failAgentViewSnapshot, createActionProposal, listActionProposals, applyActionProposal, dismissActionProposal, listAgentSelectionPresets, upsertAgentSelectionPreset, runClaudeAgentChatTurn, cancelClaudeAgentChatTurn, undo, type AgentActionProposal, type AgentChatImageContext, type AgentSelectionPreset, type AgentVisualLevel, type ClaudeAgentStreamEvent, type ImageWithFile, type PreviewState } from '$lib/api';
+    import { trashImagesDetailed, deleteImagesPermanently, getAppSetting, setAppSetting, checkLibraryHealth, regenerateThumbnailsByIds, listCollections, listSmartCollections, updatePreviewState, captureAgentWindowSnapshot, completeAgentViewSnapshot, failAgentViewSnapshot, createActionProposal, listActionProposals, applyActionProposal, dismissActionProposal, listAgentSelectionPresets, upsertAgentSelectionPreset, runClaudeAgentChatTurn, cancelClaudeAgentChatTurn, undo, type AgentActionProposal, type AgentChatImageContext, type AgentSelectionPreset, type AgentVisualLevel, type ClaudeAgentStreamEvent, type ImageWithFile, type PreviewState } from '$lib/api';
     import { initDeepLink } from '$lib/deeplink';
     import { initMenu } from '$lib/menu';
     import { loadInstalledPlugins, activateBundledPlugins } from '$lib/plugins/loader';
@@ -74,10 +74,12 @@
     import { effectiveAgentVisualLevel } from '$lib/agent-visual-context';
     import { listen } from '@tauri-apps/api/event';
     import { onMount } from 'svelte';
+    import { TRASH_IMAGES_REQUESTED_EVENT, type TrashImagesRequestDetail } from '$lib/trash-actions';
 
     let dragOver = $state(false);
     let trashConfirmVisible = $state(false);
     let trashConfirmFileName = $state('');
+    let pendingTrashIds = $state<string[]>([]);
     let skipTrashConfirmSession = $state(false);
     const previewDisplayWindow = isPreviewDisplayRoute();
     let previewSyncState = $state<PreviewState | null>(null);
@@ -154,26 +156,77 @@
         }
     }
 
-    async function executeTrash() {
+    function defaultTrashIds(): string[] {
         const imgs = $images;
         const idx = $focusedIndex;
         const img = imgs[idx];
-        if (!img) return;
-        const nextFocusIndex = nextFocusIndexAfterFocusedRemoval(idx, imgs.length);
-        const count = await trashImages([img.image.id]);
-        if (count > 0) {
-            const name = img.path.split('/').pop() ?? '';
-            showToast(`Moved to Trash`, { detail: name, type: 'info', duration: 5000 });
-            invalidateImageCache();
-            removeVisibleImageById(img.image.id, nextFocusIndex);
-            refreshImageCount().catch(e => console.error('Failed to refresh image count after trash:', e));
-            refreshCollectionCountsAfterRemoval('trash');
+        if (!img) return [];
+        if ($selectedIds.has(img.image.id)) {
+            return imgs
+                .map(item => item.image.id)
+                .filter(imageId => $selectedIds.has(imageId));
         }
+        return [img.image.id];
     }
 
-    async function handleTrash() {
-        const img = $images[$focusedIndex];
-        if (!img) return;
+    async function executeTrash() {
+        const ids = pendingTrashIds;
+        if (ids.length === 0) return;
+        const imgs = $images;
+        const idx = $focusedIndex;
+        const nextFocusIndex = nextFocusIndexAfterFocusedRemoval(idx, imgs.length);
+        let result;
+        try {
+            result = await trashImagesDetailed(ids);
+        } catch (error) {
+            showToast('Trash failed', { detail: String(error), type: 'error', duration: 8000 });
+            pendingTrashIds = [];
+            return;
+        }
+        const trashed = new Set(result.results
+            .filter(item => item.status === 'trashed')
+            .map(item => item.image_id));
+        if (trashed.size > 0) {
+            const detail = result.failed > 0
+                ? `${result.succeeded} moved, ${result.failed} failed`
+                : result.succeeded === 1
+                    ? imgs.find(item => trashed.has(item.image.id))?.path.split('/').pop() ?? '1 image'
+                    : `${result.succeeded} images`;
+            showToast('Moved to Trash', {
+                detail,
+                type: result.failed > 0 ? 'warning' : 'info',
+                duration: result.failed > 0 ? 8000 : 5000,
+            });
+            invalidateImageCache();
+            images.update(list => list.filter(item => !trashed.has(item.image.id)));
+            focusedIndex.set(clampFocusIndexToList(nextFocusIndex, $images.length));
+            selectedIds.update(selected => {
+                const next = new Set(selected);
+                for (const imageId of trashed) next.delete(imageId);
+                return next;
+            });
+            refreshImageCount().catch(e => console.error('Failed to refresh image count after trash:', e));
+            refreshCollectionCountsAfterRemoval('trash');
+        } else if (result.failed > 0) {
+            const firstError = result.results.find(item => item.error)?.error;
+            showToast('Trash failed', {
+                detail: firstError ?? `${result.failed} images could not be moved`,
+                type: 'error',
+                duration: 8000,
+            });
+        }
+        pendingTrashIds = [];
+    }
+
+    async function handleTrashRequest(event: Event) {
+        const requestedIds = event instanceof CustomEvent
+            ? (event as CustomEvent<TrashImagesRequestDetail>).detail?.imageIds ?? []
+            : [];
+        const availableIds = new Set($images.map(item => item.image.id));
+        const ids = (requestedIds.length > 0 ? requestedIds : defaultTrashIds())
+            .filter(imageId => availableIds.has(imageId));
+        if (ids.length === 0) return;
+        pendingTrashIds = [...new Set(ids)];
 
         if (skipTrashConfirmSession) {
             await executeTrash();
@@ -186,7 +239,9 @@
             return;
         }
 
-        trashConfirmFileName = img.path.split('/').pop() ?? '';
+        trashConfirmFileName = pendingTrashIds.length === 1
+            ? $images.find(item => item.image.id === pendingTrashIds[0])?.path.split('/').pop() ?? '1 image'
+            : `${pendingTrashIds.length} images`;
         trashConfirmVisible = true;
     }
 
@@ -195,6 +250,11 @@
         if (suppress === 'session') skipTrashConfirmSession = true;
         if (suppress === 'always') await setAppSetting('skip_trash_confirm', 'true');
         await executeTrash();
+    }
+
+    function cancelTrashConfirmation() {
+        trashConfirmVisible = false;
+        pendingTrashIds = [];
     }
 
     async function handlePermanentDelete() {
@@ -833,7 +893,7 @@
             dragOver = event.payload;
         });
 
-        window.addEventListener('trash-focused-image', handleTrash);
+        window.addEventListener(TRASH_IMAGES_REQUESTED_EVENT, handleTrashRequest);
         window.addEventListener('delete-focused-image', handlePermanentDelete);
         const handleReloadImages = () => loadImages({ resetFocus: false, force: true, invalidateCache: true }).catch(e => console.error('Failed to reload:', e));
         window.addEventListener('reload-images', handleReloadImages);
@@ -930,7 +990,7 @@
             panicUnlisten.then(fn => fn());
             taskFailUnlisten.then(fn => fn());
             cloudUnlisten.then(fn => fn());
-            window.removeEventListener('trash-focused-image', handleTrash);
+            window.removeEventListener(TRASH_IMAGES_REQUESTED_EVENT, handleTrashRequest);
             window.removeEventListener('delete-focused-image', handlePermanentDelete);
             window.removeEventListener('reload-images', handleReloadImages);
             window.removeEventListener('create-agent-test-proposal', handleCreateAgentTestProposal);
@@ -1058,7 +1118,7 @@
         visible={trashConfirmVisible}
         fileName={trashConfirmFileName}
         onconfirm={handleTrashConfirm}
-        oncancel={() => trashConfirmVisible = false}
+        oncancel={cancelTrashConfirmation}
     />
 
     <ActionProposalReviewDialog

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -74,12 +74,14 @@
     import { effectiveAgentVisualLevel } from '$lib/agent-visual-context';
     import { listen } from '@tauri-apps/api/event';
     import { onMount } from 'svelte';
-    import { TRASH_IMAGES_REQUESTED_EVENT, type TrashImagesRequestDetail } from '$lib/trash-actions';
+    import { requestTrashImages, TRASH_IMAGES_REQUESTED_EVENT, type TrashImagesRequestDetail } from '$lib/trash-actions';
 
     let dragOver = $state(false);
     let trashConfirmVisible = $state(false);
     let trashConfirmFileName = $state('');
     let pendingTrashIds = $state<string[]>([]);
+    let pendingTrashProposal = $state<{ proposalId: string; approvedImageIds: string[] } | null>(null);
+    let trashInFlight = $state(false);
     let skipTrashConfirmSession = $state(false);
     const previewDisplayWindow = isPreviewDisplayRoute();
     let previewSyncState = $state<PreviewState | null>(null);
@@ -170,33 +172,42 @@
     }
 
     async function executeTrash() {
-        const ids = pendingTrashIds;
+        const ids = [...pendingTrashIds];
         if (ids.length === 0) return;
+        const proposalContext = pendingTrashProposal;
+        pendingTrashIds = [];
+        pendingTrashProposal = null;
+        trashInFlight = true;
         const imgs = $images;
         const idx = $focusedIndex;
         const nextFocusIndex = nextFocusIndexAfterFocusedRemoval(idx, imgs.length);
-        let result;
+        let result: Awaited<ReturnType<typeof trashImagesDetailed>>;
         try {
             result = await trashImagesDetailed(ids);
         } catch (error) {
             showToast('Trash failed', { detail: String(error), type: 'error', duration: 8000 });
-            pendingTrashIds = [];
+            if (proposalContext) reviewProposalId = proposalContext.proposalId;
             return;
+        } finally {
+            trashInFlight = false;
         }
         const trashed = new Set(result.results
             .filter(item => item.status === 'trashed')
             .map(item => item.image_id));
+        const warning = result.results.find(item => item.status === 'trashed' && item.error)?.error;
         if (trashed.size > 0) {
-            const detail = result.failed > 0
+            const detail = warning ?? (result.failed > 0
                 ? `${result.succeeded} moved, ${result.failed} failed`
                 : result.succeeded === 1
                     ? imgs.find(item => trashed.has(item.image.id))?.path.split('/').pop() ?? '1 image'
-                    : `${result.succeeded} images`;
-            showToast('Moved to Trash', {
-                detail,
-                type: result.failed > 0 ? 'warning' : 'info',
-                duration: result.failed > 0 ? 8000 : 5000,
-            });
+                    : `${result.succeeded} images`);
+            if (!proposalContext) {
+                showToast('Moved to Trash', {
+                    detail,
+                    type: result.failed > 0 || warning ? 'warning' : 'info',
+                    duration: result.failed > 0 || warning ? 8000 : 5000,
+                });
+            }
             invalidateImageCache();
             images.update(list => list.filter(item => !trashed.has(item.image.id)));
             focusedIndex.set(clampFocusIndexToList(nextFocusIndex, $images.length));
@@ -207,7 +218,7 @@
             });
             refreshImageCount().catch(e => console.error('Failed to refresh image count after trash:', e));
             refreshCollectionCountsAfterRemoval('trash');
-        } else if (result.failed > 0) {
+        } else if (result.failed > 0 && !proposalContext) {
             const firstError = result.results.find(item => item.error)?.error;
             showToast('Trash failed', {
                 detail: firstError ?? `${result.failed} images could not be moved`,
@@ -215,10 +226,31 @@
                 duration: 8000,
             });
         }
-        pendingTrashIds = [];
+        if (proposalContext) {
+            await applyActionProposal(
+                proposalContext.proposalId,
+                proposalContext.approvedImageIds,
+                JSON.stringify(result),
+            );
+            showToast('Trash proposal applied', {
+                detail: `${result.succeeded} moved to Trash, ${result.failed} failed`,
+                type: result.failed > 0 ? 'warning' : 'info',
+                duration: 6000,
+                actions: [
+                    { label: 'Undo', onclick: () => { void undoLastTrashProposal(); } },
+                ],
+            });
+            reviewProposalId = null;
+            activeAgentProposalId.set(null);
+            await refreshAgentPanelData();
+        }
     }
 
     async function handleTrashRequest(event: Event) {
+        if (trashInFlight || pendingTrashIds.length > 0 || trashConfirmVisible) {
+            showToast('Trash is already in progress', { type: 'warning' });
+            return;
+        }
         const requestedIds = event instanceof CustomEvent
             ? (event as CustomEvent<TrashImagesRequestDetail>).detail?.imageIds ?? []
             : [];
@@ -233,7 +265,12 @@
             return;
         }
 
-        const alwaysSkip = await getAppSetting('skip_trash_confirm');
+        let alwaysSkip: string | null = null;
+        try {
+            alwaysSkip = await getAppSetting('skip_trash_confirm');
+        } catch (error) {
+            console.warn('Could not read Trash confirmation setting:', error);
+        }
         if (alwaysSkip === 'true') {
             await executeTrash();
             return;
@@ -255,6 +292,10 @@
     function cancelTrashConfirmation() {
         trashConfirmVisible = false;
         pendingTrashIds = [];
+        if (pendingTrashProposal) {
+            reviewProposalId = pendingTrashProposal.proposalId;
+            pendingTrashProposal = null;
+        }
     }
 
     async function handlePermanentDelete() {
@@ -744,21 +785,14 @@
         const proposal = agentProposals.find(item => item.id === proposalId);
         if (!proposal) return;
         if (proposal.kind === 'trash_images') {
-            const trashResult = await trashImagesDetailed(approvedImageIds);
-            await applyActionProposal(proposalId, approvedImageIds, JSON.stringify(trashResult));
-            const trashed = new Set(trashResult.results.filter(item => item.status === 'trashed').map(item => item.image_id));
-            images.update(list => list.filter(item => !trashed.has(item.image.id)));
-            invalidateImageCache();
-            refreshImageCount().catch(e => console.error('Failed to refresh image count after proposal trash:', e));
-            refreshCollectionCountsAfterRemoval('proposal trash');
-            showToast('Trash proposal applied', {
-                detail: `${trashResult.succeeded} moved to Trash, ${trashResult.failed} failed`,
-                type: trashResult.failed > 0 ? 'warning' : 'info',
-                duration: 6000,
-                actions: [
-                    { label: 'Undo', onclick: () => { void undoLastTrashProposal(); } },
-                ],
-            });
+            if (trashInFlight || pendingTrashIds.length > 0 || trashConfirmVisible) {
+                showToast('Trash is already in progress', { type: 'warning' });
+                return;
+            }
+            pendingTrashProposal = { proposalId, approvedImageIds: [...approvedImageIds] };
+            reviewProposalId = null;
+            requestTrashImages(approvedImageIds);
+            return;
         } else {
             const visibleIds = new Set($images.map(item => item.image.id));
             const visibleApprovedIds = approvedImageIds.filter(id => visibleIds.has(id));

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -86,6 +86,7 @@
         approvedImageIds: string[];
         resultJson: string;
     } | null>(null);
+    let trashProposalCompletionInFlight = $state(false);
     let trashInFlight = $state(false);
     let skipTrashConfirmSession = $state(false);
     const previewDisplayWindow = isPreviewDisplayRoute();
@@ -243,47 +244,53 @@
         completion: { proposalId: string; approvedImageIds: string[]; resultJson: string },
         result?: Awaited<ReturnType<typeof trashImagesDetailed>>,
     ) {
+        if (trashProposalCompletionInFlight) return;
+        trashProposalCompletionInFlight = true;
         try {
-            await applyActionProposal(
-                completion.proposalId,
-                completion.approvedImageIds,
-                completion.resultJson,
-            );
-        } catch (error) {
-            pendingTrashProposalCompletion = completion;
-            showToast('Images moved, but proposal update failed', {
-                detail: String(error),
-                type: 'error',
-                duration: 10000,
-                actions: [{
-                    label: 'Retry update',
-                    onclick: () => { void retryTrashProposalCompletion(); },
-                }],
-            });
-            return;
-        }
-        pendingTrashProposalCompletion = null;
-        if (result) {
-            showToast('Trash proposal applied', {
-                detail: `${result.succeeded} moved to Trash, ${result.failed} failed`,
-                type: result.failed > 0 ? 'warning' : 'info',
-                duration: 6000,
-                actions: [
-                    { label: 'Undo', onclick: () => { void undoLastTrashProposal(); } },
-                ],
-            });
-        }
-        reviewProposalId = null;
-        activeAgentProposalId.set(null);
-        try {
-            await refreshAgentPanelData();
-        } catch (error) {
-            console.error('Failed to refresh agent proposals after Trash:', error);
-            showToast('Proposal applied; refresh failed', {
-                detail: String(error),
-                type: 'warning',
-                duration: 8000,
-            });
+            try {
+                await applyActionProposal(
+                    completion.proposalId,
+                    completion.approvedImageIds,
+                    completion.resultJson,
+                );
+            } catch (error) {
+                pendingTrashProposalCompletion = completion;
+                showToast('Images moved, but proposal update failed', {
+                    detail: String(error),
+                    type: 'error',
+                    duration: 10000,
+                    actions: [{
+                        label: 'Retry update',
+                        onclick: () => { void retryTrashProposalCompletion(); },
+                    }],
+                });
+                return;
+            }
+            pendingTrashProposalCompletion = null;
+            if (result) {
+                showToast('Trash proposal applied', {
+                    detail: `${result.succeeded} moved to Trash, ${result.failed} failed`,
+                    type: result.failed > 0 ? 'warning' : 'info',
+                    duration: 6000,
+                    actions: [
+                        { label: 'Undo', onclick: () => { void undoLastTrashProposal(); } },
+                    ],
+                });
+            }
+            reviewProposalId = null;
+            activeAgentProposalId.set(null);
+            try {
+                await refreshAgentPanelData();
+            } catch (error) {
+                console.error('Failed to refresh agent proposals after Trash:', error);
+                showToast('Proposal applied; refresh failed', {
+                    detail: String(error),
+                    type: 'warning',
+                    duration: 8000,
+                });
+            }
+        } finally {
+            trashProposalCompletionInFlight = false;
         }
     }
 
@@ -841,7 +848,13 @@
         const proposal = agentProposals.find(item => item.id === proposalId);
         if (!proposal) return;
         if (proposal.kind === 'trash_images') {
-            if (trashInFlight || pendingTrashIds.length > 0 || trashConfirmVisible) {
+            if (
+                trashInFlight
+                || pendingTrashIds.length > 0
+                || trashConfirmVisible
+                || pendingTrashProposalCompletion
+                || trashProposalCompletionInFlight
+            ) {
                 showToast('Trash is already in progress', { type: 'warning' });
                 return;
             }

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -74,13 +74,18 @@
     import { effectiveAgentVisualLevel } from '$lib/agent-visual-context';
     import { listen } from '@tauri-apps/api/event';
     import { onMount } from 'svelte';
-    import { requestTrashImages, TRASH_IMAGES_REQUESTED_EVENT, type TrashImagesRequestDetail } from '$lib/trash-actions';
+    import { requestTrashImages, resolveTrashRequestIds, TRASH_IMAGES_REQUESTED_EVENT, type TrashImagesRequestDetail } from '$lib/trash-actions';
 
     let dragOver = $state(false);
     let trashConfirmVisible = $state(false);
     let trashConfirmFileName = $state('');
     let pendingTrashIds = $state<string[]>([]);
     let pendingTrashProposal = $state<{ proposalId: string; approvedImageIds: string[] } | null>(null);
+    let pendingTrashProposalCompletion = $state<{
+        proposalId: string;
+        approvedImageIds: string[];
+        resultJson: string;
+    } | null>(null);
     let trashInFlight = $state(false);
     let skipTrashConfirmSession = $state(false);
     const previewDisplayWindow = isPreviewDisplayRoute();
@@ -227,11 +232,38 @@
             });
         }
         if (proposalContext) {
+            await finalizeTrashProposal({
+                ...proposalContext,
+                resultJson: JSON.stringify(result),
+            }, result);
+        }
+    }
+
+    async function finalizeTrashProposal(
+        completion: { proposalId: string; approvedImageIds: string[]; resultJson: string },
+        result?: Awaited<ReturnType<typeof trashImagesDetailed>>,
+    ) {
+        try {
             await applyActionProposal(
-                proposalContext.proposalId,
-                proposalContext.approvedImageIds,
-                JSON.stringify(result),
+                completion.proposalId,
+                completion.approvedImageIds,
+                completion.resultJson,
             );
+        } catch (error) {
+            pendingTrashProposalCompletion = completion;
+            showToast('Images moved, but proposal update failed', {
+                detail: String(error),
+                type: 'error',
+                duration: 10000,
+                actions: [{
+                    label: 'Retry update',
+                    onclick: () => { void retryTrashProposalCompletion(); },
+                }],
+            });
+            return;
+        }
+        pendingTrashProposalCompletion = null;
+        if (result) {
             showToast('Trash proposal applied', {
                 detail: `${result.succeeded} moved to Trash, ${result.failed} failed`,
                 type: result.failed > 0 ? 'warning' : 'info',
@@ -240,10 +272,25 @@
                     { label: 'Undo', onclick: () => { void undoLastTrashProposal(); } },
                 ],
             });
-            reviewProposalId = null;
-            activeAgentProposalId.set(null);
-            await refreshAgentPanelData();
         }
+        reviewProposalId = null;
+        activeAgentProposalId.set(null);
+        try {
+            await refreshAgentPanelData();
+        } catch (error) {
+            console.error('Failed to refresh agent proposals after Trash:', error);
+            showToast('Proposal applied; refresh failed', {
+                detail: String(error),
+                type: 'warning',
+                duration: 8000,
+            });
+        }
+    }
+
+    async function retryTrashProposalCompletion() {
+        const completion = pendingTrashProposalCompletion;
+        if (!completion) return;
+        await finalizeTrashProposal(completion);
     }
 
     async function handleTrashRequest(event: Event) {
@@ -254,9 +301,7 @@
         const requestedIds = event instanceof CustomEvent
             ? (event as CustomEvent<TrashImagesRequestDetail>).detail?.imageIds ?? []
             : [];
-        const availableIds = new Set($images.map(item => item.image.id));
-        const ids = (requestedIds.length > 0 ? requestedIds : defaultTrashIds())
-            .filter(imageId => availableIds.has(imageId));
+        const ids = resolveTrashRequestIds(requestedIds, defaultTrashIds());
         if (ids.length === 0) return;
         pendingTrashIds = [...new Set(ids)];
 
@@ -285,7 +330,18 @@
     async function handleTrashConfirm(suppress: 'none' | 'session' | 'always') {
         trashConfirmVisible = false;
         if (suppress === 'session') skipTrashConfirmSession = true;
-        if (suppress === 'always') await setAppSetting('skip_trash_confirm', 'true');
+        if (suppress === 'always') {
+            try {
+                await setAppSetting('skip_trash_confirm', 'true');
+            } catch (error) {
+                console.error('Could not save Trash confirmation preference:', error);
+                showToast('Could not save Trash preference', {
+                    detail: 'This Trash action will still continue.',
+                    type: 'warning',
+                    duration: 6000,
+                });
+            }
+        }
         await executeTrash();
     }
 
@@ -787,6 +843,10 @@
         if (proposal.kind === 'trash_images') {
             if (trashInFlight || pendingTrashIds.length > 0 || trashConfirmVisible) {
                 showToast('Trash is already in progress', { type: 'warning' });
+                return;
+            }
+            if (approvedImageIds.length === 0) {
+                showToast('No images approved for Trash', { type: 'warning' });
                 return;
             }
             pendingTrashProposal = { proposalId, approvedImageIds: [...approvedImageIds] };


### PR DESCRIPTION
## Summary
- route context menu, keyboard, native menu, palette, and agent bulk Trash through one confirmation/suppression controller
- record the exact macOS Trash destination so undo/redo works with duplicate filenames and non-home Trash roots
- keep permanent deletion on a separate, unsuppressible stronger confirmation path
- make settings and proposal-bookkeeping failures visible and retryable without moving files twice

## Verification
- `npm run preflight -- full`
- frontend: 173 files / 1,296 tests
- Rust: 866 passed / 3 ignored
- two-axis fixed-point review: PASS

Beads: imageview-dtj.11