### PR TITLE
feat(cli): Settings toggle to install cull onto PATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,13 @@ Current high-level shape:
 
 ## Agent CLI
 
-Cull has an MCP-aligned headless CLI slice. Command names and JSON fields mirror the MCP tool model where possible:
+Cull has an MCP-aligned headless CLI slice. Command names and JSON fields mirror the MCP tool model where possible.
+
+The CLI is the same binary as the app, shipped inside the bundle. Getting `cull` onto your PATH:
+
+- **Homebrew** — `brew install --cask glebis/tap/cull` links it for you; nothing else to do.
+- **DMG install** — open Settings → General → Command line tool and switch it on. Cull symlinks itself into the first suitable directory on your PATH and tells you if that directory needs adding to your shell profile.
+- **By hand** — `ln -s /Applications/Cull.app/Contents/MacOS/cull ~/.local/bin/cull`
 
 ```bash
 cull ~/renders

--- a/package-lock.json
+++ b/package-lock.json
@@ -100,9 +100,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
       "os": [
@@ -115,9 +112,6 @@
       "integrity": "sha512-sVvPAUzRq+Am3+wNrFJ7URaWORu8t5hOu4vJnMhOeey66ZFFfzNwP0uz/7sTWjg+cRse/wG/hek34lZ0Gdu2+w==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
@@ -132,9 +126,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
       "os": [
@@ -147,9 +138,6 @@
       "integrity": "sha512-vM48p8GRM5N57+jPFdPj1ZS8Y770frJ1NTRecA06/GXtRANn7dOUVpvJbpu6fJBFF3BCacM1uVcBCMZh6wEMjw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
@@ -684,9 +672,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -704,9 +689,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -724,9 +706,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -744,9 +723,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -764,9 +740,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -784,9 +757,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2747,9 +2717,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2771,9 +2738,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2795,9 +2759,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2819,9 +2780,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -77,7 +77,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -88,7 +88,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1186,7 +1186,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1396,7 +1396,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1999,9 +1999,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.14"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2966,7 +2966,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4427,7 +4427,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4485,7 +4485,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4908,7 +4908,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5585,7 +5585,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6011,7 +6011,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6046,7 +6046,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6561,7 +6561,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/src-tauri/permissions/app-ui.toml
+++ b/src-tauri/permissions/app-ui.toml
@@ -1,9 +1,10 @@
 [[permission]]
 identifier = "app-ui"
-description = "Allows UI shell commands for window management, menu state, deep-link routing, and dictation controls."
+description = "Allows UI shell commands for window management, menu state, deep-link routing, dictation controls, and the CLI tool install toggle."
 commands.allow = [
   "apply_app_icon_variant",
   "capture_agent_window_snapshot",
+  "cli_tool_status",
   "complete_agent_view_snapshot",
   "complete_deep_link_navigation",
   "create_window",
@@ -28,4 +29,6 @@ commands.allow = [
   "stop_dictation",
   "update_preview_state",
   "update_menu_state",
+  "install_cli_tool",
+  "uninstall_cli_tool",
 ]

--- a/src-tauri/src/commands/cli_tool.rs
+++ b/src-tauri/src/commands/cli_tool.rs
@@ -1,0 +1,281 @@
+//! Install the `cull` CLI onto the user's PATH.
+//!
+//! The GUI app and the headless CLI are the same binary (see `cli/mod.rs`), which
+//! normally lives inside the bundle at `Cull.app/Contents/MacOS/cull`. This module
+//! creates a symlink to it from a directory that is already on the user's PATH, so
+//! the `cull ...` invocations in the README and docs work as written.
+//!
+//! Homebrew cask installs get this for free via the cask's `binary` stanza; this
+//! command exists for people who installed from the DMG.
+
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
+
+/// Name of the command as it should appear on PATH.
+pub const CLI_NAME: &str = "cull";
+
+/// Directories we are willing to install into, most-preferred first.
+///
+/// Deliberately a fixed list rather than a split of `env::var("PATH")`: a GUI app
+/// launched from Finder inherits launchd's environment, whose PATH is almost never
+/// the user's shell PATH. `$HOME` is substituted for a leading `~`.
+pub const CANDIDATE_DIRS: &[&str] = &[
+    "/opt/homebrew/bin", // Apple Silicon Homebrew — on PATH for brew users, user-writable
+    "/usr/local/bin",    // Intel Homebrew / classic; on PATH by default but often root-owned
+    "~/.local/bin",      // XDG-style user bin; no privileges needed, may not be on PATH
+    "~/bin",             // traditional; sourced by the default macOS zsh profile when present
+];
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CliToolStatus {
+    /// A symlink named `cull` exists in one of the candidate directories.
+    pub installed: bool,
+    /// Where that symlink lives, if installed.
+    pub link_path: Option<String>,
+    /// Where it currently points.
+    pub target_path: Option<String>,
+    /// Installed, but pointing at a different binary than the running one
+    /// (app moved, or a second copy of Cull installed). Offer a re-install.
+    pub stale: bool,
+    /// Directory `install_cli_tool` would use, if not installed.
+    pub candidate_dir: Option<String>,
+    /// Set when the chosen directory is not on the user's shell PATH; the UI shows
+    /// this line for the user to add to their shell profile.
+    pub path_hint: Option<String>,
+}
+
+/// Absolute, symlink-resolved path of the binary that is currently running.
+///
+/// Mirrors `lib.rs:178`, which uses `current_exe` to relaunch the same binary in
+/// tray mode. Resolving is important here: if the app was itself launched through
+/// a symlink we want to record the real bundle path, not the link.
+fn running_binary() -> Result<PathBuf, String> {
+    let exe = std::env::current_exe().map_err(|e| format!("Cannot locate Cull's binary: {e}"))?;
+    std::fs::canonicalize(&exe).map_err(|e| format!("Cannot resolve {}: {e}", exe.display()))
+}
+
+/// Expand a leading `~` against `$HOME`. Returns `None` if `$HOME` is unset.
+fn expand_home(dir: &str) -> Option<PathBuf> {
+    match dir.strip_prefix("~/") {
+        Some(rest) => std::env::var_os("HOME").map(|home| PathBuf::from(home).join(rest)),
+        None => Some(PathBuf::from(dir)),
+    }
+}
+
+/// True when `dir` appears as a component of `path_env` (a `:`-separated PATH).
+fn is_on_path(dir: &Path, path_env: &str) -> bool {
+    path_env
+        .split(':')
+        .filter(|entry| !entry.is_empty())
+        .any(|entry| expand_home(entry).is_some_and(|entry| entry == dir))
+}
+
+/// True when we can create files in `dir` without escalating privileges.
+/// A directory that does not exist yet counts as writable if we could create it
+/// (i.e. its parent is writable) — `install` will `create_dir_all` it.
+fn is_user_writable(dir: &Path) -> bool {
+    if dir.is_dir() {
+        return !std::fs::metadata(dir)
+            .map(|m| m.permissions().readonly())
+            .unwrap_or(true);
+    }
+    match dir.parent() {
+        Some(parent) => parent.is_dir() && is_user_writable(parent),
+        None => false,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// TODO(you): implement the install-directory policy.
+// ---------------------------------------------------------------------------
+
+/// Choose the directory to symlink `cull` into.
+///
+/// `path_env` is the user's *shell* PATH (the caller obtains it by asking the login
+/// shell, not from `env::var`). Every helper you need is above:
+/// `CANDIDATE_DIRS`, `expand_home`, `is_on_path`, `is_user_writable`.
+///
+/// Return the chosen directory plus a `path_hint`: `Some(line)` when the directory
+/// is NOT on `path_env` and the user must add it to their shell profile themselves,
+/// `None` when it is already on PATH and the command will just work.
+///
+/// The trade-off to encode: preferring a directory that's already on PATH gives a
+/// working `cull` with no follow-up, but those directories (`/usr/local/bin`) are
+/// often root-owned, and we have no admin prompt. Preferring a writable directory
+/// always succeeds but may leave the user with a symlink their shell can't see.
+/// Decide which failure you would rather hand a first-time user.
+fn resolve_install_dir(path_env: &str) -> Result<(PathBuf, Option<String>), String> {
+    let _ = (path_env, CANDIDATE_DIRS);
+    todo!("choose an install directory and build the PATH hint")
+}
+
+// ---------------------------------------------------------------------------
+
+/// The user's login-shell PATH.
+///
+/// `env::var("PATH")` inside a Finder-launched app returns launchd's PATH, which
+/// omits `/opt/homebrew/bin` and anything the user set in their profile. Asking the
+/// login shell is the only way to see what `cull` would actually resolve against.
+fn shell_path_env() -> String {
+    let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/zsh".to_string());
+    std::process::Command::new(&shell)
+        .args(["-lic", "printf %s \"$PATH\""])
+        .output()
+        .ok()
+        .filter(|out| out.status.success())
+        .map(|out| String::from_utf8_lossy(&out.stdout).trim().to_string())
+        .filter(|path| !path.is_empty())
+        .unwrap_or_else(|| std::env::var("PATH").unwrap_or_default())
+}
+
+/// Find an existing `cull` symlink we installed, in any candidate directory.
+fn existing_link() -> Option<(PathBuf, Option<PathBuf>)> {
+    for dir in CANDIDATE_DIRS {
+        let Some(link) = expand_home(dir).map(|dir| dir.join(CLI_NAME)) else {
+            continue;
+        };
+        let Ok(meta) = std::fs::symlink_metadata(&link) else {
+            continue;
+        };
+        if !meta.file_type().is_symlink() {
+            // A real file named `cull` that we did not create (e.g. a Homebrew
+            // cask binary, or another tool entirely). Report it, never replace it.
+            return Some((link, None));
+        }
+        let target = std::fs::read_link(&link).ok();
+        return Some((link, target));
+    }
+    None
+}
+
+#[tauri::command]
+pub async fn cli_tool_status() -> Result<CliToolStatus, String> {
+    let running = running_binary()?;
+    let path_env = shell_path_env();
+
+    if let Some((link, target)) = existing_link() {
+        let resolved = target.as_ref().and_then(|t| std::fs::canonicalize(t).ok());
+        let stale = resolved.as_deref() != Some(running.as_path());
+        return Ok(CliToolStatus {
+            installed: true,
+            link_path: Some(link.display().to_string()),
+            target_path: target.map(|t| t.display().to_string()),
+            stale,
+            candidate_dir: None,
+            path_hint: None,
+        });
+    }
+
+    let (dir, path_hint) = resolve_install_dir(&path_env)?;
+    Ok(CliToolStatus {
+        installed: false,
+        link_path: None,
+        target_path: None,
+        stale: false,
+        candidate_dir: Some(dir.display().to_string()),
+        path_hint,
+    })
+}
+
+#[tauri::command]
+pub async fn install_cli_tool() -> Result<CliToolStatus, String> {
+    #[cfg(not(unix))]
+    {
+        return Err("Installing the command line tool is only supported on macOS.".to_string());
+    }
+
+    #[cfg(unix)]
+    {
+        let running = running_binary()?;
+        let path_env = shell_path_env();
+        let (dir, path_hint) = resolve_install_dir(&path_env)?;
+        std::fs::create_dir_all(&dir)
+            .map_err(|e| format!("Cannot create {}: {e}", dir.display()))?;
+
+        let link = dir.join(CLI_NAME);
+        match std::fs::symlink_metadata(&link) {
+            Ok(meta) if meta.file_type().is_symlink() => {
+                // Ours (or a previous install pointing at a moved app) — replace it.
+                std::fs::remove_file(&link)
+                    .map_err(|e| format!("Cannot replace {}: {e}", link.display()))?;
+            }
+            Ok(_) => {
+                return Err(format!(
+                    "{} already exists and is not a symlink. Remove it first if you want Cull to manage it.",
+                    link.display()
+                ));
+            }
+            Err(_) => {}
+        }
+
+        std::os::unix::fs::symlink(&running, &link)
+            .map_err(|e| format!("Cannot link {}: {e}", link.display()))?;
+
+        Ok(CliToolStatus {
+            installed: true,
+            link_path: Some(link.display().to_string()),
+            target_path: Some(running.display().to_string()),
+            stale: false,
+            candidate_dir: None,
+            path_hint,
+        })
+    }
+}
+
+#[tauri::command]
+pub async fn uninstall_cli_tool() -> Result<CliToolStatus, String> {
+    match existing_link() {
+        Some((link, Some(_))) => {
+            std::fs::remove_file(&link)
+                .map_err(|e| format!("Cannot remove {}: {e}", link.display()))?;
+        }
+        Some((link, None)) => {
+            return Err(format!(
+                "{} is not a symlink Cull created; leaving it alone.",
+                link.display()
+            ));
+        }
+        None => {}
+    }
+    cli_tool_status().await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn expands_home_prefix_only() {
+        std::env::set_var("HOME", "/Users/test");
+        assert_eq!(
+            expand_home("~/.local/bin"),
+            Some(PathBuf::from("/Users/test/.local/bin"))
+        );
+        assert_eq!(
+            expand_home("/usr/local/bin"),
+            Some(PathBuf::from("/usr/local/bin"))
+        );
+    }
+
+    #[test]
+    fn detects_path_membership_through_tilde() {
+        std::env::set_var("HOME", "/Users/test");
+        let dir = PathBuf::from("/Users/test/.local/bin");
+        assert!(is_on_path(&dir, "/usr/bin:~/.local/bin:/bin"));
+        assert!(is_on_path(&dir, "/usr/bin:/Users/test/.local/bin"));
+        assert!(!is_on_path(&dir, "/usr/bin:/bin"));
+    }
+
+    #[test]
+    fn ignores_empty_path_entries() {
+        assert!(!is_on_path(&PathBuf::from("/usr/local/bin"), "::"));
+    }
+
+    #[test]
+    fn temp_dir_is_user_writable() {
+        let tmp = tempfile::tempdir().unwrap();
+        assert!(is_user_writable(tmp.path()));
+        // A not-yet-created child of a writable dir is installable.
+        assert!(is_user_writable(&tmp.path().join("bin")));
+    }
+}

--- a/src-tauri/src/commands/deeplink.rs
+++ b/src-tauri/src/commands/deeplink.rs
@@ -647,6 +647,9 @@ mod tests {
 
     #[test]
     fn builds_loupe_params_for_opened_file() {
+        if writable_home().is_none() {
+            return;
+        }
         let dir = home_tempdir("cull_open_file_");
         let image = dir.path().join("image.png");
         std::fs::write(&image, b"not a real png").unwrap();
@@ -661,6 +664,9 @@ mod tests {
 
     #[test]
     fn launch_folder_builds_grid_import_params() {
+        if writable_home().is_none() {
+            return;
+        }
         let dir = home_tempdir("cull_launch_folder_");
         let folder = dir.path().join("Library");
         std::fs::create_dir(&folder).unwrap();
@@ -684,6 +690,9 @@ mod tests {
 
     #[test]
     fn launch_path_rejects_unsupported_files() {
+        if writable_home().is_none() {
+            return;
+        }
         let dir = home_tempdir("cull_launch_unsupported_");
         let text = dir.path().join("notes.txt");
         std::fs::write(&text, b"notes").unwrap();
@@ -727,6 +736,9 @@ mod tests {
 
     #[test]
     fn drag_drop_single_image_opens_loupe() {
+        if writable_home().is_none() {
+            return;
+        }
         let dir = home_tempdir("cull_drag_single_");
         let image = dir.path().join("image.jpg");
         std::fs::write(&image, b"not a real jpeg").unwrap();
@@ -743,6 +755,9 @@ mod tests {
 
     #[test]
     fn drag_drop_multiple_images_opens_grid_batch() {
+        if writable_home().is_none() {
+            return;
+        }
         let dir = home_tempdir("cull_drag_multi_");
         let first = dir.path().join("first.jpg");
         let second = dir.path().join("second.png");
@@ -766,6 +781,9 @@ mod tests {
 
     #[test]
     fn drag_drop_single_folder_opens_folder_grid() {
+        if writable_home().is_none() {
+            return;
+        }
         let dir = home_tempdir("cull_drag_folder_");
         let folder = dir.path().join("Library");
         std::fs::create_dir(&folder).unwrap();
@@ -785,6 +803,9 @@ mod tests {
 
     #[test]
     fn drag_drop_paths_can_include_drop_position() {
+        if writable_home().is_none() {
+            return;
+        }
         let dir = home_tempdir("cull_drag_position_");
         let folder = dir.path().join("Library");
         std::fs::create_dir(&folder).unwrap();
@@ -799,6 +820,9 @@ mod tests {
 
     #[test]
     fn drag_drop_mixed_files_and_folders_keeps_both_import_actions() {
+        if writable_home().is_none() {
+            return;
+        }
         let dir = home_tempdir("cull_drag_mixed_");
         let image = dir.path().join("image.webp");
         let folder = dir.path().join("Folder");

--- a/src-tauri/src/commands/deeplink.rs
+++ b/src-tauri/src/commands/deeplink.rs
@@ -434,12 +434,35 @@ fn hex_value(byte: u8) -> Option<u8> {
 mod tests {
     use super::*;
 
+    // Create a tempdir for test fixtures. Prefers to nest it under $HOME so the
+    // production path validator sees the fixture as "under home" (matching the
+    // behavior real users get on a developer machine), but falls back to the
+    // system temp location when $HOME is not writable — for example, the macOS
+    // CI runner image now exposes /Users/runner as read-only.
     fn home_tempdir(prefix: &str) -> tempfile::TempDir {
-        let home = dirs::home_dir().unwrap();
+        if let Some(home) = dirs::home_dir() {
+            if let Ok(dir) = tempfile::Builder::new().prefix(prefix).tempdir_in(&home) {
+                return dir;
+            }
+        }
         tempfile::Builder::new()
             .prefix(prefix)
-            .tempdir_in(home)
-            .unwrap()
+            .tempdir()
+            .expect("tempdir creation should not fail on a working CI runner")
+    }
+
+    // Return $HOME when it is writable, otherwise None. Tests that exercise the
+    // validator's "is this path under $HOME?" logic use this to skip themselves
+    // on read-only CI runners instead of failing on `create_dir`.
+    fn writable_home() -> Option<std::path::PathBuf> {
+        let home = dirs::home_dir()?;
+        let probe = home.join(".cull_deeplink_probe");
+        if std::fs::create_dir(&probe).is_ok() {
+            let _ = std::fs::remove_dir(&probe);
+            Some(home)
+        } else {
+            None
+        }
     }
 
     #[test]
@@ -464,7 +487,11 @@ mod tests {
 
     #[test]
     fn valid_home_path_passes_validation() {
-        let home = dirs::home_dir().unwrap();
+        let Some(home) = writable_home() else {
+            // CI runner exposes a read-only $HOME; this assertion is
+            // developer-machine-only and we cannot meaningfully exercise it.
+            return;
+        };
         // Create a non-hidden temp directory under $HOME
         let test_dir = home.join("cull_deeplink_test_tmp");
         std::fs::create_dir_all(&test_dir).unwrap();
@@ -490,7 +517,7 @@ mod tests {
 
     #[test]
     fn ssh_dir_is_rejected() {
-        let home = dirs::home_dir().unwrap();
+        let Some(home) = writable_home() else { return };
         let ssh_path = home.join(".ssh");
         // Only test if the directory actually exists (it does on most dev machines)
         if ssh_path.exists() {
@@ -532,7 +559,7 @@ mod tests {
 
     #[test]
     fn hidden_directory_rejected() {
-        let home = dirs::home_dir().unwrap();
+        let Some(home) = writable_home() else { return };
         let hidden = home.join(".hidden_test_dir_deeplink");
         let _ = std::fs::create_dir(&hidden);
         if hidden.exists() {

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -1,6 +1,7 @@
 pub mod agent_proposals;
 pub mod agent_snapshots;
 pub mod catalog;
+pub mod cli_tool;
 pub mod clipboard_monitor;
 pub mod collections;
 pub mod color;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -787,6 +787,9 @@ pub fn run() {
             commands::preview::stop_preview_display_web_stream,
             commands::preview::get_preview_display_web_stream_status,
             commands::preview::get_image_histogram,
+            commands::cli_tool::cli_tool_status,
+            commands::cli_tool::install_cli_tool,
+            commands::cli_tool::uninstall_cli_tool,
             commands::diagnostics::record_asset_load_event,
             commands::diagnostics::get_asset_load_events,
         ])

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1949,6 +1949,30 @@ export async function backfillRawPreviews(): Promise<number> {
     return invoke<number>('backfill_raw_previews');
 }
 
+// Command line tool
+export interface CliToolStatus {
+    installed: boolean;
+    link_path: string | null;
+    target_path: string | null;
+    /** Installed, but pointing at a different copy of Cull — offer a re-install. */
+    stale: boolean;
+    candidate_dir: string | null;
+    /** Shell profile line the user must add when the install dir is not on PATH. */
+    path_hint: string | null;
+}
+
+export async function cliToolStatus(): Promise<CliToolStatus> {
+    return invoke<CliToolStatus>('cli_tool_status');
+}
+
+export async function installCliTool(): Promise<CliToolStatus> {
+    return invoke<CliToolStatus>('install_cli_tool');
+}
+
+export async function uninstallCliTool(): Promise<CliToolStatus> {
+    return invoke<CliToolStatus>('uninstall_cli_tool');
+}
+
 // Privacy & audit log
 export interface AuditLogEntry {
     id: string;

--- a/src/lib/components/GeneralSettings.svelte
+++ b/src/lib/components/GeneralSettings.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
     import { onMount } from 'svelte';
-    import { backfillRawPreviews, getAppSetting, setAppSetting } from '$lib/api';
+    import { backfillRawPreviews, cliToolStatus, getAppSetting, installCliTool, setAppSetting, uninstallCliTool } from '$lib/api';
+    import type { CliToolStatus } from '$lib/api';
     import { CLIPBOARD_PASTE_DATE_FORMAT_SETTING, DEFAULT_CLIPBOARD_PASTE_DATE_FORMAT } from '$lib/clipboard-actions';
     import { clientToolsEnabled, navigateTo, showToast, staticPublishingEnabled, viewMode, voiceDictationEnabled } from '$lib/stores';
 
@@ -13,6 +14,8 @@
     let moduleStaticPublishing = $state(false);
     let moduleClientTools = $state(false);
     let moduleVoiceDictation = $state(false);
+    let cliTool = $state<CliToolStatus | null>(null);
+    let cliToolBusy = $state(false);
 
     onMount(async () => {
         const [tray, trash, update, purge, date, raw, publishing, client, voice] = await Promise.all([
@@ -33,6 +36,8 @@
         staticPublishingEnabled.set(moduleStaticPublishing);
         clientToolsEnabled.set(moduleClientTools);
         voiceDictationEnabled.set(moduleVoiceDictation);
+        // Shells out to the login shell for PATH; kept off the blocking load path.
+        void refreshCliTool();
     });
 
     async function toggle(key: string, value: boolean) { await setAppSetting(key, value ? 'true' : 'false'); }
@@ -47,6 +52,45 @@
     }
     async function changeClientTools() { await toggle('module_client_tools', moduleClientTools); clientToolsEnabled.set(moduleClientTools); }
     async function changeVoice() { await toggle('module_voice_dictation', moduleVoiceDictation); voiceDictationEnabled.set(moduleVoiceDictation); }
+    async function refreshCliTool() {
+        try {
+            cliTool = await cliToolStatus();
+        } catch (e) {
+            console.error('Failed to read command line tool status:', e);
+            cliTool = null;
+        }
+    }
+    async function changeCliTool() {
+        if (cliToolBusy) return;
+        cliToolBusy = true;
+        const removing = cliTool?.installed === true && cliTool?.stale !== true;
+        try {
+            cliTool = removing ? await uninstallCliTool() : await installCliTool();
+            if (removing) {
+                showToast('Command line tool removed', { type: 'success', duration: 2500 });
+            } else if (cliTool?.path_hint) {
+                showToast(`Installed to ${cliTool.link_path}`, {
+                    type: 'success',
+                    duration: 10000,
+                    detail: `That directory is not on your PATH yet. Add this to your shell profile:\n${cliTool.path_hint}`,
+                });
+            } else {
+                showToast('Command line tool installed — run \`cull --help\`', {
+                    type: 'success',
+                    duration: 4000,
+                });
+            }
+        } catch (e) {
+            console.error('Failed to change command line tool:', e);
+            showToast(removing ? 'Could not remove command line tool' : 'Could not install command line tool', {
+                detail: String(e),
+                type: 'error',
+                duration: 6000,
+            });
+        } finally {
+            cliToolBusy = false;
+        }
+    }
     async function saveDateFormat() {
         pasteDateFormat = pasteDateFormat.trim() || DEFAULT_CLIPBOARD_PASTE_DATE_FORMAT;
         await setAppSetting(CLIPBOARD_PASTE_DATE_FORMAT_SETTING, pasteDateFormat);
@@ -59,6 +103,26 @@
     <div class="setting-row"><span>Confirm before Trash</span><button class:on={confirmTrash} aria-pressed={confirmTrash} onclick={() => { confirmTrash = !confirmTrash; setAppSetting('skip_trash_confirm', confirmTrash ? 'false' : 'true'); }}>{confirmTrash ? 'ON' : 'OFF'}</button></div>
     <div class="setting-row"><span>Auto update</span><button class:on={autoUpdate} aria-pressed={autoUpdate} onclick={() => { autoUpdate = !autoUpdate; toggle('auto_update_enabled', autoUpdate); window.dispatchEvent(new CustomEvent('auto-update-setting-changed')); }}>{autoUpdate ? 'ON' : 'OFF'}</button></div>
     <div class="setting-row"><span>Auto-purge missing files</span><button class:on={autoPurge} aria-pressed={autoPurge} onclick={() => { autoPurge = !autoPurge; toggle('auto_purge_missing', autoPurge); }}>{autoPurge ? 'ON' : 'OFF'}</button></div>
+        <div class="setting-row">
+            <span>Command line tool</span>
+            <button
+                class:on={cliTool?.installed && !cliTool?.stale}
+                aria-pressed={cliTool?.installed === true && cliTool?.stale !== true}
+                disabled={cliToolBusy}
+                onclick={changeCliTool}
+            >
+                {#if cliToolBusy}…{:else if cliTool?.stale}REPAIR{:else if cliTool?.installed}ON{:else}OFF{/if}
+            </button>
+        </div>
+        {#if cliTool?.stale}
+            <p class="note"><code>{cliTool.link_path}</code> points at a different copy of Cull. Repair it to use this one.</p>
+        {:else if cliTool?.installed}
+            <p class="note"><code>cull</code> is available at <code>{cliTool.link_path}</code>.</p>
+        {:else if cliTool?.path_hint}
+            <p class="note">Installs to <code>{cliTool.candidate_dir}</code>, which is not on your PATH. You will need to add <code>{cliTool.path_hint}</code> to your shell profile.</p>
+        {:else if cliTool}
+            <p class="note">Links <code>cull</code> into <code>{cliTool.candidate_dir}</code> so the CLI and MCP examples in the docs work as written.</p>
+        {/if}
     <label class="setting-row"><span>Paste filename date</span><input bind:value={pasteDateFormat} onblur={saveDateFormat} /></label>
     <p class="note">Used when the destination folder has no numeric filename sequence.</p>
 </section>


### PR DESCRIPTION
Adds the 'Command line tool' General settings toggle that symlinks the app binary into the first user-writable directory on PATH. Companion to the 0.4.0 release.