### PR TITLE
Humanize agent failure messages

### DIFF
--- a/src/lib/agent-error-copy.test.ts
+++ b/src/lib/agent-error-copy.test.ts
@@ -1,0 +1,37 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { agentFailureCopy } from './agent-error-copy';
+
+describe('agent failure copy', () => {
+    it.each([
+        ['API key is not configured for anthropic', 'AI access is not configured', 'Sign in to Claude Code or configure the required provider, then try again.'],
+        ['maximum budget exceeded', 'Agent budget reached', 'Reduce the selection or shorten the instruction, then try again.'],
+        ['request timed out after 120 seconds', 'Agent request timed out', 'Try again with fewer images or a shorter instruction.'],
+        ['401 Unauthorized: invalid API key sk-secret', 'Claude authentication failed', 'Sign in to Claude Code again, then retry the request.'],
+    ])('maps %s to actionable copy', (raw, title, detail) => {
+        const result = agentFailureCopy(raw);
+
+        expect(result).toEqual({ title, detail });
+        expect(`${result.title} ${result.detail}`).not.toContain(raw);
+    });
+
+    it('uses a safe fallback instead of exposing an unknown raw error', () => {
+        const raw = 'SDKError stack trace at internal/runner.ts:42';
+
+        expect(agentFailureCopy(new Error(raw))).toEqual({
+            title: 'Agent request failed',
+            detail: 'Try again. If the problem continues, check Agent Access Settings.',
+        });
+    });
+
+    it('routes the toast and activity log through the shared copy mapper', () => {
+        const page = readFileSync(join(process.cwd(), 'src/routes/+page.svelte'), 'utf8');
+        const dock = readFileSync(join(process.cwd(), 'src/lib/components/AgentProposalDock.svelte'), 'utf8');
+
+        expect(page).toContain('agentFailureCopy(e)');
+        expect(page).not.toContain("showToast('Claude agent failed', { detail: String(e)");
+        expect(dock).toContain('agentActivityMessage(event)');
+        expect(dock).not.toContain('<span>{event.message}</span>');
+    });
+});

--- a/src/lib/agent-error-copy.ts
+++ b/src/lib/agent-error-copy.ts
@@ -1,0 +1,57 @@
+export interface AgentFailureCopy {
+    title: string;
+    detail: string;
+}
+
+function errorText(error: unknown): string {
+    if (error instanceof Error) return error.message;
+    if (typeof error === 'string') return error;
+    return String(error ?? '');
+}
+
+export function agentFailureCopy(error: unknown): AgentFailureCopy {
+    const normalized = errorText(error).toLowerCase();
+
+    if (/(?:api key|credential).*(?:missing|not (?:set|configured|found|available|provided))|(?:missing|no).*(?:api key|credential)/.test(normalized)) {
+        return {
+            title: 'AI access is not configured',
+            detail: 'Sign in to Claude Code or configure the required provider, then try again.',
+        };
+    }
+
+    if (/(?:budget|spending limit|cost limit).*(?:exceed|reached|limit)|max(?:imum)?[_ ]?budget/.test(normalized)) {
+        return {
+            title: 'Agent budget reached',
+            detail: 'Reduce the selection or shorten the instruction, then try again.',
+        };
+    }
+
+    if (/(?:timed? out|timeout|deadline exceeded)/.test(normalized)) {
+        return {
+            title: 'Agent request timed out',
+            detail: 'Try again with fewer images or a shorter instruction.',
+        };
+    }
+
+    if (/(?:unauthori[sz]ed|forbidden|authentication|auth failed|invalid (?:api )?key|\b40[13]\b)/.test(normalized)) {
+        return {
+            title: 'Claude authentication failed',
+            detail: 'Sign in to Claude Code again, then retry the request.',
+        };
+    }
+
+    return {
+        title: 'Agent request failed',
+        detail: 'Try again. If the problem continues, check Agent Access Settings.',
+    };
+}
+
+export function agentActivityMessage(event: { message: string; is_error: boolean }): string {
+    return event.is_error ? agentFailureCopy(event.message).detail : event.message;
+}
+
+export function agentActivityPhase(phase: string, isError: boolean): string {
+    if (isError) return 'Error';
+    const label = phase.replace(/^sdk_/, '').replaceAll('_', ' ').trim();
+    return label ? label[0].toUpperCase() + label.slice(1) : 'Activity';
+}

--- a/src/lib/components/AgentProposalDock.svelte
+++ b/src/lib/components/AgentProposalDock.svelte
@@ -8,6 +8,7 @@
         ImageWithFile,
     } from '$lib/api';
     import { estimateAgentBudget } from '$lib/agent-token-estimate';
+    import { agentActivityMessage, agentActivityPhase } from '$lib/agent-error-copy';
     import {
         parseAgentProposalSourceContext,
         proposalActorLabel,
@@ -111,7 +112,9 @@
         streamEvents.slice().reverse().find(event => ['sdk_assistant', 'sdk_stream'].includes(event.phase) && event.message) ?? null,
     );
     const runStatus = $derived(statusForEvent(latestRunEvent, busy));
-    const assistantMessage = $derived(lastMessage ?? (busy ? latestAssistantEvent?.message ?? null : latestRunEvent?.is_error ? latestRunEvent.message : null));
+    const assistantMessage = $derived(lastMessage ?? (busy
+        ? latestAssistantEvent?.message ?? null
+        : latestRunEvent?.is_error ? agentActivityMessage(latestRunEvent) : null));
     const showChatThread = $derived(Boolean(lastInstruction || assistantMessage || busy));
     const displayInputTokens = $derived(activeProposal?.estimated_input_tokens ?? draftEstimate.inputTokens);
     const displayCostEur = $derived(activeProposal?.estimated_cost_eur ?? draftEstimate.costEur);
@@ -203,7 +206,7 @@
     }
 
     function statusForEvent(event: ClaudeAgentStreamEvent | null, isBusy: boolean) {
-        if (!isBusy && event?.is_error) return 'Could not complete the request';
+        if (event?.is_error) return agentActivityMessage(event);
         if (!isBusy) return 'Ready';
         if (!event) return 'Thinking';
         if (event.message && !['sdk_init', 'sdk_status'].includes(event.phase)) return event.message;
@@ -352,8 +355,8 @@
                             <ol>
                                 {#each streamEvents.slice(-12) as event}
                                     <li class:error={event.is_error}>
-                                        <strong>{event.phase.replace(/^sdk_/, '')}</strong>
-                                        <span>{event.message}</span>
+                                        <strong>{agentActivityPhase(event.phase, event.is_error)}</strong>
+                                        <span>{agentActivityMessage(event)}</span>
                                     </li>
                                 {/each}
                             </ol>

--- a/src/lib/components/agent-proposal-dock-errors.behavior.test.ts
+++ b/src/lib/components/agent-proposal-dock-errors.behavior.test.ts
@@ -1,0 +1,71 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen } from '@testing-library/svelte';
+import '@testing-library/jest-dom/vitest';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it } from 'vitest';
+import type { ClaudeAgentStreamEvent } from '$lib/api';
+import AgentProposalDock from './AgentProposalDock.svelte';
+
+afterEach(cleanup);
+
+function errorEvent(sequence: number, message: string): ClaudeAgentStreamEvent {
+    return {
+        request_id: 'request-1',
+        sequence,
+        phase: 'sdk_error',
+        message,
+        details: null,
+        is_final: sequence === 4,
+        is_error: true,
+    };
+}
+
+describe('AgentProposalDock error copy', () => {
+    it('shows actionable failure messages without raw SDK details', async () => {
+        const user = userEvent.setup();
+        const rawMessages = [
+            'API key is not configured for anthropic',
+            'maximum budget exceeded',
+            'request timed out after 120 seconds',
+            '401 Unauthorized: invalid API key sk-secret',
+        ];
+
+        render(AgentProposalDock, {
+            proposals: [],
+            presets: [],
+            selectedCount: 0,
+            pinned: false,
+            visible: true,
+            busy: false,
+            streamEvents: rawMessages.map((message, index) => errorEvent(index + 1, message)),
+            visualLevel: 'text',
+            activePresetId: null,
+        });
+        await user.click(screen.getByText('Activity'));
+
+        expect(screen.getByText('Sign in to Claude Code or configure the required provider, then try again.')).toBeVisible();
+        expect(screen.getByText('Reduce the selection or shorten the instruction, then try again.')).toBeVisible();
+        expect(screen.getByText('Try again with fewer images or a shorter instruction.')).toBeVisible();
+        expect(screen.getAllByText('Sign in to Claude Code again, then retry the request.')).not.toHaveLength(0);
+        for (const raw of rawMessages) expect(screen.queryByText(raw)).not.toBeInTheDocument();
+    });
+
+    it('does not expose a final raw error while the request is still busy', () => {
+        const raw = '401 Unauthorized: invalid API key sk-secret';
+
+        render(AgentProposalDock, {
+            proposals: [],
+            presets: [],
+            selectedCount: 0,
+            pinned: false,
+            visible: true,
+            busy: true,
+            streamEvents: [errorEvent(1, raw)],
+            visualLevel: 'text',
+            activePresetId: null,
+        });
+
+        expect(screen.getAllByText('Sign in to Claude Code again, then retry the request.')[0]).toBeVisible();
+        expect(screen.queryByText(raw)).not.toBeInTheDocument();
+    });
+});

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -72,6 +72,7 @@
     import { proposalViewContextKey, type AgentProposalViewContext } from '$lib/agent-proposal-context';
     import { estimateAgentBudget } from '$lib/agent-token-estimate';
     import { effectiveAgentVisualLevel } from '$lib/agent-visual-context';
+    import { agentFailureCopy } from '$lib/agent-error-copy';
     import { listen } from '@tauri-apps/api/event';
     import { onMount } from 'svelte';
     import { requestTrashImages, resolveTrashRequestIds, TRASH_IMAGES_REQUESTED_EVENT, type TrashImagesRequestDetail } from '$lib/trash-actions';
@@ -753,7 +754,9 @@
                 lastAgentMessage = 'Request cancelled';
                 return;
             }
-            showToast('Claude agent failed', { detail: String(e), type: 'error', duration: 9000 });
+            const failure = agentFailureCopy(e);
+            lastAgentMessage = failure.detail;
+            showToast(failure.title, { detail: failure.detail, type: 'error', duration: 9000 });
         } finally {
             agentChatBusy = false;
             if (activeAgentRequestId === requestId) activeAgentRequestId = null;


### PR DESCRIPTION
## Summary
- map common agent failures to short actionable copy
- sanitize toast, chat, busy-state, and activity-log rendering
- add unit and rendered regressions for missing credentials, budget, timeout, auth, and unknown errors

## Verification
- 4 focused files / 18 tests
- npm run check (0 errors, 0 warnings)
- full pre-push gate: 181 frontend files / 1320 tests; 870 Rust lib tests / 3 ignored
- independent Spec review: PASS
- independent Standards review: PASS

Tracks imageview-9k1u.7.