### PR TITLE
Make multi-row database writes atomic

### DIFF
--- a/src-tauri/src/db_core/db.rs
+++ b/src-tauri/src/db_core/db.rs
@@ -1814,6 +1814,49 @@ mod tests {
     }
 
     #[test]
+    fn insert_image_rolls_back_when_media_asset_insert_fails() {
+        let db = test_db();
+        {
+            let conn = db.conn.lock();
+            conn.execute_batch(
+                "CREATE TRIGGER fail_media_asset_insert
+                 BEFORE INSERT ON media_assets
+                 BEGIN
+                     SELECT RAISE(ABORT, 'forced media asset failure');
+                 END;",
+            )
+            .unwrap();
+        }
+        let img = Image {
+            id: "image-rollback".to_string(),
+            sha256_hash: "hash-image-rollback".to_string(),
+            width: 16,
+            height: 16,
+            format: "png".to_string(),
+            file_size: 128,
+            created_at: "2026-01-01T00:00:00Z".to_string(),
+            imported_at: "2026-01-01T00:00:00Z".to_string(),
+            ai_prompt: None,
+            raw_metadata: None,
+        };
+
+        let error = db.insert_image(&img).unwrap_err();
+
+        assert!(error.to_string().contains("forced media asset failure"));
+        assert!(db.find_by_hash(&img.sha256_hash).unwrap().is_none());
+        let media_count: i64 = db
+            .conn
+            .lock()
+            .query_row(
+                "SELECT COUNT(*) FROM media_assets WHERE primary_image_id = ?1",
+                params![img.id],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(media_count, 0);
+    }
+
+    #[test]
     fn insert_pdf_image_creates_pdf_media_asset_row() {
         let db = test_db();
         let img = Image {
@@ -2040,6 +2083,21 @@ mod tests {
 
         db.remove_from_collection(&collection_id, "non-member")
             .unwrap();
+        assert!(db
+            .list_collection_images(&collection_id)
+            .unwrap()
+            .is_empty());
+    }
+
+    #[test]
+    fn add_to_collection_rolls_back_the_batch_when_a_membership_fails() {
+        let db = test_db();
+        let collection_id = db.create_collection("Atomic Batch").unwrap();
+        insert_test_image(&db, "member", "h-member");
+
+        let result = db.add_to_collection(&collection_id, &["member", "missing-image"]);
+
+        assert!(result.is_err());
         assert!(db
             .list_collection_images(&collection_id)
             .unwrap()

--- a/src-tauri/src/db_core/queries/collections.rs
+++ b/src-tauri/src/db_core/queries/collections.rs
@@ -79,18 +79,20 @@ impl Database {
     }
 
     pub fn add_to_collection(&self, collection_id: &str, image_ids: &[&str]) -> Result<()> {
-        let conn = self.conn.lock();
-        let max_pos: i64 = conn.query_row(
+        let mut conn = self.conn.lock();
+        let tx = conn.transaction()?;
+        let max_pos: i64 = tx.query_row(
             "SELECT COALESCE(MAX(position), -1) FROM collection_items WHERE collection_id = ?1",
             params![collection_id],
             |row| row.get(0),
         )?;
         for (i, id) in image_ids.iter().enumerate() {
-            conn.execute(
+            tx.execute(
                 "INSERT OR IGNORE INTO collection_items (collection_id, image_id, position) VALUES (?1, ?2, ?3)",
                 params![collection_id, id, max_pos + 1 + i as i64],
             )?;
         }
+        tx.commit()?;
         Ok(())
     }
 

--- a/src-tauri/src/db_core/queries/images.rs
+++ b/src-tauri/src/db_core/queries/images.rs
@@ -326,8 +326,9 @@ impl Database {
     }
 
     pub fn insert_image(&self, image: &Image) -> Result<()> {
-        let conn = self.conn.lock();
-        conn.execute(
+        let mut conn = self.conn.lock();
+        let tx = conn.transaction()?;
+        tx.execute(
             "INSERT OR IGNORE INTO images (id, sha256_hash, width, height, format, file_size, created_at, imported_at)
              VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
             params![image.id, image.sha256_hash, image.width, image.height,
@@ -350,7 +351,7 @@ impl Database {
             created_at: image.created_at.clone(),
             imported_at: image.imported_at.clone(),
         };
-        conn.execute(
+        tx.execute(
             "INSERT OR IGNORE INTO media_assets (id, media_type, primary_image_id, sha256_hash, format, file_size, page_count, title, created_at, imported_at)
              VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
             params![
@@ -366,6 +367,7 @@ impl Database {
                 media_asset.imported_at
             ],
         )?;
+        tx.commit()?;
         Ok(())
     }
 


### PR DESCRIPTION
## Summary
- wrap image and media-asset creation in one SQLite transaction
- make collection membership batches all-or-nothing
- add real failure-injection regressions for both rollback paths

## Verification
- red: media-asset abort left a stranded image row
- red: invalid second collection member left the first membership committed
- focused rollback tests: 4/4 passed
- full preflight: 181 frontend files / 1320 tests; 869 Rust library tests / 3 ignored; all Rust targets passed
- independent Spec review: PASS
- independent Standards review: PASS

Tracks imageview-tfee.9.