### PR TITLE
feat: show shortcuts in image context menu

### DIFF
--- a/src/lib/clipboard-actions.ts
+++ b/src/lib/clipboard-actions.ts
@@ -1,6 +1,10 @@
 export const CLIPBOARD_PASTE_DATE_FORMAT_SETTING = 'clipboard_paste_date_format';
 export const DEFAULT_CLIPBOARD_PASTE_DATE_FORMAT = '%Y-%m-%d';
 
+export function filenameForPath(path: string): string {
+    return path.split('/').filter(Boolean).pop() ?? path;
+}
+
 export function parentFolderForPath(path: string): string | null {
     const trimmed = path.trim().replace(/\/+$/, '');
     const idx = trimmed.lastIndexOf('/');

--- a/src/lib/command-palette.test.ts
+++ b/src/lib/command-palette.test.ts
@@ -2,6 +2,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { get } from 'svelte/store';
 import {
     canAssignCommandHotkey,
+    commandForKeyboardEvent,
+    commandShortcutHints,
     eventMatchesShortcut,
     findDuplicateCommandHotkeys,
     getCommandPaletteItems,
@@ -113,6 +115,77 @@ describe('command palette helpers', () => {
         clearPluginTabs();
         registerCoreTabs();
     }
+
+    it('resolves context-menu image shortcuts from the command registry', () => {
+        resetCommandContext();
+        images.set([{
+            image: {
+                id: 'image-one',
+                sha256_hash: 'hash-one',
+                width: 100,
+                height: 100,
+                format: 'png',
+                file_size: 100,
+                created_at: '2026-08-08T00:00:00Z',
+                imported_at: '2026-08-08T00:00:00Z',
+                ai_prompt: null,
+                raw_metadata: null,
+            },
+            path: '/images/one.png',
+            thumbnail_path: null,
+            selection: null,
+            source_label: null,
+            missing_at: null,
+        }]);
+
+        expect(commandShortcutHints([
+            'image.rating.0',
+            'image.rating.3',
+            'image.decision.accept',
+            'image.decision.reject',
+            'image.decision.undecided',
+            'image.copy',
+            'image.trash',
+        ])).toEqual({
+            'image.rating.0': '0',
+            'image.rating.3': '3',
+            'image.decision.accept': 'A',
+            'image.decision.reject': 'X',
+            'image.decision.undecided': 'U',
+            'image.copy': 'Cmd+C',
+            'image.trash': 'Backspace',
+        });
+
+        setCommandHotkey('image.decision.accept', 'Shift+A');
+        expect(commandShortcutHints(['image.decision.accept'])).toEqual({
+            'image.decision.accept': 'Shift+A',
+        });
+    });
+
+    it('uses custom image shortcuts as replacements for registry defaults', () => {
+        resetCommandContext();
+        images.set([{
+            image: {
+                id: 'image-one', sha256_hash: 'hash-one', width: 100, height: 100,
+                format: 'png', file_size: 100, created_at: '2026-08-08T00:00:00Z',
+                imported_at: '2026-08-08T00:00:00Z', ai_prompt: null, raw_metadata: null,
+            },
+            path: '/images/one.png', thumbnail_path: null, selection: null,
+            source_label: null, missing_at: null,
+        }]);
+
+        expect(commandForKeyboardEvent(keyEvent('c', { metaKey: true }))?.id).toBe('image.copy');
+        expect(commandForKeyboardEvent(keyEvent('z', { metaKey: true }))).toBeNull();
+        setCommandHotkey('image.copy', 'Shift+C');
+        expect(commandForKeyboardEvent(keyEvent('c', { metaKey: true }))).toBeNull();
+        expect(commandForKeyboardEvent(keyEvent('C', { shiftKey: true }))?.id).toBe('image.copy');
+
+        expect(commandForKeyboardEvent(keyEvent('a'))?.id).toBe('image.decision.accept');
+        setCommandHotkey('image.decision.accept', 'Shift+A');
+        expect(commandForKeyboardEvent(keyEvent('a'))).toBeNull();
+        expect(commandForKeyboardEvent(keyEvent('A', { shiftKey: true }))?.id)
+            .toBe('image.decision.accept');
+    });
 
     it('scores title, category, keyword, and acronym matches', () => {
         const grid = item('view.grid', 'Grid View', 'View', { keywords: ['gallery'] });

--- a/src/lib/command-palette.ts
+++ b/src/lib/command-palette.ts
@@ -63,6 +63,8 @@ import { save as saveDialog } from '@tauri-apps/plugin-dialog';
 import { runAiLibraryJob, type AiLibraryJobKind } from './ai-library-jobs';
 import { openSettings } from './settings-navigation';
 import { requestTrashImages } from './trash-actions';
+import { copyCurrentImageToClipboard } from './image-copy-action';
+import { currentImageIndex } from './current-image-target';
 import {
     previewDisplayAlwaysOnTop,
     previewDisplayBlanked,
@@ -100,6 +102,7 @@ export interface CommandPaletteItem {
     kind: CommandPaletteItemKind;
     keywords?: string[];
     defaultShortcut?: string;
+    handlesDefaultShortcut?: boolean;
     disabled?: boolean;
     when?: () => boolean;
     run: () => void | Promise<void>;
@@ -294,6 +297,25 @@ export function shortcutForItem(item: CommandPaletteItem, hotkeys: Record<string
     return hotkeys[item.id] ?? item.defaultShortcut;
 }
 
+export function commandShortcutHints(commandIds: string[]): Record<string, string> {
+    const wanted = new Set(commandIds);
+    const hotkeys = readCommandHotkeys();
+    const compareMode = get(viewMode) === 'compare';
+    return Object.fromEntries(
+        getCommandPaletteItems('all')
+            .filter(item => wanted.has(item.id) && isCommandPaletteItemVisible(item))
+            .flatMap(item => {
+                const shortcut = shortcutForItem(item, hotkeys);
+                if (
+                    compareMode
+                    && !hotkeys[item.id]
+                    && (item.id === 'image.rating.1' || item.id === 'image.rating.2')
+                ) return [];
+                return shortcut ? [[item.id, shortcut] as const] : [];
+            }),
+    );
+}
+
 // Clear every custom hotkey assignment, reverting all commands to their defaults.
 export function resetCommandHotkeys(): Record<string, string> {
     writeJson(COMMAND_HOTKEYS_STORAGE_KEY, {});
@@ -427,7 +449,7 @@ function openCanvas(canvas: Canvas) {
 }
 
 async function setFocusedRating(rating: number) {
-    const idx = get(focusedIndex);
+    const idx = currentImageIndex();
     const image = get(images)[idx];
     if (!image) return;
     await setRating(image.image.id, rating, get(activeSession)?.id ?? null);
@@ -440,7 +462,7 @@ async function setFocusedRating(rating: number) {
 }
 
 async function setFocusedDecision(decision: ImageDecision) {
-    const idx = get(focusedIndex);
+    const idx = currentImageIndex();
     const image = get(images)[idx];
     if (!image) return;
     await setDecision(image.image.id, decision, get(activeSession)?.id ?? null);
@@ -999,6 +1021,18 @@ function commandItems(): CommandPaletteItem[] {
             run: addFocusedImageToCollectTarget,
         },
         {
+            id: 'image.copy',
+            title: 'Copy Focused Image',
+            subtitle: focusedImageTitle(),
+            category: 'Image',
+            kind: 'command',
+            keywords: ['clipboard', 'copy'],
+            defaultShortcut: 'Cmd+C',
+            handlesDefaultShortcut: true,
+            disabled: !hasImage,
+            run: copyCurrentImageToClipboard,
+        },
+        {
             id: 'image.trash',
             title: 'Move Focused Image to Trash',
             subtitle: focusedImageTitle(),
@@ -1006,6 +1040,7 @@ function commandItems(): CommandPaletteItem[] {
             kind: 'command',
             keywords: ['delete', 'remove'],
             defaultShortcut: 'Backspace',
+            handlesDefaultShortcut: true,
             disabled: !hasImage,
             run: () => requestTrashImages(),
         },
@@ -1017,6 +1052,7 @@ function commandItems(): CommandPaletteItem[] {
             kind: 'command',
             keywords: ['remove', 'destroy'],
             defaultShortcut: 'Cmd+Backspace',
+            handlesDefaultShortcut: true,
             disabled: !hasImage,
             run: () => {
                 window.dispatchEvent(new CustomEvent('delete-focused-image'));
@@ -1029,6 +1065,8 @@ function commandItems(): CommandPaletteItem[] {
             category: 'Image',
             kind: 'command',
             keywords: ['star', 'rank', 'score'],
+            defaultShortcut: String(rating),
+            handlesDefaultShortcut: true,
             disabled: !hasImage,
             run: () => setFocusedRating(rating),
         })),
@@ -1039,6 +1077,8 @@ function commandItems(): CommandPaletteItem[] {
             category: 'Image',
             kind: 'command',
             keywords: ['pick', 'cull', 'triage'],
+            defaultShortcut: decision === 'accept' ? 'A' : decision === 'reject' ? 'X' : 'U',
+            handlesDefaultShortcut: true,
             disabled: !hasImage,
             run: () => setFocusedDecision(decision),
         })),
@@ -1586,7 +1626,8 @@ export function commandForKeyboardEvent(event: KeyboardEvent): CommandPaletteIte
     const items = getCommandPaletteItems('all');
     const item = items.find(candidate => {
         if (!isCommandPaletteItemVisible(candidate)) return false;
-        const shortcut = hotkeys[candidate.id];
+        const shortcut = hotkeys[candidate.id]
+            ?? (candidate.handlesDefaultShortcut ? candidate.defaultShortcut : undefined);
         return shortcut ? eventMatchesShortcut(event, shortcut) : false;
     });
     return item && !item.disabled ? item : null;

--- a/src/lib/components/ContextMenu.svelte
+++ b/src/lib/components/ContextMenu.svelte
@@ -11,6 +11,8 @@
     import { withDecision, withRating, type ImageDecision } from '$lib/selection-updates';
     import { applyDecisionToCurrentView } from '$lib/rejected-visibility';
     import { requestTrashImages } from '$lib/trash-actions';
+    import { commandShortcutHints, eventMatchesShortcut } from '$lib/command-palette';
+    import { copyImageWithToast } from '$lib/image-copy-action';
 
     interface Props {
         image: ImageWithFile;
@@ -51,6 +53,14 @@
     let menuReady = $state(false);
     let activeIndex = $state(0);
     let placementRun = 0;
+    const shortcutHints = commandShortcutHints([
+        ...[0, 1, 2, 3, 4, 5].map(rating => `image.rating.${rating}`),
+        'image.decision.accept',
+        'image.decision.reject',
+        'image.decision.undecided',
+        'image.copy',
+        'image.trash',
+    ]);
 
     let currentRating = $derived(image.selection?.star_rating ?? 0);
     let currentDecision = $derived(image.selection?.decision ?? 'undecided');
@@ -203,6 +213,27 @@
             } else {
                 onclose();
             }
+            return;
+        }
+
+        const shortcutAction = [
+            ...[0, 1, 2, 3, 4, 5].map(rating => ({
+                id: `image.rating.${rating}`,
+                run: () => handleRate(rating),
+            })),
+            { id: 'image.decision.accept', run: () => handleDecision('accept') },
+            { id: 'image.decision.reject', run: () => handleDecision('reject') },
+            { id: 'image.decision.undecided', run: () => handleDecision('undecided') },
+            { id: 'image.copy', run: act(() => copyImageWithToast(image)) },
+            { id: 'image.trash', run: handleTrash },
+        ].find(action => {
+            const shortcut = shortcutHints[action.id];
+            return shortcut ? eventMatchesShortcut(e, shortcut) : false;
+        });
+        if (shortcutAction) {
+            e.preventDefault();
+            e.stopPropagation();
+            void shortcutAction.run();
             return;
         }
 
@@ -623,9 +654,15 @@
                 bind:this={rateSubmenuEl}
                 style={rateSubmenuPlacement}
             >
-                <button class="context-menu-item" class:active={currentRating === 0} onclick={() => handleRate(0)} role="menuitem" tabindex="-1">☆ Unrated</button>
+                <button class="context-menu-item" class:active={currentRating === 0} onclick={() => handleRate(0)} role="menuitem" tabindex="-1">
+                    <span>☆ Unrated</span>
+                    {#if shortcutHints['image.rating.0']}<kbd class="shortcut-hint" data-shortcut-for="image.rating.0">{shortcutHints['image.rating.0']}</kbd>{/if}
+                </button>
                 {#each [1, 2, 3, 4, 5] as n}
-                    <button class="context-menu-item" class:active={currentRating === n} onclick={() => handleRate(n)} role="menuitem" tabindex="-1">{'★'.repeat(n)} {n} Star{n > 1 ? 's' : ''}</button>
+                    <button class="context-menu-item" class:active={currentRating === n} onclick={() => handleRate(n)} role="menuitem" tabindex="-1">
+                        <span>{'★'.repeat(n)} {n} Star{n > 1 ? 's' : ''}</span>
+                        {#if shortcutHints[`image.rating.${n}`]}<kbd class="shortcut-hint" data-shortcut-for={`image.rating.${n}`}>{shortcutHints[`image.rating.${n}`]}</kbd>{/if}
+                    </button>
                 {/each}
             </div>
         {/if}
@@ -643,7 +680,10 @@
         tabindex={activeIndex === 1 ? 0 : -1}
     >
         <span>Accept</span>
-        {#if currentDecision === 'accept'}<span class="check">✓</span>{/if}
+        <span class="menu-item-meta">
+            {#if currentDecision === 'accept'}<span class="check">✓</span>{/if}
+            {#if shortcutHints['image.decision.accept']}<kbd class="shortcut-hint" data-shortcut-for="image.decision.accept">{shortcutHints['image.decision.accept']}</kbd>{/if}
+        </span>
     </button>
     <button
         class="context-menu-item"
@@ -654,7 +694,10 @@
         tabindex={activeIndex === 2 ? 0 : -1}
     >
         <span>Reject</span>
-        {#if currentDecision === 'reject'}<span class="check">✓</span>{/if}
+        <span class="menu-item-meta">
+            {#if currentDecision === 'reject'}<span class="check">✓</span>{/if}
+            {#if shortcutHints['image.decision.reject']}<kbd class="shortcut-hint" data-shortcut-for="image.decision.reject">{shortcutHints['image.decision.reject']}</kbd>{/if}
+        </span>
     </button>
     <button
         class="context-menu-item"
@@ -662,7 +705,10 @@
         role="menuitem"
         data-menu-index="3"
         tabindex={activeIndex === 3 ? 0 : -1}
-    >Clear Decision</button>
+    >
+        <span>Clear Decision</span>
+        {#if shortcutHints['image.decision.undecided']}<kbd class="shortcut-hint" data-shortcut-for="image.decision.undecided">{shortcutHints['image.decision.undecided']}</kbd>{/if}
+    </button>
 
     <div class="separator"></div>
 
@@ -757,7 +803,9 @@
             tabindex={activeIndex === 7 ? 0 : -1}
         >
             <span>Copy</span>
-            <span class="arrow">►</span>
+            <span class="menu-item-meta">
+                <span class="arrow">►</span>
+            </span>
         </button>
         {#if openSubmenu === 'copy'}
             <div
@@ -766,6 +814,11 @@
                 bind:this={copySubmenuEl}
                 style={copySubmenuPlacement}
             >
+                <button class="context-menu-item" onclick={act(() => copyImageWithToast(image))} role="menuitem" tabindex="-1">
+                    <span>Copy Image</span>
+                    {#if shortcutHints['image.copy']}<kbd class="shortcut-hint" data-shortcut-for="image.copy">{shortcutHints['image.copy']}</kbd>{/if}
+                </button>
+                <div class="separator"></div>
                 <button class="context-menu-item" onclick={handleCopyPath} role="menuitem" tabindex="-1">Copy Path{multiCount > 1 ? 's' : ''}</button>
                 <button class="context-menu-item" onclick={handleCopyFilename} role="menuitem" tabindex="-1">Copy Filename{multiCount > 1 ? 's' : ''}</button>
                 <button class="context-menu-item" onclick={handleCopyFileUrl} role="menuitem" tabindex="-1">Copy File URL{multiCount > 1 ? 's' : ''}</button>
@@ -913,7 +966,10 @@
         role="menuitem"
         data-menu-index="14"
         tabindex={activeIndex === 14 ? 0 : -1}
-    >Trash{multiCount > 1 ? ` (${multiCount})` : ''}</button>
+    >
+        <span>Trash{multiCount > 1 ? ` (${multiCount})` : ''}</span>
+        {#if shortcutHints['image.trash']}<kbd class="shortcut-hint" data-shortcut-for="image.trash">{shortcutHints['image.trash']}</kbd>{/if}
+    </button>
 </div>
 
 <style>
@@ -948,6 +1004,17 @@
         min-height: 30px;
         white-space: nowrap;
     }
+    .menu-item-meta {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--spacing);
+    }
+    .shortcut-hint {
+        color: var(--text-secondary);
+        font: inherit;
+        font-size: 11px;
+        line-height: 1;
+    }
     .context-menu-item:hover,
     .context-menu-item:focus {
         background: var(--blue);
@@ -969,7 +1036,9 @@
     .context-menu-item:hover .count,
     .context-menu-item:focus .count,
     .context-menu-item:hover .folder-path,
-    .context-menu-item:focus .folder-path {
+    .context-menu-item:focus .folder-path,
+    .context-menu-item:hover .shortcut-hint,
+    .context-menu-item:focus .shortcut-hint {
         color: var(--bg);
     }
     .separator {

--- a/src/lib/components/context-menu-shortcuts.behavior.test.ts
+++ b/src/lib/components/context-menu-shortcuts.behavior.test.ts
@@ -1,0 +1,120 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import '@testing-library/jest-dom/vitest';
+import { cleanup, fireEvent, render } from '@testing-library/svelte';
+import type { ImageWithFile } from '$lib/api';
+
+const mocks = vi.hoisted(() => ({
+    setDecision: vi.fn().mockResolvedValue(undefined),
+    commandShortcutHints: vi.fn((ids: string[]) => {
+        const shortcuts: Record<string, string> = {
+            'image.rating.0': '0',
+            'image.rating.1': '1',
+            'image.rating.2': '2',
+            'image.rating.3': '3',
+            'image.rating.4': '4',
+            'image.rating.5': '5',
+            'image.decision.accept': 'A',
+            'image.decision.reject': 'X',
+            'image.decision.undecided': 'U',
+            'image.copy': 'Cmd+C',
+            'image.trash': 'Backspace',
+        };
+        return Object.fromEntries(ids.flatMap(id => shortcuts[id] ? [[id, shortcuts[id]]] : []));
+    }),
+}));
+
+vi.mock('@tauri-apps/plugin-dialog', () => ({ open: vi.fn() }));
+vi.mock('$lib/api', () => ({
+    addToCollection: vi.fn(),
+    createCollection: vi.fn(),
+    listCollections: vi.fn().mockResolvedValue([]),
+    listFolders: vi.fn().mockResolvedValue([]),
+    listOpenWithApplications: vi.fn().mockResolvedValue([]),
+    moveImage: vi.fn(),
+    openImagesWithApplication: vi.fn(),
+    removeFromCollection: vi.fn(),
+    renameImage: vi.fn(),
+    setDecision: mocks.setDecision,
+    setRating: vi.fn(),
+    shareImages: vi.fn(),
+}));
+vi.mock('$lib/image-loading', () => ({
+    invalidateImageCache: vi.fn(),
+    loadImagesForCurrentScope: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock('$lib/similarity', () => ({ loadSimilarImages: vi.fn() }));
+vi.mock('$lib/command-palette', () => ({
+    commandShortcutHints: mocks.commandShortcutHints,
+    eventMatchesShortcut: vi.fn((event: KeyboardEvent, shortcut: string) => (
+        !event.metaKey && !event.ctrlKey && !event.altKey
+        && event.key.toUpperCase() === shortcut.toUpperCase()
+    )),
+}));
+vi.mock('$lib/image-copy-action', () => ({ copyImageWithToast: vi.fn() }));
+
+import ContextMenu from './ContextMenu.svelte';
+
+const image: ImageWithFile = {
+    image: {
+        id: 'image-one',
+        sha256_hash: 'hash-one',
+        width: 100,
+        height: 100,
+        format: 'png',
+        file_size: 100,
+        created_at: '2026-08-08T00:00:00Z',
+        imported_at: '2026-08-08T00:00:00Z',
+        ai_prompt: null,
+        raw_metadata: null,
+    },
+    path: '/images/one.png',
+    thumbnail_path: null,
+    selection: null,
+    source_label: null,
+    missing_at: null,
+};
+
+afterEach(() => cleanup());
+beforeEach(() => vi.clearAllMocks());
+
+describe('ContextMenu shortcut hints', () => {
+    it('renders the command registry shortcuts beside matching actions', async () => {
+        const { container } = render(ContextMenu, {
+            props: { image, x: 20, y: 20, onclose: vi.fn() },
+        });
+
+        expect(container.querySelector('[data-shortcut-for="image.decision.accept"]')).toHaveTextContent('A');
+        expect(container.querySelector('[data-shortcut-for="image.decision.reject"]')).toHaveTextContent('X');
+        expect(container.querySelector('[data-shortcut-for="image.decision.undecided"]')).toHaveTextContent('U');
+        expect(container.querySelector('[data-shortcut-for="image.trash"]')).toHaveTextContent('Backspace');
+
+        expect(mocks.commandShortcutHints).toHaveBeenCalledWith([
+            'image.rating.0',
+            'image.rating.1',
+            'image.rating.2',
+            'image.rating.3',
+            'image.rating.4',
+            'image.rating.5',
+            'image.decision.accept',
+            'image.decision.reject',
+            'image.decision.undecided',
+            'image.copy',
+            'image.trash',
+        ]);
+
+        await fireEvent.mouseEnter(container.querySelector('[data-submenu-key="rate"]')!.parentElement!);
+        for (let rating = 0; rating <= 5; rating += 1) {
+            expect(container.querySelector(`[data-shortcut-for="image.rating.${rating}"]`))
+                .toHaveTextContent(String(rating));
+        }
+
+        await fireEvent.mouseEnter(container.querySelector('[data-submenu-key="copy"]')!.parentElement!);
+        expect(container.querySelector('[data-shortcut-for="image.copy"]')).toHaveTextContent('Cmd+C');
+        expect(container.querySelector('[data-shortcut-for="image.copy"]')?.closest('button'))
+            .toHaveTextContent('Copy Image');
+
+        await fireEvent.keyDown(container.querySelector('[role="menu"]')!, { key: 'a' });
+        expect(mocks.setDecision).toHaveBeenCalledWith('image-one', 'accept', null);
+    });
+});

--- a/src/lib/current-image-target.test.ts
+++ b/src/lib/current-image-target.test.ts
@@ -1,0 +1,33 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import type { ImageWithFile } from './api';
+import { compareActiveSide, focusedIndex, images, selectedIds, viewMode } from './stores';
+import { currentImageIndex } from './current-image-target';
+
+function image(id: string): ImageWithFile {
+    return {
+        image: {
+            id, sha256_hash: `hash-${id}`, width: 100, height: 100, format: 'png',
+            file_size: 100, created_at: '2026-08-08T00:00:00Z',
+            imported_at: '2026-08-08T00:00:00Z', ai_prompt: null, raw_metadata: null,
+        },
+        path: `/images/${id}.png`, thumbnail_path: null, selection: null,
+        source_label: null, missing_at: null,
+    };
+}
+
+describe('currentImageIndex', () => {
+    beforeEach(() => {
+        images.set([image('one'), image('two'), image('three')]);
+        selectedIds.set(new Set());
+        focusedIndex.set(0);
+        compareActiveSide.set(0);
+        viewMode.set('grid');
+    });
+
+    it('uses the active selected side in Compare', () => {
+        viewMode.set('compare');
+        selectedIds.set(new Set(['one', 'three']));
+        compareActiveSide.set(1);
+        expect(currentImageIndex()).toBe(2);
+    });
+});

--- a/src/lib/current-image-target.ts
+++ b/src/lib/current-image-target.ts
@@ -1,0 +1,24 @@
+import { get } from 'svelte/store';
+import {
+    compareActiveSide,
+    focusedIndex,
+    images,
+    selectedIds,
+    viewMode,
+} from './stores';
+
+export function currentImageIndex(): number {
+    const index = get(focusedIndex);
+    if (get(viewMode) !== 'compare') return index;
+
+    const allImages = get(images);
+    const selected = get(selectedIds);
+    const side = get(compareActiveSide);
+    if (selected.size >= 2) {
+        const selectedImageIds = Array.from(selected);
+        const targetId = selectedImageIds[side] ?? selectedImageIds[0];
+        const selectedIndex = allImages.findIndex(item => item.image.id === targetId);
+        return selectedIndex >= 0 ? selectedIndex : index;
+    }
+    return index + side;
+}

--- a/src/lib/image-copy-action.test.ts
+++ b/src/lib/image-copy-action.test.ts
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ImageWithFile } from './api';
+import { compareActiveSide, focusedIndex, images, selectedIds, viewMode } from './stores';
+
+const mocks = vi.hoisted(() => ({
+    copyImageToClipboard: vi.fn(),
+}));
+
+vi.mock('./api', async importOriginal => ({
+    ...(await importOriginal<typeof import('./api')>()),
+    copyImageToClipboard: mocks.copyImageToClipboard,
+}));
+
+import { copyCurrentImageToClipboard } from './image-copy-action';
+
+function image(id: string): ImageWithFile {
+    return {
+        image: {
+            id,
+            sha256_hash: `hash-${id}`,
+            width: 100,
+            height: 100,
+            format: 'png',
+            file_size: 100,
+            created_at: '2026-08-08T00:00:00Z',
+            imported_at: '2026-08-08T00:00:00Z',
+            ai_prompt: null,
+            raw_metadata: null,
+        },
+        path: `/images/${id}.png`,
+        thumbnail_path: null,
+        selection: null,
+        source_label: null,
+        missing_at: null,
+    };
+}
+
+describe('copyCurrentImageToClipboard', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        images.set([image('one'), image('two')]);
+        selectedIds.set(new Set());
+        focusedIndex.set(0);
+        compareActiveSide.set(0);
+        viewMode.set('grid');
+    });
+
+    it('copies the focused image in the library', async () => {
+        await copyCurrentImageToClipboard();
+        expect(mocks.copyImageToClipboard).toHaveBeenCalledWith('one');
+    });
+
+    it('copies the active comparison side', async () => {
+        viewMode.set('compare');
+        selectedIds.set(new Set(['one', 'two']));
+        compareActiveSide.set(1);
+
+        await copyCurrentImageToClipboard();
+        expect(mocks.copyImageToClipboard).toHaveBeenCalledWith('two');
+    });
+});

--- a/src/lib/image-copy-action.ts
+++ b/src/lib/image-copy-action.ts
@@ -1,0 +1,33 @@
+import { get } from 'svelte/store';
+import { copyImageToClipboard } from './api';
+import { filenameForPath } from './clipboard-actions';
+import { images, showToast } from './stores';
+import { currentImageIndex } from './current-image-target';
+import type { ImageWithFile } from './api';
+
+export async function copyImageWithToast(image: ImageWithFile | null | undefined) {
+    if (!image) {
+        showToast('No current image to copy', { type: 'warning', duration: 3000 });
+        return;
+    }
+
+    try {
+        await copyImageToClipboard(image.image.id);
+        showToast('Copied image', {
+            detail: filenameForPath(image.path),
+            type: 'success',
+            duration: 2500,
+        });
+    } catch (error) {
+        console.error('Failed to copy image:', error);
+        showToast('Could not copy image', {
+            detail: String(error),
+            type: 'error',
+            duration: 5000,
+        });
+    }
+}
+
+export function copyCurrentImageToClipboard() {
+    return copyImageWithToast(get(images)[currentImageIndex()]);
+}

--- a/src/lib/keys-compare-shortcuts.test.ts
+++ b/src/lib/keys-compare-shortcuts.test.ts
@@ -1,0 +1,105 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { get } from 'svelte/store';
+import type { ImageWithFile } from './api';
+import { compareActiveSide, focusedIndex, images, selectedIds, viewMode } from './stores';
+
+const mocks = vi.hoisted(() => ({
+    commandForKeyboardEvent: vi.fn(),
+    runCommandPaletteItem: vi.fn(),
+    setDecision: vi.fn().mockResolvedValue(undefined),
+    setRating: vi.fn().mockResolvedValue(undefined),
+    undo: vi.fn().mockResolvedValue('library action'),
+}));
+
+vi.mock('./api', () => ({
+    addToCollection: vi.fn(), createCollection: vi.fn(), listCollections: vi.fn(),
+    pasteImageFromClipboard: vi.fn(), redo: vi.fn(), rotateImage: vi.fn(),
+    setDecision: mocks.setDecision, setRating: mocks.setRating, undo: mocks.undo,
+}));
+vi.mock('./command-palette', () => ({
+    commandForKeyboardEvent: mocks.commandForKeyboardEvent,
+    openCommandPalette: vi.fn(),
+    runCommandPaletteItem: mocks.runCommandPaletteItem,
+}));
+vi.mock('./image-loading', () => ({
+    invalidateImageCache: vi.fn(),
+    loadImagesForCurrentScope: vi.fn(),
+}));
+vi.mock('./shortcut-reminders', () => ({
+    recordShortcutUse: vi.fn(),
+    VIEW_CYCLE_SHORTCUT_REMINDER_ID: 'view-cycle',
+}));
+
+import { handleKeydown } from './keys';
+
+function image(id: string): ImageWithFile {
+    return {
+        image: {
+            id, sha256_hash: `hash-${id}`, width: 100, height: 100, format: 'png',
+            file_size: 100, created_at: '2026-08-08T00:00:00Z',
+            imported_at: '2026-08-08T00:00:00Z', ai_prompt: null, raw_metadata: null,
+        },
+        path: `/images/${id}.png`, thumbnail_path: null, selection: null,
+        source_label: null, missing_at: null,
+    };
+}
+
+function keyEvent(key: string, modifiers: Partial<KeyboardEvent> = {}): KeyboardEvent {
+    return {
+        key, metaKey: false, shiftKey: false, ctrlKey: false, altKey: false,
+        target: null, preventDefault: vi.fn(),
+        ...modifiers,
+    } as unknown as KeyboardEvent;
+}
+
+describe('Compare image shortcuts', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        vi.stubGlobal('HTMLElement', class {});
+        vi.stubGlobal('HTMLInputElement', class {});
+        vi.stubGlobal('HTMLTextAreaElement', class {});
+        vi.stubGlobal('HTMLSelectElement', class {});
+        vi.stubGlobal('document', { querySelector: vi.fn(() => null), fullscreenElement: null });
+        vi.stubGlobal('window', new EventTarget());
+        const allImages = [image('left'), image('right')];
+        images.set(allImages);
+        selectedIds.set(new Set(['left', 'right']));
+        focusedIndex.set(0);
+        compareActiveSide.set(0);
+        viewMode.set('compare');
+    });
+
+    it('keeps bare 1/2 reserved for choosing the winning side', async () => {
+        mocks.commandForKeyboardEvent.mockReturnValue({ id: 'image.rating.1' });
+
+        handleKeydown(keyEvent('1'));
+
+        expect(mocks.commandForKeyboardEvent).not.toHaveBeenCalled();
+        expect(mocks.runCommandPaletteItem).not.toHaveBeenCalled();
+        await vi.waitFor(() => expect(mocks.setDecision).toHaveBeenCalledTimes(2));
+        expect(mocks.setDecision).toHaveBeenNthCalledWith(1, 'left', 'accept', null);
+        expect(mocks.setDecision).toHaveBeenNthCalledWith(2, 'right', 'reject', null);
+    });
+
+    it('rates the active side when a Compare rating chord is pending', async () => {
+        mocks.commandForKeyboardEvent.mockReturnValue(null);
+        handleKeydown(keyEvent('s'));
+        handleKeydown(keyEvent('1'));
+
+        expect(mocks.runCommandPaletteItem).not.toHaveBeenCalled();
+        expect(mocks.setDecision).not.toHaveBeenCalled();
+        await vi.waitFor(() => expect(mocks.setRating).toHaveBeenCalledWith('left', 1, null));
+    });
+
+    it('keeps Grid selection undo ahead of database undo', () => {
+        mocks.commandForKeyboardEvent.mockReturnValue(null);
+        viewMode.set('grid');
+        selectedIds.reset();
+        selectedIds.set(new Set(['left']));
+
+        handleKeydown(keyEvent('z', { metaKey: true }));
+
+        expect(get(selectedIds)).toEqual(new Set());
+        expect(mocks.undo).not.toHaveBeenCalled();
+    });
+});

--- a/src/lib/keys.ts
+++ b/src/lib/keys.ts
@@ -16,7 +16,7 @@ import { computeCompareSwap, nextComparePresentationState } from './compare-util
 import { nextExportPresentationState } from './presentation-utils';
 import type { NsfwMode } from './stores';
 import type { ViewMode } from './stores';
-import { setRating, setDecision, createCollection, addToCollection, listCollections, rotateImage, undo, redo, copyImageToClipboard, pasteImageFromClipboard } from './api';
+import { setRating, setDecision, createCollection, addToCollection, listCollections, rotateImage, undo, redo, pasteImageFromClipboard } from './api';
 import { showToast } from './stores';
 import { invalidateImageCache, loadImagesForCurrentScope } from './image-loading';
 import { focusImagePath } from './transform-results';
@@ -24,9 +24,9 @@ import { commandForKeyboardEvent, openCommandPalette, runCommandPaletteItem } fr
 import { recordShortcutUse, VIEW_CYCLE_SHORTCUT_REMINDER_ID } from './shortcut-reminders';
 import { withRating, type ImageDecision } from './selection-updates';
 import { applyDecisionToCurrentView } from './rejected-visibility';
-import { pasteDestinationForContext } from './clipboard-actions';
+import { filenameForPath, pasteDestinationForContext } from './clipboard-actions';
 import { nudgeThumbnailSize } from './thumbnail-zoom';
-import { requestTrashImages } from './trash-actions';
+import { currentImageIndex } from './current-image-target';
 
 let waitingForStar = false;
 
@@ -188,45 +188,7 @@ function getCompareActiveIndexForSide(side: 0 | 1): number {
 }
 
 function getCompareActiveIndex(): number {
-    const imgs = get(images);
-    const sel = get(selectedIds);
-    const idx = get(focusedIndex);
-    const side = get(compareActiveSide);
-
-    if (sel.size >= 2) {
-        const selArr = Array.from(sel);
-        const targetId = selArr[side] ?? selArr[0];
-        const found = imgs.findIndex(i => i.image.id === targetId);
-        return found >= 0 ? found : idx;
-    }
-    return idx + side;
-}
-
-function filenameForPath(path: string): string {
-    return path.split('/').filter(Boolean).pop() ?? path;
-}
-
-function currentClipboardImage() {
-    if (get(viewMode) === 'compare') {
-        return get(images)[getCompareActiveIndex()] ?? null;
-    }
-    return get(focusedImage);
-}
-
-async function handleCopyCurrentImage() {
-    const img = currentClipboardImage();
-    if (!img) {
-        showToast('No current image to copy', { type: 'warning', duration: 3000 });
-        return;
-    }
-
-    try {
-        await copyImageToClipboard(img.image.id);
-        showToast('Copied image', { detail: filenameForPath(img.path), type: 'success', duration: 2500 });
-    } catch (err) {
-        console.error('Failed to copy image:', err);
-        showToast('Could not copy image', { detail: String(err), type: 'error', duration: 5000 });
-    }
+    return currentImageIndex();
 }
 
 async function handlePasteImage() {
@@ -321,12 +283,6 @@ export function handleKeydown(e: KeyboardEvent) {
     const tag = (e.target as HTMLElement)?.tagName;
     if (['BUTTON', 'A', 'SELECT'].includes(tag) && (e.key === ' ' || e.key === 'Enter')) return;
 
-    if (e.key.toLowerCase() === 'c' && e.metaKey && !e.shiftKey && !e.ctrlKey && !e.altKey) {
-        e.preventDefault();
-        void handleCopyCurrentImage();
-        return;
-    }
-
     if (e.key.toLowerCase() === 'v' && e.metaKey && !e.shiftKey && !e.ctrlKey && !e.altKey) {
         e.preventDefault();
         void handlePasteImage();
@@ -360,14 +316,6 @@ export function handleKeydown(e: KeyboardEvent) {
         return;
     }
 
-    const commandItem = commandForKeyboardEvent(e);
-    if (commandItem) {
-        e.preventDefault();
-        runCommandPaletteItem(commandItem)
-            .catch(err => console.error('Failed to run command hotkey:', err));
-        return;
-    }
-
     // Star rating chord (works in all modes)
     if (waitingForStar) {
         if (e.key === 'Escape') {
@@ -388,6 +336,25 @@ export function handleKeydown(e: KeyboardEvent) {
             }
             return;
         }
+    }
+
+    // Compare reserves bare 1/2 for choosing the winning side. Custom rating
+    // shortcuts still flow through the registry below.
+    if (
+        mode === 'compare'
+        && (e.key === '1' || e.key === '2')
+        && !e.metaKey && !e.ctrlKey && !e.altKey && !e.shiftKey
+    ) {
+        handleCompareKeys(e);
+        return;
+    }
+
+    const commandItem = commandForKeyboardEvent(e);
+    if (commandItem) {
+        e.preventDefault();
+        runCommandPaletteItem(commandItem)
+            .catch(err => console.error('Failed to run command hotkey:', err));
+        return;
     }
 
     // Shift+. (>) toggles zen mode; compare/export cycle through an image-only state too.
@@ -495,18 +462,6 @@ export function handleKeydown(e: KeyboardEvent) {
         return;
     }
 
-    // Delete: Backspace → trash, Cmd+Backspace → permanent delete
-    if (e.key === 'Backspace' && !e.metaKey) {
-        e.preventDefault();
-        requestTrashImages();
-        return;
-    }
-    if (e.key === 'Backspace' && e.metaKey) {
-        e.preventDefault();
-        window.dispatchEvent(new CustomEvent('delete-focused-image'));
-        return;
-    }
-
     switch (mode) {
         case 'grid':
             handleGridKeys(e);
@@ -532,16 +487,6 @@ function handleGridKeys(e: KeyboardEvent) {
     const visibleRows = Math.max(1, Math.floor(
         (document.querySelector('.grid-container')?.clientHeight ?? 600) / (get(thumbnailSize) + get(gridGap))
     ));
-
-    // Direct 1-5 rating in grid (without Cmd)
-    if (!e.metaKey && !e.ctrlKey && !e.altKey) {
-        const n = parseInt(e.key);
-        if (n >= 1 && n <= 5) {
-            e.preventDefault();
-            handleStarRating(n);
-            return;
-        }
-    }
 
     switch (e.key) {
         case 'h':
@@ -576,22 +521,6 @@ function handleGridKeys(e: KeyboardEvent) {
             e.preventDefault();
             waitingForStar = true;
             statusHint.set('Rate: press 1-5');
-            break;
-        case '0':
-            e.preventDefault();
-            handleStarRating(0);
-            break;
-        case 'a':
-            e.preventDefault();
-            handleDecision('accept');
-            break;
-        case 'x':
-            e.preventDefault();
-            handleDecision('reject');
-            break;
-        case 'u':
-            e.preventDefault();
-            handleDecision('undecided');
             break;
         case '+':
         case '=':
@@ -778,15 +707,6 @@ function compareSwapFocusedImage(direction: 1 | -1) {
 }
 
 function handleCanvasKeys(e: KeyboardEvent) {
-    if (!e.metaKey && !e.ctrlKey && !e.altKey) {
-        const n = parseInt(e.key);
-        if (n >= 1 && n <= 5) {
-            e.preventDefault();
-            handleStarRating(n);
-            return;
-        }
-    }
-
     switch (e.key) {
         case 'h':
         case 'ArrowLeft':
@@ -820,22 +740,6 @@ function handleCanvasKeys(e: KeyboardEvent) {
             e.preventDefault();
             waitingForStar = true;
             statusHint.set('Rate: press 1-5');
-            break;
-        case '0':
-            e.preventDefault();
-            handleStarRating(0);
-            break;
-        case 'a':
-            e.preventDefault();
-            handleDecision('accept');
-            break;
-        case 'x':
-            e.preventDefault();
-            handleDecision('reject');
-            break;
-        case 'u':
-            e.preventDefault();
-            handleDecision('undecided');
             break;
         case 'Enter':
             e.preventDefault();
@@ -890,26 +794,10 @@ function handleCompareKeys(e: KeyboardEvent) {
             e.preventDefault();
             handleDecision('accept', getCompareActiveIndex());
             break;
-        case 'x':
-            e.preventDefault();
-            handleDecision('reject', getCompareActiveIndex());
-            break;
-        case 'a':
-            e.preventDefault();
-            handleDecision('accept', getCompareActiveIndex());
-            break;
         case 's':
             e.preventDefault();
             waitingForStar = true;
             statusHint.set('Rate: press 1-5');
-            break;
-        case '0':
-            e.preventDefault();
-            handleStarRating(0, getCompareActiveIndex());
-            break;
-        case 'u':
-            e.preventDefault();
-            handleDecision('undecided', getCompareActiveIndex());
             break;
         case 'Escape':
             e.preventDefault();
@@ -919,16 +807,6 @@ function handleCompareKeys(e: KeyboardEvent) {
 }
 
 function handleLoupeKeys(e: KeyboardEvent) {
-    // Direct 1-5 rating in loupe (no chord needed)
-    if (!e.metaKey && !e.ctrlKey && !e.altKey) {
-        const n = parseInt(e.key);
-        if (n >= 1 && n <= 5) {
-            e.preventDefault();
-            handleStarRating(n);
-            return;
-        }
-    }
-
     if (e.key === '[') {
         e.preventDefault();
         const img = get(focusedImage);
@@ -1000,22 +878,6 @@ function handleLoupeKeys(e: KeyboardEvent) {
             e.preventDefault();
             waitingForStar = true;
             statusHint.set('Rate: press 1-5');
-            break;
-        case '0':
-            e.preventDefault();
-            handleStarRating(0);
-            break;
-        case 'a':
-            e.preventDefault();
-            handleDecision('accept');
-            break;
-        case 'x':
-            e.preventDefault();
-            handleDecision('reject');
-            break;
-        case 'u':
-            e.preventDefault();
-            handleDecision('undecided');
             break;
         case 'Escape':
             e.preventDefault();

--- a/src/lib/trash-safety-contract.test.ts
+++ b/src/lib/trash-safety-contract.test.ts
@@ -16,7 +16,8 @@ describe('shared destructive-action safety contract', () => {
         expect(contextMenu).toContain('requestTrashImages(targetIds)');
         expect(menu).toContain('requestTrashImages(ids)');
         expect(palette).toContain('run: () => requestTrashImages()');
-        expect(keys).toContain('requestTrashImages()');
+        expect(keys).toContain('const commandItem = commandForKeyboardEvent(e);');
+        expect(keys).toContain('runCommandPaletteItem(commandItem)');
         expect(page).toContain('window.addEventListener(TRASH_IMAGES_REQUESTED_EVENT, handleTrashRequest)');
         expect(page).toContain('await trashImagesDetailed(ids)');
         expect(page).toContain('pendingTrashProposal = { proposalId, approvedImageIds: [...approvedImageIds] }');

--- a/tests/e2e/smoke.py
+++ b/tests/e2e/smoke.py
@@ -1050,14 +1050,26 @@ def test_context_menu(page: Page) -> None:
 
     expect(menu).to_contain_text("Rate")
     expect(menu).to_contain_text("Copy")
+    expect(menu.locator('[data-shortcut-for="image.decision.accept"]')).to_have_text("A")
+    expect(menu.locator('[data-shortcut-for="image.decision.reject"]')).to_have_text("X")
+    expect(menu.locator('[data-shortcut-for="image.trash"]')).to_have_text("Backspace")
     menu.get_by_role("menuitem").first.focus()
     expect(menu.get_by_role("menuitem").first).to_be_focused()
 
     menu.locator('button[data-submenu-key="rate"]').hover()
     expect(menu.locator(".submenu").first).to_be_visible()
+    expect(menu.locator('[data-shortcut-for="image.rating.3"]')).to_have_text("3")
 
     # Menu-local Escape closes the submenu first; the capture fallback must not
     # collapse the entire menu while focus is inside it.
+    page.keyboard.press("Escape")
+    expect(menu).to_be_visible()
+    expect(menu.locator(".submenu")).to_have_count(0)
+
+    menu.locator('button[data-submenu-key="copy"]').hover()
+    expect(menu.locator(".submenu").first).to_be_visible()
+    expect(menu.locator('[data-shortcut-for="image.copy"]')).to_have_text("Cmd+C")
+    expect(menu.locator("[data-shortcut-for='image.copy']").locator("..")).to_contain_text("Copy Image")
     page.keyboard.press("Escape")
     expect(menu).to_be_visible()
     expect(menu.locator(".submenu")).to_have_count(0)


### PR DESCRIPTION
## Summary
- render registry-backed keyboard shortcut hints in the image context menu, including custom overrides
- centralize active-image targeting and copy behavior while preserving Compare winner keys, rating chords, and Grid selection undo
- make menu-local shortcuts act on the explicit context image/selection and keep Copy Image behavior aligned with its hint

## Verification
- `npm run preflight -- full` — 1,309 frontend tests; 867 Rust tests passed, 3 ignored; fmt/clippy/check passed
- focused shortcut suites — 47/47 passed
- Spec and Standards reviews — PASS
- manual E2E: S27 context-menu scenario passed, including shortcut hints; the wider suite still has unrelated current-main mock/assertion failures in rejected visibility, embedding copy, Trash mock response, folder rename mock, and AI Settings

Beads: imageview-10s0.4