### PR TITLE
chore(release): v0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [0.5.1] - 2026-08-20
+
+### Fixed
+
+- **Release script: anchor releaseCommit on the merge commit.** scripts/cull-release.mjs previously recorded the version-bump commit as releaseCommit, but the immutable release tag gate requires origin/main to be an ancestor of the tagged SHA. On merge-commit-style release PRs the bump commit is one commit behind the merge commit, so the gate fired with STALE_RELEASE_SOURCE for v0.4.0 and v0.5.0. The script now records the pre-prepare source (= origin/main tip = merge commit) so runTag and the gate anchor on the same SHA. PR #190.
+
 ## [0.5.0] - 2026-08-20
 
 - Recovered a v0.4.0 publish race: STALE_RELEASE_SOURCE fired because v0.4.0 was tagged on the release commit before its PR landed on main.

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -49,4 +49,4 @@ Cull reaches 1.0 when all three surfaces are `stable` and:
 
 ---
 
-Last updated: 0.5.0 (2026-08-20)
+Last updated: 0.5.1 (2026-08-20)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cull",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cull",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.3.222",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cull",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Local-first desktop image viewer for AI-generated art workflows.",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -928,7 +928,7 @@ checksum = "52560adf09603e58c9a7ee1fe1dcb95a16927b17c127f0ac02d6e768a0e25bc1"
 
 [[package]]
 name = "cull"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "base64 0.23.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cull"
-version = "0.5.0"
+version = "0.5.1"
 description = "Local-first desktop image viewer for AI-generated art workflows."
 authors = ["Gleb Kalinin <glebis@gmail.com>"]
 license = "Apache-2.0"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Cull",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "identifier": "com.glebkalinin.cull",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## Cull v0.5.1

Patch release shipping the once-and-forever fix for the `STALE_RELEASE_SOURCE` race that stranded v0.4.0 (workflow 32304477429, recovered by retag) and v0.5.0 (workflow 32360385499, stranded).

### Fixed

- **Release script: anchor `releaseCommit` on the merge commit, not the version-bump commit.** `scripts/cull-release.mjs` previously recorded the version-bump commit as `releaseCommit`, but the immutable release tag gate requires `origin/main` to be an ancestor of the tagged SHA. On merge-commit-style release PRs the bump commit is one commit behind the merge commit, so the gate fired every time. The script now records the pre-prepare `source` (= origin/main tip = merge commit) so `runTag` and the gate anchor on the same SHA. PR #190.

### What this is *not*

- v0.5.0 remains stranded on origin at `87efda6d7` — no GitHub Release was ever published for it, but the tag is ruleset-protected (`Protect immutable release tags`, id 18866636) so CLI recovery requires a one-time UI bypass. This release does not attempt that recovery; v0.5.1 ships the same content as v0.5.0 with the script-side race fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)