### PR TITLE
docs(security): support 0.6.x line

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -69,6 +69,7 @@ Cull is a local-first Tauri 2 desktop app. It never phones home. All data stays 
 
 | Version | Supported |
 |---------|-----------|
+| 0.6.x   | Yes       |
 | 0.5.x   | Yes       |
 | 0.4.x   | Yes       |
 | 0.3.x   | Yes       |


### PR DESCRIPTION
Adds the 0.6.x row to the supported-versions table ahead of the v0.6.0 release (required by the HYG-006 release-contract test once the version bumps).