### PR TITLE
chore(release): v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-08-19
+
+- Ship cli_tool install toggle (PR #184)
+- Fix CI flakes (RUSTSEC-2026-0258 / h2 bump, deeplink tests on read-only HOME)
+
 ## [0.3.3] - 2026-08-08
 
 ### Fixed

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -49,4 +49,4 @@ Cull reaches 1.0 when all three surfaces are `stable` and:
 
 ---
 
-Last updated: 0.3.3 (2026-08-08)
+Last updated: 0.4.0 (2026-08-19)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cull",
-  "version": "0.3.3",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cull",
-      "version": "0.3.3",
+      "version": "0.4.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.3.222",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cull",
-  "version": "0.3.3",
+  "version": "0.4.0",
   "description": "Local-first desktop image viewer for AI-generated art workflows.",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -928,7 +928,7 @@ checksum = "52560adf09603e58c9a7ee1fe1dcb95a16927b17c127f0ac02d6e768a0e25bc1"
 
 [[package]]
 name = "cull"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "base64 0.23.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cull"
-version = "0.3.3"
+version = "0.4.0"
 description = "Local-first desktop image viewer for AI-generated art workflows."
 authors = ["Gleb Kalinin <glebis@gmail.com>"]
 license = "Apache-2.0"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Cull",
-  "version": "0.3.3",
+  "version": "0.4.0",
   "identifier": "com.glebkalinin.cull",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
Release commit for v0.4.0. Generated by `node scripts/cull-release.mjs prepare --bump minor`.

Ship cli_tool install toggle (PR #184) and CI flake fixes (RUSTSEC-2026-0258 / h2 bump, deeplink tests on read-only HOME).