### PR TITLE
fix(grid): overview canvas paints cells with real dominant colors (imageview-lr9q)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ### Fixed
 
+- **Grid overview: tiny cells now show real image colors.** At extreme zoom-out the overview canvas painted each cell with a color hashed from the image ID (random-looking, unrelated to content). Cells now paint with the image's stored dominant color (`get_dominant_colors`), falling back to a neutral surface when metrics are missing. (`imageview-lr9q`)
 - **Concurrent external-device reads.** Opening another folder now cancels and supersedes the previous read, and duplicate-content registration resolves the canonical image identity instead of surfacing a foreign-key error.
 - **External-drive detection on macOS.** Removable or ejectable SD cards remain visible even when macOS also reports the volume as internal.
 - **Release regression coverage for sidebar feature retention.** The release gate now blocks if Recent Imports regains a decorative clock glyph or if connected-device visibility regresses.

--- a/src-tauri/permissions/app-ai-processing.toml
+++ b/src-tauri/permissions/app-ai-processing.toml
@@ -31,6 +31,7 @@ commands.allow = [
   "get_color_metrics_count",
   "get_detection_count",
   "get_detections",
+  "get_dominant_colors",
   "get_embedding_count",
   "get_embedding_model_download_info",
   "get_embedding_page",

--- a/src-tauri/src/commands/color.rs
+++ b/src-tauri/src/commands/color.rs
@@ -48,6 +48,14 @@ pub async fn get_color_metrics_count(state: State<'_, AppState>) -> Result<u32, 
 }
 
 #[tauri::command]
+pub async fn get_dominant_colors(
+    state: State<'_, AppState>,
+) -> Result<std::collections::HashMap<String, String>, String> {
+    let ctx = ServiceContext::from_app_state(&state, None);
+    crate::services::ai::list_dominant_colors(&ctx).map_err(|e| e.to_string())
+}
+
+#[tauri::command]
 pub async fn list_images_by_color_bucket(
     state: State<'_, AppState>,
     bucket: String,

--- a/src-tauri/src/db_core/db.rs
+++ b/src-tauri/src/db_core/db.rs
@@ -3172,6 +3172,11 @@ mod tests {
         assert_eq!(stored.palette[0].red, 242);
         assert_eq!(db.color_metrics_count().unwrap(), 2);
 
+        let dominant = db.list_dominant_colors().unwrap();
+        assert_eq!(dominant.get("red").map(String::as_str), Some("#f20c14"));
+        assert_eq!(dominant.get("blue").map(String::as_str), Some("#1848f0"));
+        assert_eq!(dominant.len(), 2);
+
         let images = db.list_images_by_color_bucket("red", 10, 0).unwrap();
         assert_eq!(images.len(), 1);
         assert_eq!(images[0].image.id, "red");

--- a/src-tauri/src/db_core/queries/misc.rs
+++ b/src-tauri/src/db_core/queries/misc.rs
@@ -229,6 +229,16 @@ impl Database {
         .optional()
     }
 
+    /// Compact image_id -> dominant_hex map for overview-canvas placeholders.
+    pub fn list_dominant_colors(&self) -> Result<HashMap<String, String>> {
+        let conn = self.conn.lock();
+        let mut stmt = conn.prepare("SELECT image_id, dominant_hex FROM image_color_metrics")?;
+        let rows = stmt.query_map([], |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+        })?;
+        rows.collect()
+    }
+
     pub fn color_metrics_count(&self) -> Result<u32> {
         let conn = self.conn.lock();
         conn.query_row("SELECT COUNT(*) FROM image_color_metrics", [], |row| {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -700,6 +700,7 @@ pub fn run() {
             commands::color::analyze_image_colors,
             commands::color::get_image_color_metrics,
             commands::color::get_color_metrics_count,
+            commands::color::get_dominant_colors,
             commands::color::list_images_by_color_bucket,
             commands::perceptual_hash::analyze_perceptual_hashes,
             commands::perceptual_hash::get_image_perceptual_hash,

--- a/src-tauri/src/services/ai.rs
+++ b/src-tauri/src/services/ai.rs
@@ -10,6 +10,7 @@ use crate::db_core::perceptual_hash::{self, PHASH_ALGORITHM};
 use crate::db_core::quality;
 use crate::services::library::enrich_thumbnails;
 use crate::services::{Pagination, ServiceContext, ServiceError};
+use std::collections::HashMap;
 use std::collections::HashSet;
 
 const MAX_EMBEDDING_PAGE_SIZE: u32 = 5000;
@@ -568,6 +569,10 @@ pub fn get_image_color_metrics(
 
 pub fn get_color_metrics_count(ctx: &ServiceContext) -> Result<u32, ServiceError> {
     Ok(ctx.db.color_metrics_count()?)
+}
+
+pub fn list_dominant_colors(ctx: &ServiceContext) -> Result<HashMap<String, String>, ServiceError> {
+    Ok(ctx.db.list_dominant_colors()?)
 }
 
 pub fn list_images_by_color_bucket(

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1482,6 +1482,10 @@ export async function getColorMetricsCount(): Promise<number> {
     return invoke('get_color_metrics_count');
 }
 
+export async function getDominantColors(): Promise<Record<string, string>> {
+    return invoke('get_dominant_colors');
+}
+
 export async function listImagesByColorBucket(
     bucket: string,
     limit = 100,

--- a/src/lib/components/GridOverviewCanvas.svelte
+++ b/src/lib/components/GridOverviewCanvas.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import { convertFileSrc } from '@tauri-apps/api/core';
-    import type { ImageWithFile } from '$lib/api';
+    import { getDominantColors, type ImageWithFile } from '$lib/api';
     import { shouldDecodeGridOverviewThumbnails } from '$lib/grid-overview';
     import { safeAssetPreviewPath } from '$lib/view-utils';
 
@@ -22,15 +22,28 @@
     let canvas: HTMLCanvasElement;
     let renderGeneration = 0;
 
+    let dominantColors = $state<Record<string, string>>({});
+    let dominantColorsFetchCount = -1;
+
+    // Fetch real per-image dominant colors so tiny overview cells reflect actual
+    // image content instead of arbitrary placeholder hues. Re-fetch only when the
+    // library size changes (scroll/repaints must not trigger IPC).
+    $effect(() => {
+        const count = items.length;
+        if (count === 0 || count === dominantColorsFetchCount) return;
+        dominantColorsFetchCount = count;
+        getDominantColors()
+            .then((map) => { dominantColors = map; })
+            .catch(() => { /* placeholders stay neutral when metrics are unavailable */ });
+    });
+
     function token(styles: CSSStyleDeclaration, name: string): string {
         return styles.getPropertyValue(name).trim();
     }
 
-    function imageColor(index: number, palette: string[]): string {
-        const id = items[index]?.image.id ?? String(index);
-        let hash = 0;
-        for (let i = 0; i < id.length; i += 1) hash = ((hash << 5) - hash + id.charCodeAt(i)) | 0;
-        return palette[Math.abs(hash) % palette.length];
+    function imageColor(index: number, fallback: string): string {
+        const id = items[index]?.image.id;
+        return (id && dominantColors[id]) || fallback;
     }
 
     $effect(() => {
@@ -46,7 +59,7 @@
 
         const styles = getComputedStyle(canvas);
         const background = token(styles, '--bg');
-        const palette = [token(styles, '--surface'), token(styles, '--border'), token(styles, '--text-secondary'), token(styles, '--blue'), token(styles, '--purple')];
+        const fallbackColor = token(styles, '--surface');
         const selectedColor = token(styles, '--green');
         const focusedColor = token(styles, '--blue');
         ctx.fillStyle = background;
@@ -65,7 +78,7 @@
                 if (!item) break;
                 const x = col * cellSize;
                 const y = row * cellSize - scrollTop;
-                ctx.fillStyle = selectedIds.has(item.image.id) ? selectedColor : index === focusedIndex ? focusedColor : imageColor(index, palette);
+                ctx.fillStyle = selectedIds.has(item.image.id) ? selectedColor : index === focusedIndex ? focusedColor : imageColor(index, fallbackColor);
                 ctx.fillRect(x, y, size, size);
                 if (decodeThumbnails) {
                     const path = safeAssetPreviewPath(item, { displayPx: size, dpr: 1 });

--- a/src/lib/tauri-mock.ts
+++ b/src/lib/tauri-mock.ts
@@ -669,6 +669,12 @@ const MOCK_HANDLERS: Record<string, (...args: any[]) => any> = {
     analyzed_at: '2026-01-01T00:00:00Z',
   }),
   get_color_metrics_count: () => 18,
+  get_dominant_colors: () => {
+    const palette = ['#7aa2f7', '#9ece6a', '#e0af68', '#bb9af7', '#f7768e', '#414868'];
+    return Object.fromEntries(
+      Array.from({ length: 24 }, (_, i) => [`img-${i + 1}`, palette[i % palette.length]]),
+    );
+  },
   list_images_by_color_bucket: () => [makeMockImage(1), makeMockImage(4), makeMockImage(7)],
   analyze_perceptual_hashes: (_: any, args: { imageIds: string[] }) => args.imageIds.length,
   get_image_perceptual_hash: (_: any, args: { imageId: string }) => ({


### PR DESCRIPTION
At extreme zoom-out (thumbnail size <=12px) the overview canvas never
decodes thumbnails and painted each cell with a color hashed from the
image UUID mapped to 5 theme colors, so colors looked randomly assigned
and unrelated to image content.

Paint cells with each image's stored dominant_hex instead:
- new get_dominant_colors command (bulk image_id -> dominant_hex map
  from image_color_metrics, computed at import time)
- GridOverviewCanvas fetches the map once per library-size change and
  falls back to neutral --surface for images without metrics
- matching placeholder now also shows while real thumbnails decode in
  the 13-64px range
- command registered + permission-granted (contract test), E2E mock
  updated, bulk query covered by unit test
