### PR TITLE
Expose Agent Skills onboarding

### DIFF
--- a/src/lib/command-palette.test.ts
+++ b/src/lib/command-palette.test.ts
@@ -32,6 +32,7 @@ import {
     activeSmartCollection,
     agentPanelPinned,
     agentPanelVisible,
+    agentSkillsOpen,
     agentVisualLevel,
     collectMode,
     collectModeTarget,
@@ -369,6 +370,20 @@ describe('command palette helpers', () => {
         items.find(i => i.id === 'agent.toggle-panel')?.run();
         expect(get(agentPanelVisible)).toBe(true);
         expect(get(agentPanelPinned)).toBe(true);
+    });
+
+    it('opens the Agent Skills guide from the command palette', () => {
+        resetCommandContext();
+        agentSkillsOpen.set(false);
+        const command = getCommandPaletteItems('commands')
+            .find(item => item.id === 'agent.install-skills');
+
+        expect(command).toMatchObject({
+            title: 'Install Agent Skills',
+            category: 'Agent',
+        });
+        command?.run();
+        expect(get(agentSkillsOpen)).toBe(true);
     });
 
     it('shows Publish View as a command only when a plugin registers the publish tab', () => {

--- a/src/lib/command-palette.ts
+++ b/src/lib/command-palette.ts
@@ -8,6 +8,7 @@ import {
     activeSmartCollection,
     agentPanelPinned,
     agentPanelVisible,
+    agentSkillsOpen,
     agentVisualLevel,
     collectMode,
     collectModeTarget,
@@ -779,6 +780,15 @@ function commandItems(): CommandPaletteItem[] {
             kind: 'command',
             keywords: ['fullscreen', 'focus', 'immersive'],
             run: () => zenMode.update(value => !value),
+        },
+        {
+            id: 'agent.install-skills',
+            title: 'Install Agent Skills',
+            subtitle: 'Open the Cull skill and agent setup guide',
+            category: 'Agent',
+            kind: 'command',
+            keywords: ['agent', 'skill', 'install', 'setup', 'onboarding', 'mcp', 'claude', 'codex'],
+            run: () => agentSkillsOpen.set(true),
         },
         {
             id: 'agent.toggle-panel',

--- a/src/lib/components/AgentAccessSettings.svelte
+++ b/src/lib/components/AgentAccessSettings.svelte
@@ -2,7 +2,7 @@
     import { onMount } from 'svelte';
     import { createMcpToken, getAppSetting, listMcpTokens, revokeMcpToken, rotateMcpToken, setAppSetting, type McpToken } from '$lib/api';
     import { MCP_CONFIG_SNIPPET } from '$lib/mcp-config';
-    import { showToast } from '$lib/stores';
+    import { agentSkillsOpen, showToast } from '$lib/stores';
     import { expiryState, relativeExpiry } from '$lib/token-expiry';
 
     const SKILL_SOURCE = 'https://github.com/glebis/claude-skills/blob/main/cull/SKILL.md';
@@ -135,7 +135,10 @@
         {/each}
     </div>
     <div class="copy-box"><code>{selectedMethod.copy}</code><button aria-label={`Copy ${selectedMethod.label} installation instructions`} onclick={() => copy(selectedMethod.copy, 'Installation instructions')}>Copy</button></div>
-    <a href={SKILL_SOURCE} target="_blank" rel="noreferrer">View SKILL.md source ↗</a>
+    <div class="skill-links">
+        <button onclick={() => agentSkillsOpen.set(true)}>Open Agent Skills guide</button>
+        <a href={SKILL_SOURCE} target="_blank" rel="noreferrer">View SKILL.md source ↗</a>
+    </div>
 </section>
 
 <section class="settings-section">
@@ -191,6 +194,7 @@
     button.primary { color: var(--blue); }
     button.danger { color: var(--red); }
     .copy-box { display: flex; align-items: stretch; gap: 8px; margin-bottom: 8px; }
+    .skill-links { display: flex; align-items: center; gap: 8px; }
     code, pre { flex: 1; min-width: 0; margin: 0; padding: 10px; overflow: auto; white-space: pre-wrap; overflow-wrap: anywhere; background: var(--bg); border: 1px solid var(--border); border-radius: var(--radius); color: var(--text); font: 10px/1.5 var(--font); }
     a { color: var(--blue); font-size: 10px; }
     .setting-row, .token-row { display: flex; align-items: center; justify-content: space-between; gap: 12px; color: var(--text); font-size: 12px; }

--- a/src/lib/components/agent-access-settings.behavior.test.ts
+++ b/src/lib/components/agent-access-settings.behavior.test.ts
@@ -3,8 +3,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import '@testing-library/jest-dom/vitest';
 import { cleanup, render, screen, waitFor, within } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
+import { get } from 'svelte/store';
 import AgentAccessSettings from './AgentAccessSettings.svelte';
 import { createMcpToken, getAppSetting, listMcpTokens, setAppSetting } from '$lib/api';
+import { agentSkillsOpen } from '$lib/stores';
 
 vi.mock('$lib/api', () => ({
     createMcpToken: vi.fn(),
@@ -24,6 +26,7 @@ beforeEach(() => {
         return null;
     });
     vi.mocked(setAppSetting).mockResolvedValue(undefined);
+    agentSkillsOpen.set(false);
 });
 
 async function renderedPortInput(): Promise<HTMLInputElement> {
@@ -164,5 +167,13 @@ describe('Agent Access installation and token accessibility', () => {
 
         expect(await screen.findByText(/Start with the Cull skill and CLI; MCP is not required\./)).toBeVisible();
         expect(screen.getByText(/After installation, start a new agent turn or session if the skill is not discovered immediately\./)).toBeVisible();
+    });
+
+    it('cross-links to the Agent Skills guide', async () => {
+        const user = userEvent.setup();
+        render(AgentAccessSettings);
+
+        await user.click(await screen.findByRole('button', { name: 'Open Agent Skills guide' }));
+        expect(get(agentSkillsOpen)).toBe(true);
     });
 });


### PR DESCRIPTION
## Summary
- add an Install Agent Skills command to the command palette
- cross-link Agent Access Settings to the existing Agent Skills guide
- cover both entry points with behavior tests

## Verification
- npm run preflight -- quick
- npm test -- --run (179 files, 1312 tests)
- full pre-push gate (fmt, clippy, 870 Rust lib tests / 3 ignored)
- independent Spec review: PASS
- independent Standards review: PASS

Tracks imageview-9k1u.10.