### PR TITLE
Fix Command Palette pin actions and menu placement

### DIFF
--- a/src/lib/components/CommandPalette.svelte
+++ b/src/lib/components/CommandPalette.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+    import { tick } from 'svelte';
     import {
         activeCollection,
         activeCanvas,
@@ -46,6 +47,7 @@
         WORKFLOW_CREATE_COMMAND_ID,
         type CommandPaletteItem,
     } from '$lib/command-palette';
+    import { clampFloatingPosition, type FloatingPoint } from '$lib/floating-position';
     import ModalDialog from './ModalDialog.svelte';
 
     let query = $state('');
@@ -57,12 +59,15 @@
     let frequencies = $state<Record<string, number>>({});
     let hotkeys = $state<Record<string, string>>({});
     let contextMenu = $state<{ itemId: string; x: number; y: number } | null>(null);
+    let contextMenuEl: HTMLDivElement | undefined = $state();
+    let contextMenuPositionSeq = 0;
     let hotkeyTargetId = $state<string | null>(null);
     let capturedShortcut = $state('');
 
     const COMMAND_PALETTE_RESULTS_ID = 'command-palette-results';
     const COMMAND_PALETTE_TITLE_ID = 'command-palette-title';
     const COMMAND_PALETTE_DESCRIPTION_ID = 'command-palette-description';
+    const CONTEXT_MENU_SIZE = { width: 220, height: 188 };
 
     let visibleItems = $derived(sortCommandPaletteItems(items, query, {
         mode: $commandPaletteMode,
@@ -165,24 +170,43 @@
         event.preventDefault();
         event.stopPropagation();
         selectedIndex = index;
-        const width = 220;
-        const height = 188;
+        showContextMenu(item.id, { x: event.clientX, y: event.clientY });
+    }
+
+    async function showContextMenu(itemId: string, anchor: FloatingPoint) {
+        const positionSeq = ++contextMenuPositionSeq;
+        const initialPosition = clampFloatingPosition(
+            anchor,
+            CONTEXT_MENU_SIZE,
+            { width: window.innerWidth, height: window.innerHeight },
+        );
         contextMenu = {
-            itemId: item.id,
-            x: Math.max(8, Math.min(event.clientX, window.innerWidth - width - 8)),
-            y: Math.max(8, Math.min(event.clientY, window.innerHeight - height - 8)),
+            itemId,
+            ...initialPosition,
         };
+        await tick();
+        if (positionSeq !== contextMenuPositionSeq || contextMenu?.itemId !== itemId || !contextMenuEl) return;
+
+        const rect = contextMenuEl.getBoundingClientRect();
+        const measuredPosition = clampFloatingPosition(
+            anchor,
+            {
+                width: rect.width || CONTEXT_MENU_SIZE.width,
+                height: rect.height || CONTEXT_MENU_SIZE.height,
+            },
+            { width: window.innerWidth, height: window.innerHeight },
+        );
+        contextMenu = { itemId, ...measuredPosition };
     }
 
     function openContextMenuForSelected() {
         const item = selectedItem;
         if (!item) return;
         const rect = inputEl?.getBoundingClientRect();
-        contextMenu = {
-            itemId: item.id,
+        showContextMenu(item.id, {
             x: Math.max(8, (rect?.left ?? 0) + 24),
             y: Math.max(8, (rect?.bottom ?? 0) + 48),
-        };
+        });
     }
 
     function isPinned(item: CommandPaletteItem) {
@@ -441,6 +465,7 @@
 
         {#if contextMenu && contextItem}
             <div
+                bind:this={contextMenuEl}
                 class="palette-context-menu"
                 style={`left: ${contextMenu.x}px; top: ${contextMenu.y}px;`}
                 role="menu"
@@ -451,7 +476,7 @@
                     Run
                 </button>
                 <button type="button" role="menuitem" onclick={() => togglePinned(contextItem)}>
-                    {isPinned(contextItem) ? 'Unfavorite' : 'Favorite'}
+                    {isPinned(contextItem) ? 'Unpin' : 'Pin'}
                 </button>
                 <button type="button" role="menuitem" onclick={() => startHotkeyCapture(contextItem)}>
                     Set Hotkey...

--- a/src/lib/components/command-palette-destinations.behavior.test.ts
+++ b/src/lib/components/command-palette-destinations.behavior.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/svelte';
 import CommandPalette from './CommandPalette.svelte';
 import {
@@ -28,6 +28,7 @@ describe('CommandPalette destinations', () => {
     afterEach(() => {
         commandPaletteOpen.set(false);
         cleanup();
+        vi.restoreAllMocks();
     });
 
     it('populates destinations when switching an open command-only palette to All', async () => {
@@ -37,5 +38,58 @@ describe('CommandPalette destinations', () => {
         await fireEvent.click(screen.getByRole('button', { name: 'All' }));
 
         await waitFor(() => expect(screen.getByText('Portfolio')).toBeTruthy());
+    });
+
+    it('keeps the keyboard context menu inside the viewport', async () => {
+        Object.defineProperty(window, 'innerWidth', { configurable: true, value: 1024 });
+        Object.defineProperty(window, 'innerHeight', { configurable: true, value: 768 });
+        const originalRect = HTMLElement.prototype.getBoundingClientRect;
+        vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(function (this: HTMLElement) {
+            if (this.classList.contains('palette-context-menu')) {
+                return {
+                    x: 796,
+                    y: 450,
+                    left: 796,
+                    right: 1016,
+                    top: 450,
+                    bottom: 760,
+                    width: 220,
+                    height: 310,
+                    toJSON: () => ({}),
+                };
+            }
+            return originalRect.call(this);
+        });
+        render(CommandPalette);
+
+        const input = screen.getByPlaceholderText('Run a command');
+        input.getBoundingClientRect = () => ({
+            x: 976,
+            y: 692,
+            left: 976,
+            right: 1008,
+            top: 692,
+            bottom: 716,
+            width: 32,
+            height: 24,
+            toJSON: () => ({}),
+        });
+
+        await fireEvent.keyDown(input, { key: 'F10', shiftKey: true });
+
+        const menu = screen.getByRole('menu');
+        expect(menu.getAttribute('style')).toContain('left: 796px');
+        expect(menu.getAttribute('style')).toContain('top: 450px');
+    });
+
+    it('uses Pin and Unpin terminology for command preferences', async () => {
+        render(CommandPalette);
+
+        const settings = screen.getByRole('option', { name: /Open Settings/ });
+        await fireEvent.contextMenu(settings, { clientX: 40, clientY: 40 });
+        await fireEvent.click(screen.getByRole('menuitem', { name: 'Pin' }));
+
+        await fireEvent.contextMenu(settings, { clientX: 40, clientY: 40 });
+        expect(screen.getByRole('menuitem', { name: 'Unpin' })).toBeTruthy();
     });
 });

--- a/tests/e2e/smoke.py
+++ b/tests/e2e/smoke.py
@@ -921,8 +921,8 @@ def test_command_palette_navigate_and_execute(page: Page) -> None:
     wait_mode(page, "grid")
 
 
-def test_command_palette_arrows_and_favorite(page: Page) -> None:
-    """S19 (zu0.8) — Arrow keys move selection; row context menu favorites a result."""
+def test_command_palette_arrows_and_pin(page: Page) -> None:
+    """S19 (zu0.8) — Arrow keys move selection; row context menu pins a result."""
     press(page, "Meta+1")
     wait_mode(page, "grid")
 
@@ -940,13 +940,13 @@ def test_command_palette_arrows_and_favorite(page: Page) -> None:
     second_selected = page.locator(".palette-row.selected").first.get_attribute("id")
     assert first_selected != second_selected, "ArrowDown did not move palette selection"
 
-    # Right-click the first row to open the result context menu and Favorite it.
+    # Right-click the first row to open the result context menu and pin it.
     page.locator(".palette-row").first.click(button="right")
     expect(page.locator(".palette-context-menu")).to_be_visible()
-    expect(page.locator(".palette-context-menu")).to_contain_text("Favorite")
-    page.locator(".palette-context-menu button", has_text="Favorite").first.click()
+    expect(page.locator(".palette-context-menu")).to_contain_text("Pin")
+    page.locator(".palette-context-menu button", has_text="Pin").first.click()
 
-    # A favorited row now carries the pin mark.
+    # A pinned row now carries the pin mark.
     expect(page.locator(".palette-row .row-mark", has_text="*").first).to_be_visible()
 
     palette_input.press("Escape")
@@ -1374,7 +1374,7 @@ def main() -> int:
         smoke.step("S29a zen mode", lambda: test_zen_mode(page))
         smoke.step("S19a command palette open/close", lambda: test_command_palette_open_close(page))
         smoke.step("S19b command palette navigate and execute", lambda: test_command_palette_navigate_and_execute(page))
-        smoke.step("S19c command palette arrows and favorite", lambda: test_command_palette_arrows_and_favorite(page))
+        smoke.step("S19c command palette arrows and pin", lambda: test_command_palette_arrows_and_pin(page))
         smoke.step("S19d keyboard shortcuts panel", lambda: test_keyboard_shortcuts_panel(page))
         smoke.step("S19e palette does not hijack text input", lambda: test_palette_does_not_hijack_text_input(page))
         smoke.step("S19f AI settings and library commands", lambda: test_ai_settings_and_library_commands(page))


### PR DESCRIPTION
## Summary
- reuse the shared floating-position clamp for pointer and keyboard result menus
- measure dynamic context-menu dimensions before the final viewport clamp
- align command preference language with the pinned store using Pin/Unpin
- update rendered and browser smoke coverage

## Verification
- `npx vitest run src/lib/components/command-palette-destinations.behavior.test.ts`
- `npm run check` (0 errors, 0 warnings; known nested site config notice)
- `npm run preflight -- full` (174 files / 1299 frontend tests; 866 Rust tests, 3 ignored)
- `npm run test:e2e` (branch-relevant S19c flow passed after assertion update; unrelated current-main smoke failures remain in view/curation/embeddings/Trash/folder-rename flows)
- independent Spec review: PASS
- independent Standards review: PASS

Closes imageview-10s0.7