### PR TITLE
chore(release): v0.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [0.6.2] - 2026-09-01
+
+### Changed
+
+- **Publish-path recovery.** v0.6.1 was fully built, signed, notarized, and verified, but publication failed: since c10cf8315 the provenance records workflowRunId as a number while the publish job compared it against a string with strict inequality, so publication could never pass. The tag was also burned by the release-gate\u2019s staleness guard when the publish fix landed on origin/main. v0.6.2 carries the one-line string comparison fix (PR #212) and the same application content as v0.6.0/v0.6.1: ~26 MB smaller release bundle, pruned Claude Agent SDK resources, compressed bundled art, and the sidebar work below. No behavior changes.
+
 ## [0.6.1] - 2026-09-01
 
 ### Changed

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -49,4 +49,4 @@ Cull reaches 1.0 when all three surfaces are `stable` and:
 
 ---
 
-Last updated: 0.6.1 (2026-09-01)
+Last updated: 0.6.2 (2026-09-01)

--- a/docs/releases/0.6.1-smoke.md
+++ b/docs/releases/0.6.1-smoke.md
@@ -1,0 +1,21 @@
+# v0.6.1 manual smoke record
+
+date: 2026-09-01
+binary_sha256: 704b0b1edafe1cedc67f45001dff6db2789eec4397211bccc5996accc14a33a6
+source: 2cb85d92196202bae3ca5db9109c1086001496f1
+installed_by: scripts/install-local-build.sh (landing worktree build)
+
+## What was verified
+
+- App launches from /Applications/Cull.app; version reports 0.6.1.
+- Same content as the human-verified v0.6.0 build (e3990492c): recovery
+  release, only dev-dependency bumps and the release-gate script fix differ.
+- Library/grid, thumbnails, ratings/selections, sidebar sections, MCP reachability
+  unchanged from the v0.6.0 smoke pass (docs/releases/0.6.0-smoke.md).
+
+## Known non-blockers
+
+- Lineage thumbnail zoom remains unlanded WIP (wip/pre-release-2026-09-01),
+  intentionally out of this release per operator decision.
+- v0.6.0 tag is burned (STALE_RELEASE_SOURCE after dependabot merges landed
+  post-push); this 0.6.1 recovery follows the v0.5.0 precedent.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cull",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cull",
-      "version": "0.6.1",
+      "version": "0.6.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.3.222",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cull",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Local-first desktop image viewer for AI-generated art workflows.",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -928,7 +928,7 @@ checksum = "52560adf09603e58c9a7ee1fe1dcb95a16927b17c127f0ac02d6e768a0e25bc1"
 
 [[package]]
 name = "cull"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "anyhow",
  "base64 0.23.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cull"
-version = "0.6.1"
+version = "0.6.2"
 description = "Local-first desktop image viewer for AI-generated art workflows."
 authors = ["Gleb Kalinin <glebis@gmail.com>"]
 license = "Apache-2.0"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Cull",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "identifier": "com.glebkalinin.cull",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
Publish-path recovery: carries the workflowRunId string-comparison fix (PR #212) in the tagged tree so the release workflow can publish. Records the v0.6.1 smoke doc. Same app content as v0.6.0/v0.6.1.