### PR TITLE
fix: add safe undo hint after Trash

### DIFF
--- a/src/lib/trash-safety-contract.test.ts
+++ b/src/lib/trash-safety-contract.test.ts
@@ -20,6 +20,8 @@ describe('shared destructive-action safety contract', () => {
         expect(keys).toContain('runCommandPaletteItem(commandItem)');
         expect(page).toContain('window.addEventListener(TRASH_IMAGES_REQUESTED_EVENT, handleTrashRequest)');
         expect(page).toContain('await trashImagesDetailed(ids)');
+        expect(page).toContain("label: 'Undo in Action History'");
+        expect(page).toContain('onclick: () => undoHistoryOpen.set(true)');
         expect(page).toContain('pendingTrashProposal = { proposalId, approvedImageIds: [...approvedImageIds] }');
         expect(page).toContain('requestTrashImages(approvedImageIds)');
         expect(contextMenu).not.toContain('trashImages(');

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -38,7 +38,7 @@
     import GenerationResultsStrip from '$lib/components/GenerationResultsStrip.svelte';
     import PreviewDisplay from '$lib/components/PreviewDisplay.svelte';
     import { handleKeydown } from '$lib/keys';
-    import { images, focusedIndex, focusedImage, viewMode, sidebarVisible, zenMode, minSizeFilter, showToast, settingsOpen, aboutOpen, agentSkillsOpen, applePhotosCatalogOpen, searchOpen, showMissing, showRejected, smartCollections, activeSmartCollection, activeFolder, activeCollection, activeDetectedClass, staticPublishingEnabled, clientToolsEnabled, voiceDictationEnabled, pluginsEnabled, selectedIds, activeCanvas, activeSession, collections, windowLabel, agentPanelPinned, agentPanelVisible, agentVisualLevel, activeAgentProposalId, activeAgentSelectionPresetId, cycleAgentVisualLevel } from '$lib/stores';
+    import { images, focusedIndex, focusedImage, viewMode, sidebarVisible, zenMode, minSizeFilter, showToast, settingsOpen, aboutOpen, agentSkillsOpen, applePhotosCatalogOpen, searchOpen, showMissing, showRejected, smartCollections, activeSmartCollection, activeFolder, activeCollection, activeDetectedClass, staticPublishingEnabled, clientToolsEnabled, voiceDictationEnabled, pluginsEnabled, selectedIds, activeCanvas, activeSession, collections, windowLabel, agentPanelPinned, agentPanelVisible, agentVisualLevel, activeAgentProposalId, activeAgentSelectionPresetId, undoHistoryOpen, cycleAgentVisualLevel } from '$lib/stores';
     import { trashImagesDetailed, deleteImagesPermanently, getAppSetting, setAppSetting, checkLibraryHealth, regenerateThumbnailsByIds, listCollections, listSmartCollections, updatePreviewState, captureAgentWindowSnapshot, completeAgentViewSnapshot, failAgentViewSnapshot, createActionProposal, listActionProposals, applyActionProposal, dismissActionProposal, listAgentSelectionPresets, upsertAgentSelectionPreset, runClaudeAgentChatTurn, cancelClaudeAgentChatTurn, undo, type AgentActionProposal, type AgentChatImageContext, type AgentSelectionPreset, type AgentVisualLevel, type ClaudeAgentStreamEvent, type ImageWithFile, type PreviewState } from '$lib/api';
     import { initDeepLink } from '$lib/deeplink';
     import { initMenu } from '$lib/menu';
@@ -212,6 +212,10 @@
                     detail,
                     type: result.failed > 0 || warning ? 'warning' : 'info',
                     duration: result.failed > 0 || warning ? 8000 : 5000,
+                    actions: [{
+                        label: 'Undo in Action History',
+                        onclick: () => undoHistoryOpen.set(true),
+                    }],
                 });
             }
             invalidateImageCache();


### PR DESCRIPTION
## Summary
- keep multi-image context-menu Trash on the shared confirmation/suppression controller
- add an `Undo in Action History` action to ordinary successful Trash toasts
- open the durable Action History rather than undoing a potentially newer unrelated action

## Verification
- TDD: contract test failed before the affordance and passed after
- `npm run preflight -- quick` — 1,309 frontend tests passed
- pre-push full gate — 1,309 frontend tests; 867 Rust tests passed, 3 ignored; fmt/clippy/check passed
- independent Spec and Standards reviews — PASS

Beads: imageview-10s0.5