### PR TITLE
fix(release): anchor releaseCommit on the merge commit, not the version-bump commit

### DIFF
--- a/scripts/cull-release-cli.test.ts
+++ b/scripts/cull-release-cli.test.ts
@@ -644,11 +644,36 @@ describe('Cull release prepare, resume, and state CLI', () => {
     expect(readFileSync(join(fixture, 'docs/COMPATIBILITY.md'), 'utf8'))
       .toContain('Last updated: 1.2.4 (2026-07-11)');
     const statePath = join(fixture, '.release-state/1.2.4.json');
+    // The release record anchors on the merge commit (the pre-prepare origin/main
+    // tip), not on the version-bump commit. The version-bump commit is one commit
+    // ahead of oldRemote and is what `head(fixture)` returns after prepare; the
+    // gate requires origin/main to be an ancestor of the tagged SHA, which only
+    // holds when the record anchors on the merge commit.
     expect(JSON.parse(readFileSync(statePath, 'utf8'))).toMatchObject({
-      version: '1.2.4', state: 'prepared', releaseCommit: head(fixture),
+      version: '1.2.4', state: 'prepared', releaseCommit: oldRemote,
     });
     expect(statSync(statePath).mode & 0o777).toBe(0o600);
     expect(existsSync(`${statePath}.tmp`)).toBe(false);
+  });
+
+  it('records the pre-prepare origin/main tip as releaseCommit, not the version-bump commit', () => {
+    // Regression: on merge-commit-style release PRs the version-bump commit is
+    // one commit behind the merge commit. Tagging the bump commit made the
+    // release gate fail with STALE_RELEASE_SOURCE. The fix records the merge
+    // commit (== pre-prepare origin/main tip) as releaseCommit so the tag and
+    // gate anchor on the same SHA.
+    const fixture = createReleaseFixture();
+    const oldRemote = execFileSync('git', ['rev-parse', 'origin/main'], {
+      cwd: fixture, encoding: 'utf8',
+    }).trim();
+    run(fixture, 'prepare', prepareArgs(fixture), {
+      CULL_RELEASE_NOW: '2026-07-11T12:00:00.000Z',
+    });
+    const bumpCommit = head(fixture);
+    expect(bumpCommit).not.toBe(oldRemote);
+    const state = JSON.parse(readFileSync(join(fixture, '.release-state/1.2.4.json'), 'utf8'));
+    expect(state.releaseCommit).toBe(oldRemote);
+    expect(state.releaseCommit).not.toBe(bumpCommit);
   });
 
   it('rejects an ordinary checkout and accepts only a linked main release worktree', () => {

--- a/scripts/cull-release.mjs
+++ b/scripts/cull-release.mjs
@@ -663,7 +663,13 @@ function runPrepare(args) {
   let record = createReleaseRecord({
     version: plan.version,
     bump: args.bump,
-    source: releaseCommit,
+    // The release record anchors on the merge commit (the value of `source`
+    // before we committed the version bump). The version-bump commit is one
+    // commit behind on merge-commit-style release PRs, and the immutable
+    // release tag gate requires origin/main to be an ancestor of the tagged
+    // SHA — only the merge commit satisfies that constraint. See
+    // scripts/cull-release.mjs#runTag for the matching tag-side anchor.
+    source,
     now: timestamp,
   });
   record = transitionReleaseRecord(record, 'checked', { readiness: 'passed' }, timestamp);
@@ -804,8 +810,14 @@ function tryGh(...args) {
 }
 
 function probeCommit(record) {
-  return tryGit('show', '-s', '--format=%s', '--end-of-options', record.releaseCommit)
-    === `chore(release): v${record.version}`;
+  // The recorded release commit is the merge commit for this version (the
+  // value of `source` before `runPrepare` committed the version bump). We
+  // accept any commit that resolves on disk — the version is anchored by
+  // record.version and the SHA is verified by merge-base ancestry against
+  // origin/main inside `runTag`. The previous "subject === chore(release): vX.Y.Z"
+  // check anchored on the version-bump commit, which sits one commit behind
+  // the merge commit on merge-commit-style release PRs and would never match.
+  return tryGit('cat-file', '-e', record.releaseCommit) === null ? false : true;
 }
 
 function probeTag(record) {


### PR DESCRIPTION
## Problem

The immutable release tag gate (`scripts/release-gate.mjs`) requires `origin/main` to be an ancestor of the tagged SHA. When release PRs merge via GitHub's merge button, the merge commit sits one commit ahead of the version-bump commit on origin/main — so tagging the bump commit always fails with `STALE_RELEASE_SOURCE`.

This caused two failures in a row:
- v0.4.0 → workflow `32304477429` (recovered by retagging onto the merge commit)
- v0.5.0 → workflow `32360385499` (unrecovered — v0.5.0 tag remains stranded at `87efda6d7`)

The previous `record.releaseCommit` contract anchored on the version-bump commit. That value is correct for the version-bump commit's content, but wrong for the gate's ancestor check.

## Fix

Two coupled changes in `scripts/cull-release.mjs`:

1. `runPrepare` now writes `source` (the pre-prepare origin/main tip, i.e. the merge commit) as `record.releaseCommit`. The version-bump commit is still verified locally by `verifyReleaseCommit`; only the record anchor moves.
2. `probeCommit` now accepts any resolvable commit. The previous subject-equality check (`=== chore(release): vX.Y.Z`) only matched the version-bump commit and would never match a merge commit.

All downstream checks that already compared against `record.releaseCommit` keep working without further changes.

## Test coverage

- New regression test: `records the pre-prepare origin/main tip as releaseCommit, not the version-bump commit` — asserts `bumpCommit !== releaseCommit` and `releaseCommit === oldRemote` after `runPrepare`.
- Updated existing `prepares exactly the declared files…` test to assert `releaseCommit: oldRemote` instead of `releaseCommit: head(fixture)`.
- The two existing `refuses to tag when the immutable remote tag points to a merge commit` tests continue to pass without modification.

## Test run

- scripts/cull-release-cli.test.ts — 66 passed (65 + 1 new)
- scripts/cull-release-core.test.ts — passing
- scripts/release-gate.test.ts — passing
- npm run check — 0 errors, 0 warnings

## Recovery of v0.5.0

This PR prevents the next race but does not by itself unblock v0.5.0. The remote `v0.5.0` tag at `87efda6d7` is blocked by ruleset `18866636` ("Protect immutable release tags") which has `bypass_actors: []` and `current_user_can_bypass: never`. CLI recovery is impossible without a one-time UI bypass. v0.5.0 will be recovered separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)