### PR TITLE
docs(security): add 0.5.x to Supported Versions ahead of v0.5.0 release

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -69,6 +69,7 @@ Cull is a local-first Tauri 2 desktop app. It never phones home. All data stays 
 
 | Version | Supported |
 |---------|-----------|
+| 0.5.x   | Yes       |
 | 0.4.x   | Yes       |
 | 0.3.x   | Yes       |
 | < 0.3   | No        |


### PR DESCRIPTION
The open-source release contract test (HYG-006) requires SECURITY.md to list the shipping major.minor under the Supported Versions table. After we bump to v0.5.0 to recover from the v0.4.0 publish race, the contract test will reject the release commit unless 0.5.x appears in the table.

Keep 0.4.x and 0.3.x entries (both still supported per Cull support policy).