### PR TITLE
chore(release): v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-09-01
+
+### Changed
+
+- **~26 MB smaller release bundle.** Release binaries are now stripped and link-time optimized; the bundled Claude Agent SDK is pruned to its runtime entry (sdk.mjs + package.json); bundled art is properly sized and quantized (favicon 810 KB → 2.4 KB, clipboard empty-state 550 KB → 35 KB, DMG background 306 KB → 68 KB). Unused framework placeholder SVGs and two unused EB Garamond faces were removed, and OS junk files no longer ship in the frontend build. Cull.app 71 MB → 45 MB, DMG 26.8 MB → 20.4 MB. No behavior changes; runtime import resolution verified in the built app.
+
 ### Added
 
 - **Sidebar: recency rail above the folder tree.** Persistent `Just imported:` chip and last-N scope list above LIBRARY; auto-reveal + highlight until visited. Replaces the 8-second toast. (`imageview-1i2k.1`)

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -49,4 +49,4 @@ Cull reaches 1.0 when all three surfaces are `stable` and:
 
 ---
 
-Last updated: 0.5.1 (2026-08-20)
+Last updated: 0.6.0 (2026-09-01)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cull",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cull",
-      "version": "0.5.1",
+      "version": "0.6.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.3.222",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cull",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "Local-first desktop image viewer for AI-generated art workflows.",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -928,7 +928,7 @@ checksum = "52560adf09603e58c9a7ee1fe1dcb95a16927b17c127f0ac02d6e768a0e25bc1"
 
 [[package]]
 name = "cull"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "base64 0.23.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cull"
-version = "0.5.1"
+version = "0.6.0"
 description = "Local-first desktop image viewer for AI-generated art workflows."
 authors = ["Gleb Kalinin <glebis@gmail.com>"]
 license = "Apache-2.0"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Cull",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "identifier": "com.glebkalinin.cull",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
Release commit for v0.6.0 (minor bump from 0.5.1).

- Version bumps across package.json, package-lock.json, tauri.conf.json, Cargo.toml, Cargo.lock
- Curated CHANGELOG entry for 0.6.0 (release bundle ~26 MB smaller + all Unreleased sidebar work)
- Compatibility review recorded (no stable breaking changes; all surfaces unchanged)

Prepared via `release:cull prepare` with the full local validation gate green.