### PR TITLE
fix(release): ignore gitignored directories in pre-commit race check

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -69,5 +69,6 @@ Cull is a local-first Tauri 2 desktop app. It never phones home. All data stays 
 
 | Version | Supported |
 |---------|-----------|
+| 0.4.x   | Yes       |
 | 0.3.x   | Yes       |
 | < 0.3   | No        |

--- a/scripts/cull-release.mjs
+++ b/scripts/cull-release.mjs
@@ -539,7 +539,19 @@ function assertPreCommitPlan(plan, source, snapshot) {
   if (actual.size !== expected.size || [...actual].some((path) => !expected.has(path))) {
     throw commandError('PREPARE_RACE', 'Repository changes no longer match the release plan');
   }
-  const newDirectories = [...snapshotDirectories()].filter((path) => !snapshot.directories.has(path));
+  const allNewDirectories = [...snapshotDirectories()].filter((path) => !snapshot.directories.has(path));
+  const newDirectories = allNewDirectories.filter((path) => {
+    try {
+      execFileSync('git', ['check-ignore', '-q', '--', path], {
+        cwd: repoRoot,
+        env: { ...process.env, GIT_OPTIONAL_LOCKS: '0' },
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+      return false;
+    } catch {
+      return true;
+    }
+  });
   if (newDirectories.length > 0) {
     throw commandError('PREPARE_RACE', 'Release gates created unexpected directories', {
       sideEffects: newDirectories.sort(),


### PR DESCRIPTION
The pre-commit snapshot comparison in `assertPreCommitPlan` flagged every new directory the gate created, including `.svelte-kit/` and `src-tauri/target/` subtrees that vite build and cargo test legitimately produce. Filter new directories through `git check-ignore` so only path-bearing untracked directories are treated as a race; gitignored build artifacts are tolerated.

Targets `PREPARE_RACE - Release gates created unexpected directories`.

## Test plan
- [x] 129 release-engine tests pass (npm run test:release)
- [ ] Manual: run prepare on a worktree with stale .svelte-kit/ and verify it does not throw PREPARE_RACE