### PR TITLE
chore(deps): bump sha2 from 0.10 to 0.11

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -376,6 +376,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "block2"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -726,6 +735,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "const-random"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -864,6 +879,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "cssparser"
 version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -948,7 +972,7 @@ dependencies = [
  "schemars 1.2.1",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.11.0",
  "subtle",
  "tauri",
  "tauri-build",
@@ -1129,8 +1153,19 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "const-oid",
+ "crypto-common 0.2.2",
 ]
 
 [[package]]
@@ -2130,6 +2165,15 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -4787,7 +4831,18 @@ checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -5237,7 +5292,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "syn 2.0.117",
  "tauri-utils",
  "thiserror 2.0.18",
@@ -7115,7 +7170,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "raw-window-handle",
- "sha2",
+ "sha2 0.10.9",
  "soup3",
  "tao-macros",
  "thiserror 2.0.18",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -32,7 +32,7 @@ tauri-plugin-opener = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 rusqlite = { version = "0.40", features = ["bundled"] }
-sha2 = "0.10"
+sha2 = "0.11"
 image = { version = "0.25", default-features = false, features = ["jpeg", "png", "webp", "gif", "bmp", "tiff", "ico"] }
 walkdir = "2"
 chrono = { version = "0.4", features = ["serde"] }

--- a/src-tauri/src/db_core/embeddings.rs
+++ b/src-tauri/src/db_core/embeddings.rs
@@ -440,7 +440,7 @@ mod tests {
 
             assert_eq!(size, spec.expected_size_bytes, "{}", spec.model_id);
             assert_eq!(
-                format!("{:x}", hasher.finalize()),
+                hex::encode(hasher.finalize()),
                 spec.expected_sha256,
                 "{}",
                 spec.model_id

--- a/src-tauri/src/db_core/import.rs
+++ b/src-tauri/src/db_core/import.rs
@@ -408,7 +408,7 @@ fn create_image_record(
 fn compute_hash(data: &[u8]) -> String {
     let mut hasher = Sha256::new();
     hasher.update(data);
-    format!("{:x}", hasher.finalize())
+    hex::encode(hasher.finalize())
 }
 
 const DOCUMENT_PREVIEW_DIMENSION: u32 = 1200;
@@ -449,7 +449,7 @@ fn hash_file_cancellable(
         }
         hasher.update(&buf[..n]);
     }
-    Ok(format!("{:x}", hasher.finalize()))
+    Ok(hex::encode(hasher.finalize()))
 }
 
 fn read_file_cancellable(

--- a/src-tauri/src/services/clipboard_monitor.rs
+++ b/src-tauri/src/services/clipboard_monitor.rs
@@ -326,7 +326,7 @@ fn sha256_bytes(bytes: &[u8]) -> String {
     use sha2::{Digest, Sha256};
     let mut hasher = Sha256::new();
     hasher.update(bytes);
-    format!("{:x}", hasher.finalize())
+    hex::encode(hasher.finalize())
 }
 
 fn unique_capture_filename(

--- a/src-tauri/src/services/generation.rs
+++ b/src-tauri/src/services/generation.rs
@@ -731,7 +731,7 @@ fn save_image_bytes(
 
     let mut hasher = Sha256::new();
     hasher.update(&bytes);
-    let hash = format!("{:x}", hasher.finalize());
+    let hash = hex::encode(hasher.finalize());
 
     let img = image::open(&file_path).map_err(|e| format!("Image decode error: {}", e))?;
     let (width, height) = (img.width(), img.height());

--- a/src-tauri/src/services/model_download.rs
+++ b/src-tauri/src/services/model_download.rs
@@ -157,7 +157,7 @@ pub fn sha256_file(path: &Path) -> Result<String, String> {
         }
         hasher.update(&buffer[..read]);
     }
-    Ok(format!("{:x}", hasher.finalize()))
+    Ok(hex::encode(hasher.finalize()))
 }
 
 pub fn verify_model_file(

--- a/src-tauri/src/services/sessions.rs
+++ b/src-tauri/src/services/sessions.rs
@@ -23,10 +23,18 @@ pub fn sanitize_folder_name(name: &str) -> String {
 #[allow(dead_code)]
 pub fn compute_sha256(path: &Path) -> Result<String, ServiceError> {
     use sha2::{Digest, Sha256};
+    use std::io::Read;
     let mut file = std::fs::File::open(path)?;
     let mut hasher = Sha256::new();
-    std::io::copy(&mut file, &mut hasher)?;
-    Ok(format!("{:x}", hasher.finalize()))
+    let mut buffer = [0u8; 64 * 1024];
+    loop {
+        let read = file.read(&mut buffer)?;
+        if read == 0 {
+            break;
+        }
+        hasher.update(&buffer[..read]);
+    }
+    Ok(hex::encode(hasher.finalize()))
 }
 
 #[allow(dead_code)]


### PR DESCRIPTION
Supersedes #166, which could not be a plain version bump: `digest` 0.11 removes two APIs this codebase used.

## Changes

**`finalize()` no longer implements `LowerHex`** — it now returns `Array<u8, N>`, so `format!("{:x}", hasher.finalize())` fails to compile. Replaced with `hex::encode(...)` at all 7 sites. `hex` was already a dependency and this idiom was already the house style in `plugins/install.rs`, `plugins/loader.rs`, and `services/tokens.rs`. Output is identical lowercase hex, so **persisted hashes stay compatible** — import dedup keys, plugin integrity hashes, and API token hashes all continue to match.

**`Sha256` no longer implements `std::io::Write`** — broke `std::io::copy(&mut file, &mut hasher)` in `services::sessions::compute_sha256`. Replaced with the same 64 KiB read loop already used by `db_core::import::hash_file_cancellable` and `services::model_download::sha256_file`.

## Note on the lockfile

`tauri-codegen` still pins `sha2 ^0.10`, so `Cargo.lock` now carries both 0.10 and 0.11. That copy is build-time only (proc-macro dependency) and does not ship in the binary.

## Verification

- `cargo check --all-targets` — clean (only pre-existing `dead_code` warnings in `apple_photos`)
- `cargo test --lib` — 871 passed, 0 failed, 3 ignored

🤖 Generated with [Claude Code](https://claude.com/claude-code)