### PR TITLE
fix: make embedding clusters keyboard accessible

### DIFF
--- a/src/lib/components/EmbeddingExplorer.svelte
+++ b/src/lib/components/EmbeddingExplorer.svelte
@@ -2587,30 +2587,26 @@
         {#if clusters.length > 0}
             <div class="panel-section">
                 <div class="section-header">CLUSTERS</div>
-                <!-- svelte-ignore a11y_click_events_have_key_events -->
-                <!-- svelte-ignore a11y_no_static_element_interactions -->
-                <div class="cluster-item all" class:active={highlightedCluster === null} onclick={() => { highlightedCluster = null; activeZLayerKey = null; fitView(); requestDraw(); saveViewState(); }}>
+                <button type="button" class="cluster-item all" class:active={highlightedCluster === null} aria-pressed={highlightedCluster === null} onclick={() => { highlightedCluster = null; activeZLayerKey = null; fitView(); requestDraw(); saveViewState(); }}>
                     <span class="cluster-dot" style="background: var(--text-secondary)"></span>
                     All Images
                     <span class="cluster-count">({points.length})</span>
-                </div>
+                </button>
                 {#each clusters as cluster}
-                    <!-- svelte-ignore a11y_click_events_have_key_events -->
-                    <!-- svelte-ignore a11y_no_static_element_interactions -->
-                    <div class="cluster-item" class:active={highlightedCluster === cluster.id} onclick={() => focusCluster(cluster.id)}>
-                        <div class="cluster-info-row">
+                    <button type="button" class="cluster-item" class:active={highlightedCluster === cluster.id} aria-pressed={highlightedCluster === cluster.id} onclick={() => focusCluster(cluster.id)}>
+                        <span class="cluster-info-row">
                             <span class="cluster-dot" style="background: {cluster.color}"></span>
                             <span class="cluster-name">{cluster.label}</span>
                             <span class="cluster-count">({cluster.count})</span>
-                        </div>
+                        </span>
                         {#if cluster.previewPaths.length > 0}
-                            <div class="cluster-previews">
+                            <span class="cluster-previews">
                                 {#each cluster.previewPaths.slice(0, 4) as preview}
                                     <img src={convertFileSrc(preview)} class="cluster-thumb" alt="" />
                                 {/each}
-                            </div>
+                            </span>
                         {/if}
-                    </div>
+                    </button>
                 {/each}
             </div>
         {/if}
@@ -3156,10 +3152,15 @@
     .cluster-item {
         display: flex;
         flex-direction: column;
+        width: 100%;
         gap: 4px;
         font-size: 11px;
+        font-family: inherit;
+        text-align: left;
         padding: 5px 4px;
         color: var(--text);
+        background: transparent;
+        border: 0;
         cursor: pointer;
         border-radius: var(--radius);
         transition: background 0.15s;

--- a/src/lib/components/embedding-explorer-scope.behavior.test.ts
+++ b/src/lib/components/embedding-explorer-scope.behavior.test.ts
@@ -715,6 +715,25 @@ describe('Embedding Explorer library scope', () => {
         ]);
     });
 
+    it('lets keyboard users activate cluster filters and return to all images', async () => {
+        const user = userEvent.setup();
+        render(EmbeddingExplorer);
+
+        const clusterButton = await screen.findByRole('button', { name: /Cluster 1.*2/ });
+        clusterButton.focus();
+        await user.keyboard('{Enter}');
+        expect(clusterButton).toHaveClass('active');
+        expect(clusterButton).toHaveAttribute('aria-pressed', 'true');
+
+        const allImagesButton = screen.getByRole('button', { name: /All Images.*2/ });
+        allImagesButton.focus();
+        await user.keyboard(' ');
+        expect(allImagesButton).toHaveClass('active');
+        expect(allImagesButton).toHaveAttribute('aria-pressed', 'true');
+        expect(clusterButton).toHaveAttribute('aria-pressed', 'false');
+        expect(clusterButton).not.toHaveClass('active');
+    });
+
     it('renders the projection before naming completes and ignores a stale provider label', async () => {
         const user = userEvent.setup();
         let resolveOldName!: (value: Array<{ cluster_id: number; label: string; source: string }>) => void;


### PR DESCRIPTION
## Summary
- replace mouse-only cluster filter divs with semantic buttons
- preserve the existing layout while enabling native Enter/Space activation and visible focus
- expose the selected filter with `aria-pressed` and remove the cluster-specific a11y suppressions

## Verification
- TDD: rendered role/keyboard test failed before the semantic controls and passed after
- focused Embedding Explorer suite — 19/19 passed
- `npm run preflight -- quick` — 1,310 frontend tests passed
- pre-push full gate — 1,310 frontend tests; 867 Rust tests passed, 3 ignored; fmt/clippy/check passed
- independent Spec and Standards reviews — PASS

Beads: imageview-xgjq.4