### PR TITLE
Render agent commands as inline code

### DIFF
--- a/src/lib/components/AgentSkillsDialog.svelte
+++ b/src/lib/components/AgentSkillsDialog.svelte
@@ -67,7 +67,7 @@ Do not rely on Cull tools as the confirmation layer for destructive operations. 
                     >Copy</button>
                 </div>
                 <p class="section-copy">
-                    Put this in the agent runtime's MCP config. The `cull` command opens the app in
+                    Put this in the agent runtime's MCP config. The <code>cull</code> command opens the app in
                     tray mode if it is not already running.
                 </p>
                 <pre><code>{mcpConfig}</code></pre>
@@ -92,7 +92,7 @@ Do not rely on Cull tools as the confirmation layer for destructive operations. 
                 </div>
                 <div>
                     <span class="meta-label">Headless work</span>
-                    <span class="meta-value">Use `cull --json` for import, export, stats, embeddings, and quality jobs.</span>
+                    <span class="meta-value">Use <code>cull --json</code> for import, export, stats, embeddings, and quality jobs.</span>
                 </div>
                 <div>
                     <span class="meta-label">Reference</span>

--- a/src/lib/components/agent-skills-dialog.behavior.test.ts
+++ b/src/lib/components/agent-skills-dialog.behavior.test.ts
@@ -1,0 +1,20 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import '@testing-library/jest-dom/vitest';
+import { cleanup, render, screen } from '@testing-library/svelte';
+import AgentSkillsDialog from './AgentSkillsDialog.svelte';
+
+afterEach(() => cleanup());
+
+describe('AgentSkillsDialog inline code', () => {
+    it('renders command names as semantic code without visible Markdown backticks', () => {
+        render(AgentSkillsDialog, { onclose: vi.fn() });
+
+        const dialog = screen.getByRole('dialog', { name: 'Install Agent Skills' });
+        expect(screen.getByText('cull', { selector: 'code' })).toBeInTheDocument();
+        expect(screen.getByText('cull --json', { selector: 'code' })).toBeInTheDocument();
+        expect(dialog).not.toHaveTextContent('`cull`');
+        expect(dialog).not.toHaveTextContent('`cull --json`');
+    });
+});


### PR DESCRIPTION
## Summary
- replace visible Markdown backticks in AgentSkillsDialog with semantic inline code elements
- add rendered coverage for both command references and absence of literal backticks

## Verification
- focused rendered test: 1/1
- `npm run check`: 0 errors, 0 warnings (known nested site config notice)
- pre-push full gate: 175 files / 1300 frontend tests; 866 Rust tests, 3 ignored
- independent Spec review: PASS
- independent Standards review: PASS

Closes imageview-9k1u.8