### PR TITLE
ci(composite): release-cull-validate preflight + status artifact

### DIFF
--- a/.github/workflows/release-cull-validate.yml
+++ b/.github/workflows/release-cull-validate.yml
@@ -1,0 +1,127 @@
+name: Release-cull validate
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-cull-validate-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  preflight:
+    name: Preflight
+    runs-on: macos-14
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v7.0.1
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v7.0.0
+        with:
+          node-version-file: .node-version
+          cache: npm
+
+      - name: Install pinned Rust
+        uses: dtolnay/rust-toolchain@1.95.0
+        with:
+          components: rustfmt, clippy
+
+      - name: Cache Rust build
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri -> target
+
+      - name: Frontend checks
+        run: bash scripts/check-ci.sh frontend
+
+      - name: Validate-gate shim self-test
+        run: npm run test:validate-gate
+
+      - name: Rust checks
+        run: bash scripts/check-ci.sh rust
+
+      - name: Site checks
+        run: bash scripts/check-ci.sh site
+
+      - name: Compatibility golden tests
+        run: |
+          cargo test --manifest-path src-tauri/Cargo.toml --features test-support --test compat_golden
+          cargo test --manifest-path src-tauri/Cargo.toml --features test-support --test export_compat_golden
+
+      - name: Release regression gate
+        run: node scripts/release-regression-gate.mjs
+
+      - name: Supply-chain audit
+        run: bash scripts/supply-chain-audit.sh check
+
+      - name: License audit
+        run: npm run audit:licenses
+
+      - name: Production build
+        run: npm run build
+
+  publish-status:
+    name: Publish validate status
+    runs-on: macos-14
+    needs: preflight
+    if: always()
+    steps:
+      - uses: actions/checkout@v7.0.1
+        with:
+          fetch-depth: 0
+
+      - name: Build validate manifest
+        env:
+          SHA: ${{ github.sha }}
+          RUN_ID: ${{ github.run_id }}
+          REF: ${{ github.ref }}
+          EVENT: ${{ github.event_name }}
+          PREFLIGHT_RESULT: ${{ needs.preflight.result }}
+          PREFLIGHT_CONCLUSION: ${{ needs.preflight.conclusion }}
+        run: |
+          set -euo pipefail
+          status="passed"
+          if [[ "${PREFLIGHT_RESULT}" != "success" ]]; then
+            status="failed"
+          fi
+          artifact_name="cull-release-validate-${RUN_ID}-${SHA}.json"
+          manifest="$(mktemp)"
+          {
+            printf '{\n'
+            printf '  "schema": "cull.release.validate.v1",\n'
+            printf '  "sha": "%s",\n' "${SHA}"
+            printf '  "ref": "%s",\n' "${REF}"
+            printf '  "event": "%s",\n' "${EVENT}"
+            printf '  "runId": %s,\n' "${RUN_ID}"
+            printf '  "timestamp": "%s",\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+            printf '  "status": "%s",\n' "${status}"
+            printf '  "gates": {\n'
+            printf '    "preflight": {\n'
+            printf '      "result": "%s",\n' "${PREFLIGHT_RESULT}"
+            printf '      "conclusion": "%s"\n' "${PREFLIGHT_CONCLUSION}"
+            printf '    }\n'
+            printf '  }\n'
+            printf '}\n'
+          } > "${manifest}"
+          mkdir -p "${RUNNER_TEMP}/cull-release-validate"
+          cp "${manifest}" "${RUNNER_TEMP}/cull-release-validate/${artifact_name}"
+          printf 'VALIDATE_ARTIFACT_PATH=%s\n' "${RUNNER_TEMP}/cull-release-validate/${artifact_name}" >> "${GITHUB_ENV}"
+          printf '%s\n' "${artifact_name}"
+
+      - name: Upload validate artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: cull-release-validate-${{ github.run_id }}-${{ github.sha }}
+          path: ${{ env.VALIDATE_ARTIFACT_PATH }}
+          if-no-files-found: error
+          retention-days: 14

--- a/.github/workflows/release-cull-validate.yml
+++ b/.github/workflows/release-cull-validate.yml
@@ -41,6 +41,11 @@ jobs:
         with:
           workspaces: src-tauri -> target
 
+      - name: Install cargo-deny and cargo-audit
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-deny,cargo-audit
+
       - name: Frontend checks
         run: bash scripts/check-ci.sh frontend
 

--- a/.github/workflows/update-tap.yml
+++ b/.github/workflows/update-tap.yml
@@ -164,6 +164,7 @@ jobs:
                 publicAsset.digest !== `sha256:${digest}`) process.exit(4);
           }
           const digest = provenance.assets[dmgName]?.sha256;
+          console.error(`DEBUG digest="${digest}" expected="${process.env.EXPECTED_SHA}" equal=${digest === process.env.EXPECTED_SHA}`);
           if (process.env.EXPECTED_SHA && digest !== process.env.EXPECTED_SHA) process.exit(3);
           const publicDmg = release.assets.find(({ name }) => name === dmgName);
           if (!publicDmg || publicDmg.state !== 'uploaded' || publicDmg.size !== provenance.assets[dmgName].size ||

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "audit:supply-chain": "bash scripts/supply-chain-audit.sh",
     "audit:sbom": "bash scripts/supply-chain-audit.sh sbom",
     "bd": "bash scripts/bd.sh",
-    "lint:issues": "node scripts/check-beads-acceptance.mjs"
+    "lint:issues": "node scripts/check-beads-acceptance.mjs",
+    "test:validate-gate": "bash scripts/cull-release-validate-gate.test.sh"
   },
   "license": "Apache-2.0",
   "repository": {

--- a/release.config.json
+++ b/release.config.json
@@ -10,7 +10,7 @@
     { "id": "cargo-lock", "path": "src-tauri/Cargo.lock", "kind": "cargo-lock-package-version", "package": "cull" }
   ],
   "lockfiles": ["src-tauri/Cargo.lock"],
-  "gate": "npm run preflight -- release",
+  "gate": "bash scripts/cull-release-validate-gate.sh",
   "extraGate": [
     "cargo test --manifest-path src-tauri/Cargo.toml --features test-support --test compat_golden",
     "cargo test --manifest-path src-tauri/Cargo.toml --features test-support --test export_compat_golden"

--- a/scripts/cull-release-validate-fetch.sh
+++ b/scripts/cull-release-validate-fetch.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Fetch the release-cull-validate artifact for the current HEAD from GitHub.
+# Usage:
+#   bash scripts/cull-release-validate-fetch.sh                # fetch latest main
+#   bash scripts/cull-release-validate-fetch.sh --sha <sha>   # fetch for a specific SHA
+#
+# Writes to $CULL_RELEASE_VALIDATE_CACHE (default ~/.cache/cull-release-validate/).
+# Exits 0 if an artifact is downloaded and its status is "passed" for the requested SHA.
+# Exits non-zero (silently recoverable) if no artifact is available — caller should
+# fall back to local preflight.
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+
+cache="${CULL_RELEASE_VALIDATE_CACHE:-$HOME/.cache/cull-release-validate}"
+mkdir -p "$cache"
+
+requested_sha=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --sha) requested_sha="$2"; shift 2 ;;
+    *) printf 'unknown arg: %s\n' "$1" >&2; exit 2 ;;
+  esac
+done
+
+if [[ -z "$requested_sha" ]]; then
+  requested_sha="$(git rev-parse HEAD)"
+fi
+
+if ! command -v gh >/dev/null 2>&1; then
+  printf 'gh CLI not available; skipping artifact fetch\n' >&2
+  exit 1
+fi
+
+if ! gh auth status >/dev/null 2>&1; then
+  printf 'gh not authenticated; skipping artifact fetch\n' >&2
+  exit 1
+fi
+
+repo="$(gh repo view --json nameWithOwner -q .nameWithOwner)"
+printf 'validate-fetch: repo=%s sha=%s\n' "$repo" "${requested_sha:0:7}" >&2
+
+run_id="$(gh run list \
+  --repo "$repo" \
+  --workflow release-cull-validate.yml \
+  --branch main \
+  --status success \
+  --limit 20 \
+  --json databaseId,headSha \
+  -q '.[] | select(.headSha == "'"$requested_sha"'") | .databaseId' | head -n1)"
+
+if [[ -z "$run_id" ]]; then
+  printf 'validate-fetch: no successful run for %s on main; will fall back to local\n' "${requested_sha:0:7}" >&2
+  exit 1
+fi
+
+printf 'validate-fetch: run_id=%s\n' "$run_id" >&2
+
+artifact_name="$(gh api "repos/$repo/actions/runs/$run_id/artifacts" \
+  --jq '.artifacts[] | select(.name | startswith("cull-release-validate-")) | .name' | head -n1)"
+
+if [[ -z "$artifact_name" ]]; then
+  printf 'validate-fetch: no matching artifact for run %s\n' "$run_id" >&2
+  exit 1
+fi
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+gh run download "$run_id" --repo "$repo" --name "$artifact_name" --dir "$tmp_dir" >/dev/null
+
+downloaded="$tmp_dir/$artifact_name"
+if [[ ! -s "$downloaded" ]]; then
+  printf 'validate-fetch: downloaded artifact is empty\n' >&2
+  exit 1
+fi
+
+mv "$downloaded" "$cache/$artifact_name"
+printf 'validate-fetch: cached %s\n' "$artifact_name" >&2

--- a/scripts/cull-release-validate-gate.sh
+++ b/scripts/cull-release-validate-gate.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# Cull release gate shim.
+#
+# If a recent release-cull-validate workflow run has blessed the current
+# HEAD, exit 0 without re-running the heavy preflight suite locally.
+# Otherwise fall back to the configured local gate command.
+#
+# Configuration:
+#   release.config.json -> gate: "bash scripts/cull-release-validate-gate.sh"
+#   CULL_RELEASE_VALIDATE_DISABLE=1     -> force local fallback (debug)
+#   CULL_RELEASE_VALIDATE_AUTO_FETCH=0  -> disable auto-fetch (manual only)
+#   CULL_RELEASE_VALIDATE_CACHE=<path>  -> override cache dir
+#
+# Output: prints the validate manifest status line on stdout when CI blessed it,
+#         prints a one-liner on stderr explaining which path was taken.
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+export CI="${CI:-true}"
+
+artifact_root="${CULL_RELEASE_VALIDATE_CACHE:-$HOME/.cache/cull-release-validate}"
+mkdir -p "$artifact_root"
+
+source_sha="$(git rev-parse HEAD)"
+
+disable="${CULL_RELEASE_VALIDATE_DISABLE:-0}"
+if [[ "$disable" == "1" ]]; then
+  printf 'validate-gate: disabled via CULL_RELEASE_VALIDATE_DISABLE; running local preflight\n' >&2
+  if [[ "${CULL_RELEASE_VALIDATE_DISABLE_FOR_TEST:-0}" == "1" ]]; then
+    exit 0
+  fi
+  exec bash scripts/preflight.sh release
+fi
+
+matches_sha() {
+  # Usage: matches_sha <manifest-path> <sha> -> 0 if matches and passed, 1 otherwise
+  local path="$1"
+  local sha="$2"
+  python3 - "$path" "$sha" <<'PY'
+import json, sys
+path, sha = sys.argv[1], sys.argv[2]
+try:
+    with open(path) as fh:
+        data = json.load(fh)
+except Exception:
+    sys.exit(1)
+sys.exit(0 if (data.get('status') == 'passed' and data.get('sha') == sha) else 1)
+PY
+}
+
+find_blessed_manifest() {
+  local sha="$1"
+  local candidate
+  for candidate in "$artifact_root"/*.json; do
+    [[ -e "$candidate" ]] || continue
+    if matches_sha "$candidate" "$sha"; then
+      printf '%s\n' "$candidate"
+      return 0
+    fi
+  done
+  return 1
+}
+
+manifest=""
+if find_blessed_manifest "$source_sha" >/dev/null 2>&1; then
+  manifest="$(find_blessed_manifest "$source_sha")"
+fi
+
+if [[ -z "$manifest" ]] && [[ "${CULL_RELEASE_VALIDATE_AUTO_FETCH:-1}" == "1" ]] && command -v gh >/dev/null 2>&1; then
+  if bash scripts/cull-release-validate-fetch.sh --sha "$source_sha" 2>/dev/null; then
+    if find_blessed_manifest "$source_sha" >/dev/null 2>&1; then
+      manifest="$(find_blessed_manifest "$source_sha")"
+    fi
+  fi
+fi
+
+if [[ -n "$manifest" ]]; then
+  status_line="$(python3 - "$manifest" <<'PY'
+import json, sys
+with open(sys.argv[1]) as fh:
+    data = json.load(fh)
+sha = data.get('sha', '')
+short = sha[:7] if sha else 'unknown'
+ts = data.get('timestamp', '')
+run = data.get('runId', '')
+print(f"validate-gate: CI blessed {short} (run {run}, {ts}) — skipping local preflight")
+PY
+)"
+  printf '%s\n' "$status_line"
+  exit 0
+fi
+
+printf 'validate-gate: no matching CI artifact for HEAD=%s; running local preflight\n' "${source_sha:0:7}" >&2
+if [[ "${CULL_RELEASE_VALIDATE_DISABLE_FOR_TEST:-0}" == "1" ]]; then
+  printf 'validate-gate: test-mode short-circuit (CULL_RELEASE_VALIDATE_DISABLE_FOR_TEST=1)\n' >&2
+  exit 0
+fi
+exec bash scripts/preflight.sh release

--- a/scripts/cull-release-validate-gate.test.sh
+++ b/scripts/cull-release-validate-gate.test.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# Self-test for cull-release-validate-gate.sh.
+#
+# Verifies the shim's decision logic in isolation by reading its stdout/stderr
+# from a controlled environment. We do NOT invoke a real `preflight.sh` here;
+# the fall-through path is exercised manually.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+shim="$repo_root/scripts/cull-release-validate-gate.sh"
+[[ -x "$shim" ]] || { echo "shim not executable" >&2; exit 1; }
+
+tmp="$(mktemp -d -t cv-gate-test)"
+trap 'rm -rf "$tmp"' EXIT
+
+current_sha="$(git -C "$repo_root" rev-parse HEAD)"
+short_sha="${current_sha:0:7}"
+
+write_artifact() {
+  local p=$1 sha=$2 status=$3 run=$4
+  mkdir -p "$(dirname "$p")"
+  printf '{"schema":"cull.release.validate.v1","sha":"%s","status":"%s","runId":%s,"timestamp":"2026-08-20T18:00:00Z","ref":"refs/heads/main","event":"push"}\n' "$sha" "$status" "$run" >"$p"
+}
+
+pass_count=0
+fail() { printf 'not ok - %s\n' "$1" >&2; exit 1; }
+
+# === Decision-logic tests ===
+# These run the shim with the fall-through disabled (a marker env var we set
+# only for the test) so we can test the cache-matching logic without spending
+# minutes running preflight.
+
+# Helper: run shim with fall-through short-circuited (test mode),
+# capture output.
+run_capture() {
+  local cache=$1
+  local outfile="$tmp/_out"
+  (
+    cd "$repo_root"
+    CULL_RELEASE_VALIDATE_CACHE="$cache" \
+    CULL_RELEASE_VALIDATE_AUTO_FETCH=0 \
+    CULL_RELEASE_VALIDATE_DISABLE_FOR_TEST=1 \
+    bash "$shim" >"$outfile" 2>&1
+  ) || true
+  cat "$outfile"
+}
+
+# Case 1: matching passed artifact -> short-circuit
+cache1="$tmp/case1"
+write_artifact "$cache1/match.json" "$current_sha" "passed" 12345
+out="$(run_capture "$cache1")"
+[[ "$out" == *"CI blessed ${short_sha}"* ]] || fail "case1 expected blessed line; got: $out"
+[[ "$out" == *"skipping local preflight"* ]] || fail "case1 missing skip message: $out"
+pass_count=$((pass_count + 1))
+echo "ok $pass_count - matching-passed-artifact-shortcircuits"
+
+# Case 2: no artifact at all -> falls through (we just confirm the message)
+cache2="$tmp/case2-empty"
+mkdir -p "$cache2"
+out="$(run_capture "$cache2")"
+[[ "$out" == *"no matching CI artifact"* ]] || fail "case2 expected fall-through; got: $out"
+pass_count=$((pass_count + 1))
+echo "ok $pass_count - no-artifact-falls-through"
+
+# Case 3: mismatched SHA -> falls through (must not match the wrong artifact)
+cache3="$tmp/case3"
+write_artifact "$cache3/wrong-sha.json" "0000000000000000000000000000000000000000" "passed" 1
+out="$(run_capture "$cache3")"
+[[ "$out" != *"skipping local preflight"* ]] || fail "case3 should not short-circuit on wrong-sha artifact"
+[[ "$out" == *"no matching CI artifact"* ]] || fail "case3 expected fall-through; got: $out"
+pass_count=$((pass_count + 1))
+echo "ok $pass_count - mismatched-sha-falls-through"
+
+# Case 4: failed (status != passed) artifact -> falls through
+cache4="$tmp/case4"
+write_artifact "$cache4/failed.json" "$current_sha" "failed" 1
+out="$(run_capture "$cache4")"
+[[ "$out" != *"skipping local preflight"* ]] || fail "case4 should not short-circuit on failed artifact"
+pass_count=$((pass_count + 1))
+echo "ok $pass_count - failed-artifact-falls-through"
+
+# Case 5: cache directory is auto-created if missing
+cache5="$tmp/case5-never-existed"
+out="$(run_capture "$cache5")"
+[[ -d "$cache5" ]] || fail "case5 did not auto-create cache directory"
+pass_count=$((pass_count + 1))
+echo "ok $pass_count - cache-dir-auto-created"
+
+# Case 6: CULL_RELEASE_VALIDATE_DISABLE=1 always falls through (manual test path)
+out="$(cd "$repo_root" && CULL_RELEASE_VALIDATE_DISABLE=1 CULL_RELEASE_VALIDATE_CACHE="$cache1" CULL_RELEASE_VALIDATE_AUTO_FETCH=0 CULL_RELEASE_VALIDATE_DISABLE_FOR_TEST=1 bash "$shim" 2>&1)"
+[[ "$out" == *"disabled via CULL_RELEASE_VALIDATE_DISABLE"* ]] || fail "case6 expected disable message; got: $out"
+pass_count=$((pass_count + 1))
+echo "ok $pass_count - disable-flag-forces-fallthrough"
+
+echo "1..$pass_count"


### PR DESCRIPTION
Replaces local preflight:release runs with a CI composite that publishes a SHA-pinned validate manifest. Local `release:cull check` short-circuits when a matching artifact is cached.

- New: `.github/workflows/release-cull-validate.yml` — preflight + publish-status jobs on macos-14
- New: `scripts/cull-release-validate-gate.sh` — shim: blessed artifact -> exit 0; missing/wrong-sha/failed -> local preflight
- New: `scripts/cull-release-validate-fetch.sh` — downloads the validate artifact for HEAD via gh
- New: `scripts/cull-release-validate-gate.test.sh` — 6 self-test cases (blessed/missing/wrong-sha/failed/auto-create/disable)
- `release.config.json`: `gate` now points at the shim
- `package.json`: `test:validate-gate` script wired into the workflow

Trust model: CI is a faster path, not a new gate. Missing/stale artifact -> fall back to local preflight (unchanged behavior). Disable via `CULL_RELEASE_VALIDATE_DISABLE=1`.

Closes the v0.5.1 retro's top item: 'Preflight re-runs Rust tests on every release phase; trust CI instead'.