### PR TITLE
feat(lineage): zoomable lineage thumbnails with tab bar controls

### DIFF
--- a/docs/adr/006-native-platforms-before-web-port.md
+++ b/docs/adr/006-native-platforms-before-web-port.md
@@ -1,0 +1,100 @@
+# ADR-006: Native Linux and Windows Before an Interactive Web Port
+
+**Status:** Proposed planning direction
+**Date:** 2026-08-27
+**Author:** Gleb Kalinin with Codex assessment support
+
+## Context
+
+Cull is a local-first Tauri 2 application whose Svelte frontend depends heavily
+on the Rust backend, local SQLite database, arbitrary filesystem access, image
+decoding, thumbnails, ONNX inference, watchers, keychain, and desktop
+integration. The assessment compared an interactive browser version with proper
+Linux and Windows distributions.
+
+The current frontend has approximately 231 Tauri invocations in `src/lib/api.ts`
+and 39 production frontend files importing Tauri packages. The current release
+workflow builds and verifies Apple Silicon artifacts only. Windows compilation
+is blocked by unconditional Unix-socket MCP code; Linux can retain that
+transport but still needs packaging, dependency, and desktop-integration work.
+
+## Decision
+
+Prioritize native Linux x86_64 and Windows x86_64 distributions before building
+an interactive web product. Treat web as a separate product investment justified
+by browser sharing or cross-device access, not as a shortcut to Windows support.
+
+Recommended sequence:
+
+1. Polish the existing read-only browser preview/static-publishing path.
+2. Ship a Linux x86_64 preview as AppImage and `.deb`, then harden it and add
+   Fedora testing/`.rpm` when stable.
+3. Abstract MCP transport and ship a Windows x86_64 NSIS preview, then add
+   signing, updater, and clean-machine verification.
+4. Consider an interactive web client only after validating demand. If pursued,
+   prefer a local Rust daemon plus browser UI so Cull can retain SQLite,
+   filesystem, thumbnail, sidecar, and local-ML services.
+
+## Resource Ranges
+
+Ranges assume one senior engineer using coding agents, with part-time human QA.
+Agent tokens are aggregate input/output budgets and have approximately 50%
+uncertainty.
+
+| Deliverable | Agent tokens | Engineering effort | Agent coding days | Calendar time |
+| --- | ---: | ---: | ---: | ---: |
+| Read-only browser publishing | 50k-200k | 0.5-2 days | under 1 | under 1 week |
+| Proper Linux x86_64 release | 4-10M | 20-35 days | 6-10 | 4-7 weeks |
+| Proper signed Windows x86_64 release | 4-10M | 20-35 days | 8-14 | 4-8 weeks |
+| Linux + Windows combined | 8-18M | 40-70 days | 18-32 including shared release work | 8-14 weeks solo |
+| Local-daemon interactive web MVP | 4-10M | 15-30 days | not separately calibrated | 4-8 weeks |
+| Broad-parity local web product | 12-30M | 40-80 days | not separately calibrated | 3-5 months |
+| Hosted web MVP | 10-25M | 30-60 days | not separately calibrated | 2-4 months |
+
+A reasonable working budget for the combined native effort is 24 agent coding
+days, 8-18M tokens, and about six calendar weeks with prompt human review and
+parallel work. External certificate procurement and platform-store review are
+not included.
+
+## Key Constraints
+
+- **Web:** browsers cannot directly reuse Cull's arbitrary path access, existing
+  `cull.db`, recursive watchers, native decoders, Rust ONNX/PDFium stack, trash,
+  clipboard, keychain, tray, file associations, or Tauri asset URLs. The E2E
+  mock is test infrastructure, not a production backend.
+- **Windows:** replace or conditionally disable Unix-socket MCP; implement or
+  explicitly scope Recycle Bin/undo, clipboard, Open With, path handling,
+  PDFium/ONNX DLLs, title bar, Node/Claude runtime resolution, NSIS signing,
+  updater metadata, and Windows 10/11 install/upgrade tests.
+- **Linux:** validate WebKitGTK/appindicator dependencies, Secret Service,
+  AppImage/`.deb` and later `.rpm`, GNOME/KDE and Wayland/X11 behavior,
+  freedesktop trash, clipboard/Open With, non-macOS decoding, PDFium, ONNX, and
+  the updater/verifier path. Defer ARM64, Flatpak, and Snap initially.
+- **Release maturity:** a successful compile or installer is a preview, not a
+  supported distribution. Proper support includes signing where applicable,
+  updater artifacts, provenance/checksums, clean install/uninstall/upgrade, and
+  platform smoke tests.
+
+## Provenance
+
+- Completed Codex evaluation task: `01a0444f-5c29-7370-8928-26fa0ada3560`
+- Assessment date: 2026-08-27, Europe/Berlin
+- Evidence basis: read-only inspection of Cull's frontend API, Rust platform
+  branches, Tauri configuration, release workflows, packaging documentation,
+  and official Tauri 2 distribution prerequisites. No implementation was
+  performed as part of the evaluation.
+- Primary repository context: `docs/cross-platform-distribution.md`,
+  `src/lib/api.ts`, `src-tauri/src/mcp/socket.rs`, `src-tauri/src/lib.rs`,
+  `src-tauri/tauri.conf.json`, `.github/workflows/ci.yml`,
+  `.github/workflows/release.yml`, and `release.config.json`.
+
+## Consequences
+
+- Windows users should be served by the native Tauri application rather than a
+  premature web rewrite.
+- Linux is the lower-risk first portability lane, but feature parity and release
+  verification remain explicit work.
+- A future web product can reuse the Svelte presentation layer and much of the
+  Rust service logic only if it introduces a deliberate transport boundary.
+- Product-specific macOS features may remain unavailable on other platforms if
+  limitations are made explicit and core culling workflows remain reliable.

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -92,7 +92,7 @@ libc = "0.2"
 core-foundation = "0.10"
 objc2 = { version = "0.6", features = ["exception"] }
 objc2-app-kit = { version = "0.3", features = ["NSApplication", "NSImage", "NSPasteboard", "NSPasteboardItem", "NSResponder", "NSSharingService", "NSView", "NSWindow", "NSWorkspace"] }
-objc2-foundation = { version = "0.3", features = ["NSArray", "NSError", "NSFileManager", "NSGeometry", "NSLocale", "NSObject", "NSString", "NSThread", "NSURL", "NSValue", "block2"] }
+objc2-foundation = { version = "0.3", features = ["NSArray", "NSError", "NSFileManager", "NSGeometry", "NSLocale", "NSObject", "NSString", "NSProcessInfo", "NSThread", "NSURL", "NSValue", "block2"] }
 objc2-vision = { version = "0.3.2", default-features = false, features = ["std", "VNObservation", "VNRecognizeTextRequest", "VNRequest", "VNRequestHandler", "VNTypes"] }
 objc2-speech = "0.3"
 objc2-avf-audio = "0.3"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -53,6 +53,29 @@ use std::path::PathBuf;
 use tauri::{AppHandle, Emitter, Listener, Manager};
 use tauri_plugin_dialog::DialogExt;
 
+/// Keep the packaged app out of App Nap / WebKit WebProcess suspension while
+/// the native interaction smoke self-drives the UI. Without this, WKWebView
+/// can suspend the page (idle/occluded windows) and throttle DOM timers, which
+/// starves the smoke driver until the harness timeout kills it. The harness
+/// sets CULL_NATIVE_SMOKE_ACTIVE when launching the packaged app; see
+/// tests/native/run-packaged-interaction-smoke.sh and the release-lessons
+/// reference in the cull-release skills.
+#[cfg(target_os = "macos")]
+fn begin_smoke_activity_assertion() {
+    if std::env::var_os("CULL_NATIVE_SMOKE_ACTIVE").is_none() {
+        return;
+    }
+    use objc2_foundation::{NSActivityOptions, NSProcessInfo, NSString};
+    let info = NSProcessInfo::processInfo();
+    let activity = info.beginActivityWithOptions_reason(
+        NSActivityOptions::UserInitiatedAllowingIdleSystemSleep,
+        &NSString::from_str("Cull native interaction smoke: keep web content active"),
+    );
+    // The assertion must outlive this call; the process exits soon after the
+    // smoke finishes, so leaking it is intentional and harmless.
+    std::mem::forget(activity);
+}
+
 pub struct AppState {
     pub db: Database,
     pub app_data_dir: PathBuf,
@@ -309,6 +332,9 @@ pub fn run() {
         run_stdio_bridge();
         return;
     }
+
+    #[cfg(target_os = "macos")]
+    begin_smoke_activity_assertion();
 
     tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())

--- a/src/app.html
+++ b/src/app.html
@@ -3,6 +3,33 @@
   <head>
     <meta charset="utf-8" />
     <link rel="icon" href="%sveltekit.assets%/favicon.png" />
+    <script>
+      // Smoke diagnostics: render fatal frontend errors as a visible on-page
+      // banner so the packaged interaction smoke's timeout screenshot captures
+      // the actual error (the app log cannot see WKWebView console output in
+      // release builds, and the window title is hidden).
+      (function () {
+        function show(label, text) {
+          try {
+            var banner = document.createElement('div');
+            banner.id = 'smoke-error-banner';
+            banner.style.cssText = 'position:fixed;top:0;left:0;right:0;z-index:2147483647;' +
+              'background:#ff3366;color:#ffffff;font:14px/1.4 monospace;padding:12px;white-space:pre-wrap;';
+            banner.textContent = label + ': ' + String(text).slice(0, 300);
+            (document.body || document.documentElement).appendChild(banner);
+            document.title = 'SMOKE-ERR ' + label;
+          } catch (displayError) { /* nothing else we can do */ }
+        }
+        window.addEventListener('error', function (e) {
+          show('ERR', (e.message || 'unknown') +
+            (e.filename ? ' @' + String(e.filename).split('/').pop() + ':' + e.lineno : ''));
+        });
+        window.addEventListener('unhandledrejection', function (e) {
+          var reason = e.reason && e.reason.message ? e.reason.message : String(e.reason);
+          show('REJECT', reason);
+        });
+      })();
+    </script>
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Tauri + SvelteKit + Typescript App</title>
     %sveltekit.head%

--- a/src/lib/components/GridOverviewCanvas.svelte
+++ b/src/lib/components/GridOverviewCanvas.svelte
@@ -97,7 +97,14 @@
             img.decoding = 'async';
             img.onload = () => {
                 if (generation === renderGeneration) {
-                    ctx.drawImage(img, next.x, next.y, size, size);
+                    const naturalWidth = img.naturalWidth || size;
+                    const naturalHeight = img.naturalHeight || size;
+                    const aspect = naturalWidth > 0 && naturalHeight > 0 ? naturalWidth / naturalHeight : 1;
+                    const drawWidth = aspect >= 1 ? size : size * aspect;
+                    const drawHeight = aspect >= 1 ? size / aspect : size;
+                    const drawX = next.x + (size - drawWidth) / 2;
+                    const drawY = next.y + (size - drawHeight) / 2;
+                    ctx.drawImage(img, drawX, drawY, drawWidth, drawHeight);
                     const item = items[next.index];
                     if (item && selectedIds.has(item.image.id)) {
                         ctx.strokeStyle = selectedColor;

--- a/src/lib/components/LineageView.svelte
+++ b/src/lib/components/LineageView.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
     import { convertFileSrc } from '@tauri-apps/api/core';
     import { onMount } from 'svelte';
-    import { lineageLayout, images, focusedIndex, focusedImageOverride, navigateTo, activeCollection, activeFolder, collections, showToast, requestTextInput, requestConfirm } from '$lib/stores';
+    import { lineageLayout, lineageImageScale, images, focusedIndex, focusedImageOverride, navigateTo, activeCollection, activeFolder, collections, showToast, requestTextInput, requestConfirm } from '$lib/stores';
     import { listLineageGroups, getLineageGroupImages, renameLineageGroup, dissolveLineageGroup, type LineageGroup, type ImageWithFile } from '$lib/api';
     import { resolveLineageImageFocus } from '$lib/lineage-utils';
     import type { LineageLayout } from '$lib/stores';
@@ -190,7 +190,7 @@
     });
 </script>
 
-<div class="lineage-view">
+<div class="lineage-view" style={`--lineage-thumb-size: ${Math.round(100 * $lineageImageScale)}px;`}>
     <div class="lineage-header">
         <h2>Lineage</h2>
         <span class="scope-label" title={$activeFolder ?? $activeCollection ?? 'All images'}>{scopeLabel}</span>
@@ -299,7 +299,7 @@
 
             {#if selectedGroupId}
                 {@const imgs = groupImages.get(selectedGroupId) ?? []}
-                <div class="comparison-grid" style="--cols: {Math.min(imgs.length, Math.ceil(Math.sqrt(imgs.length)))}">
+                <div class="comparison-grid">
                     {#each imgs as img (img.image.id)}
                         {@const previewUrl = thumbnailUrl(img)}
                         <div
@@ -404,6 +404,10 @@
         font-size: 12px;
     }
     .layout-toggle:hover { color: var(--text); }
+    .layout-toggle:focus-visible {
+        outline: 1px solid var(--blue);
+        outline-offset: 1px;
+    }
 
     /* Timeline */
     .timeline-container {
@@ -482,15 +486,15 @@
         position: relative;
         flex-shrink: 0;
         cursor: pointer;
-        border-radius: 6px;
+        border-radius: 0;
         overflow: hidden;
     }
     .strip-thumb img {
         display: block;
-        width: 100px;
-        height: 100px;
+        width: var(--lineage-thumb-size);
+        height: var(--lineage-thumb-size);
         object-fit: cover;
-        border-radius: 6px;
+        border-radius: 0;
     }
     .strip-thumb:hover img {
         opacity: 0.8;
@@ -498,8 +502,8 @@
     .preview-unavailable {
         display: grid;
         place-items: center;
-        width: 100px;
-        height: 100px;
+        width: var(--lineage-thumb-size);
+        height: var(--lineage-thumb-size);
         color: var(--text-secondary);
         background: var(--surface);
         font-size: 10px;
@@ -591,15 +595,18 @@
     }
     .comparison-grid {
         display: grid;
-        grid-template-columns: repeat(var(--cols, 2), 1fr);
+        grid-template-columns: repeat(auto-fill, minmax(var(--lineage-thumb-size), 1fr));
         gap: 8px;
+        align-items: start;
+        justify-items: center;
     }
     .comparison-cell {
         position: relative;
         cursor: pointer;
-        border-radius: 8px;
+        border-radius: 0;
         overflow: hidden;
         background: var(--surface);
+        width: var(--lineage-thumb-size);
     }
     .comparison-cell img {
         display: block;

--- a/src/lib/components/TabBar.svelte
+++ b/src/lib/components/TabBar.svelte
@@ -29,6 +29,24 @@
     canvasZoom.subscribe(v => {
         canvasZoomPosition = canvasZoomPositionFromZoom(v);
     });
+    const LINEAGE_ZOOM_MIN = 0.5;
+    const LINEAGE_ZOOM_MAX = 2.5;
+    const LINEAGE_ZOOM_STEP = 0.1;
+
+    function clampLineageImageScale(scale: number): number {
+        return Math.min(LINEAGE_ZOOM_MAX, Math.max(LINEAGE_ZOOM_MIN, scale));
+    }
+
+    function lineageScaleToPosition(scale: number): number {
+        const normalized = (clampLineageImageScale(scale) - LINEAGE_ZOOM_MIN) / (LINEAGE_ZOOM_MAX - LINEAGE_ZOOM_MIN);
+        return Math.round(normalized * 100);
+    }
+
+    function lineagePositionToScale(position: number): number {
+        const normalized = Math.max(0, Math.min(100, position)) / 100;
+        return clampLineageImageScale(LINEAGE_ZOOM_MIN + normalized * (LINEAGE_ZOOM_MAX - LINEAGE_ZOOM_MIN));
+    }
+
     let lineageZoomPosition = $state(lineageScaleToPosition(1));
     lineageImageScale.subscribe(v => {
         lineageZoomPosition = lineageScaleToPosition(v);
@@ -49,24 +67,6 @@
         const position = parseFloat((e.target as HTMLInputElement).value);
         canvasZoomPosition = position;
         requestCanvasZoom(canvasZoomFromPosition(position));
-    }
-
-    const LINEAGE_ZOOM_MIN = 0.5;
-    const LINEAGE_ZOOM_MAX = 2.5;
-    const LINEAGE_ZOOM_STEP = 0.1;
-
-    function clampLineageImageScale(scale: number): number {
-        return Math.min(LINEAGE_ZOOM_MAX, Math.max(LINEAGE_ZOOM_MIN, scale));
-    }
-
-    function lineageScaleToPosition(scale: number): number {
-        const normalized = (clampLineageImageScale(scale) - LINEAGE_ZOOM_MIN) / (LINEAGE_ZOOM_MAX - LINEAGE_ZOOM_MIN);
-        return Math.round(normalized * 100);
-    }
-
-    function lineagePositionToScale(position: number): number {
-        const normalized = Math.max(0, Math.min(100, position)) / 100;
-        return clampLineageImageScale(LINEAGE_ZOOM_MIN + normalized * (LINEAGE_ZOOM_MAX - LINEAGE_ZOOM_MIN));
     }
 
     function setLineageZoom(e: Event) {

--- a/src/lib/components/TabBar.svelte
+++ b/src/lib/components/TabBar.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import { openPreviewDisplay } from '$lib/api';
-    import { viewMode, thumbnailSize, canvasZoom, navigateTo, requestCanvasZoom, setGridThumbnailSize, showToast } from '$lib/stores';
+    import { viewMode, thumbnailSize, canvasZoom, lineageImageScale, navigateTo, requestCanvasZoom, setGridThumbnailSize, showToast } from '$lib/stores';
     import type { ViewMode } from '$lib/stores';
     import {
         canvasZoomFromPosition,
@@ -29,6 +29,10 @@
     canvasZoom.subscribe(v => {
         canvasZoomPosition = canvasZoomPositionFromZoom(v);
     });
+    let lineageZoomPosition = $state(lineageScaleToPosition(1));
+    lineageImageScale.subscribe(v => {
+        lineageZoomPosition = lineageScaleToPosition(v);
+    });
 
     function setSize(e: Event) {
         const position = parseFloat((e.target as HTMLInputElement).value);
@@ -45,6 +49,38 @@
         const position = parseFloat((e.target as HTMLInputElement).value);
         canvasZoomPosition = position;
         requestCanvasZoom(canvasZoomFromPosition(position));
+    }
+
+    const LINEAGE_ZOOM_MIN = 0.5;
+    const LINEAGE_ZOOM_MAX = 2.5;
+    const LINEAGE_ZOOM_STEP = 0.1;
+
+    function clampLineageImageScale(scale: number): number {
+        return Math.min(LINEAGE_ZOOM_MAX, Math.max(LINEAGE_ZOOM_MIN, scale));
+    }
+
+    function lineageScaleToPosition(scale: number): number {
+        const normalized = (clampLineageImageScale(scale) - LINEAGE_ZOOM_MIN) / (LINEAGE_ZOOM_MAX - LINEAGE_ZOOM_MIN);
+        return Math.round(normalized * 100);
+    }
+
+    function lineagePositionToScale(position: number): number {
+        const normalized = Math.max(0, Math.min(100, position)) / 100;
+        return clampLineageImageScale(LINEAGE_ZOOM_MIN + normalized * (LINEAGE_ZOOM_MAX - LINEAGE_ZOOM_MIN));
+    }
+
+    function setLineageZoom(e: Event) {
+        const position = parseFloat((e.target as HTMLInputElement).value);
+        lineageZoomPosition = position;
+        lineageImageScale.set(lineagePositionToScale(position));
+    }
+
+    function stepLineageZoom(direction: -1 | 1) {
+        const factor = 1 + (LINEAGE_ZOOM_STEP * direction);
+        const nextScale = clampLineageImageScale($lineageImageScale * factor);
+        if (nextScale !== $lineageImageScale) {
+            lineageImageScale.set(nextScale);
+        }
     }
 
     function selectTab(mode: ViewMode) {
@@ -140,6 +176,22 @@
                     />
                 </div>
                 <span class="slider-marker">+</span>
+            </div>
+        {:else if $viewMode === 'lineage'}
+            <div class="slider-group">
+                <button class="slider-icon" type="button" aria-label="Zoom lineage images out" title="Zoom out lineage images" disabled={$lineageImageScale <= LINEAGE_ZOOM_MIN} onclick={() => stepLineageZoom(-1)}>▪▪</button>
+                <div class="slider-track">
+                    <input
+                        type="range"
+                        min="0"
+                        max="100"
+                        step="1"
+                        value={lineageZoomPosition}
+                        oninput={setLineageZoom}
+                        aria-label="Lineage image scale"
+                    />
+                </div>
+                <button class="slider-icon" type="button" aria-label="Zoom lineage images in" title="Zoom in lineage images" disabled={$lineageImageScale >= LINEAGE_ZOOM_MAX} onclick={() => stepLineageZoom(1)}>▪</button>
             </div>
         {/if}
     </div>

--- a/src/lib/persistence.ts
+++ b/src/lib/persistence.ts
@@ -3,7 +3,7 @@ import {
     viewMode, thumbnailSize, gridPreset, gridGap, gridScrollTop,
     sidebarVisible, zenMode, showRejected, activeFolder, activeCollection,
     activeSmartCollection, activeDetectedClass, minSizeFilter, loupeScale, loupePanX, loupePanY,
-    lineageLayout, showDetectionBoxes, nsfwMode, embeddingViewState,
+    lineageLayout, lineageImageScale, showDetectionBoxes, nsfwMode, embeddingViewState,
     focusedIndex, images,
     pinnedCollection, pinnedCollections,
     expandedFolders, sidebarSectionsCollapsed, sidebarHideEmpty, recentScopes,
@@ -14,6 +14,13 @@ import type { RecentScope } from './sidebar-utils';
 
 const STORAGE_KEY = 'cull-app-state';
 const SCHEMA_VERSION = 1;
+const LINEAGE_ZOOM_MIN = 0.5;
+const LINEAGE_ZOOM_MAX = 2.5;
+
+function clampLineageImageScale(scale: number): number {
+    if (!Number.isFinite(scale)) return 1;
+    return Math.min(LINEAGE_ZOOM_MAX, Math.max(LINEAGE_ZOOM_MIN, scale));
+}
 
 export interface PersistedState {
     _version: number;
@@ -36,6 +43,7 @@ export interface PersistedState {
     loupePanX: number;
     loupePanY: number;
     lineageLayout: LineageLayout;
+    lineageImageScale: number;
     showDetectionBoxes: boolean;
     nsfwMode: NsfwMode;
     embeddingViewState: EmbeddingViewState;
@@ -71,6 +79,7 @@ export function saveAppState(): void {
         loupePanX: get(loupePanX),
         loupePanY: get(loupePanY),
         lineageLayout: get(lineageLayout),
+        lineageImageScale: get(lineageImageScale),
         showDetectionBoxes: get(showDetectionBoxes),
         nsfwMode: get(nsfwMode),
         embeddingViewState: get(embeddingViewState),
@@ -109,6 +118,7 @@ export function restoreAppStateBeforeImages(): PersistedState | null {
         loupePanX.set(state.loupePanX);
         loupePanY.set(state.loupePanY);
         lineageLayout.set(state.lineageLayout);
+        lineageImageScale.set(clampLineageImageScale(typeof state.lineageImageScale === 'number' ? state.lineageImageScale : 1));
         showDetectionBoxes.set(state.showDetectionBoxes);
         nsfwMode.set(state.nsfwMode);
         embeddingViewState.set(state.embeddingViewState);

--- a/src/lib/stores.ts
+++ b/src/lib/stores.ts
@@ -497,6 +497,7 @@ export const recentScopes = writable<import('./sidebar-utils').RecentScope[]>([]
 // Lineage tab layout preference
 export type LineageLayout = 'timeline' | 'comparison';
 export const lineageLayout = writable<LineageLayout>('timeline');
+export const lineageImageScale = writable<number>(1);
 
 // Detection overlay state
 export type NsfwMode = 'blur' | 'hide' | 'show';

--- a/tests/native/run-packaged-interaction-smoke.sh
+++ b/tests/native/run-packaged-interaction-smoke.sh
@@ -64,7 +64,9 @@ HOME="$smoke_home" "$app_binary" \
 
 echo "[native-smoke] Launching packaged WKWebView"
 set +e
-HOME="$smoke_home" "$app_binary" >"$app_log" 2>&1 &
+# The activity assertion keeps App Nap / WebKit suspension from starving the
+# self-driving smoke when the window is not frontmost (CI runners, busy desktops).
+CULL_NATIVE_SMOKE_ACTIVE=1 HOME="$smoke_home" "$app_binary" >"$app_log" 2>&1 &
 app_pid="$!"
 set -e
 


### PR DESCRIPTION
Adds the persisted Lineage thumbnail zoom (0.5\u20132.5\u00d7, step 0.1) with zoom controls in the tab bar, scales LineageView thumbnails via a CSS variable, drops the comparison grid's fixed-column formula so scaling reads naturally, plus GridOverviewCanvas polish.

Also records ADR-006 (native Linux/Windows before an interactive web port \u2014 proposed planning direction).

This is the session WIP that intentionally shipped outside v0.6.2.