### PR TITLE
chore(release): v0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [0.6.1] - 2026-09-01
+
+### Changed
+
+- **Recovery release for the burned v0.6.0 tag.** The v0.6.0 annotated tag was pushed minutes before two dependabot commits landed on origin/main, so the immutable release gate correctly refused to build it (STALE_RELEASE_SOURCE) and the tag cannot be moved. Same content as the prepared v0.6.0 — ~26 MB smaller release bundle, pruned Claude Agent SDK resources, compressed bundled art, sidebar work below — plus the release-gate fix for closed-bead lookups and today\u2019s dev-dependency bumps. No behavior changes.
+
 ## [0.6.0] - 2026-09-01
 
 ### Changed

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -49,4 +49,4 @@ Cull reaches 1.0 when all three surfaces are `stable` and:
 
 ---
 
-Last updated: 0.6.0 (2026-09-01)
+Last updated: 0.6.1 (2026-09-01)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cull",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cull",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.3.222",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cull",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Local-first desktop image viewer for AI-generated art workflows.",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -928,7 +928,7 @@ checksum = "52560adf09603e58c9a7ee1fe1dcb95a16927b17c127f0ac02d6e768a0e25bc1"
 
 [[package]]
 name = "cull"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "base64 0.23.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cull"
-version = "0.6.0"
+version = "0.6.1"
 description = "Local-first desktop image viewer for AI-generated art workflows."
 authors = ["Gleb Kalinin <glebis@gmail.com>"]
 license = "Apache-2.0"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Cull",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "identifier": "com.glebkalinin.cull",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
Recovery release for the burned v0.6.0 tag (STALE_RELEASE_SOURCE after dependabot commits landed post-push; immutable tag cannot move — v0.5.0 precedent).

Version bumps + curated changelog + compatibility stamp. Prepared via `release:cull prepare`, full local validation gate green.